### PR TITLE
Add flexible color pickers for DM badges

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -88,12 +88,12 @@
            <div class="roomTitle"><span id="roomTitle">main</span></div>
           </div>
 
-          <div class="row" style="align-items:center; gap:10px;">
+            <div class="row" style="align-items:center; gap:10px;">
             <div class="searchWrap">
               <input id="searchInput" placeholder="Search messages...">
             </div>
-            <button class="iconBtn" id="dmToggleBtn" type="button" title="Direct messages">💬</button>
-            <button class="iconBtn" id="groupDmToggleBtn" type="button" title="Group chats">👪</button>
+            <button class="iconBtn withBadge" id="dmToggleBtn" type="button" title="Direct messages">💬<span class="notifDot" id="dmBadgeDot" title="New DMs"></span></button>
+            <button class="iconBtn withBadge" id="groupDmToggleBtn" type="button" title="Group chats">👪<span class="notifDot right" id="groupDmBadgeDot" title="New group DMs"></span></button>
             <button class="iconBtn mobOnly" id="openMembersBtn" type="button" title="Members">👥</button>
           </div>
         </div>
@@ -190,7 +190,7 @@
       <div class="tabs" id="tabs">
         <div class="tab active" data-tab="info" id="tabInfo">Info</div>
         <div class="tab" data-tab="about" id="tabAbout">About</div>
-        <div class="tab" data-tab="media" id="tabMedia">Media</div>
+        <div class="tab" data-tab="customize" id="tabCustomize">Customization</div>
         <div class="tab" data-tab="moderation" id="tabModeration" style="display:none;">Moderation</div>
       </div>
 
@@ -302,10 +302,30 @@
         </div>
       </div>
 
-      <div id="viewMedia" style="display:none;">
-        <div class="sectionTitle">Media</div>
+      <div id="viewCustomize" style="display:none;">
+        <div class="sectionTitle">Customization</div>
         <div class="panelBox">
-          <div class="small">Nothing shared yet. Use DMs to swap files or links.</div>
+          <div class="field">
+            <label>Direct message badge color</label>
+            <div class="colorInputRow">
+              <input id="directBadgeColor" type="color" aria-label="Direct message badge color">
+              <input id="directBadgeColorText" type="text" placeholder="#ed4245 or red" aria-label="Direct message badge color text">
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Group DM badge color</label>
+            <div class="colorInputRow">
+              <input id="groupBadgeColor" type="color" aria-label="Group DM badge color">
+              <input id="groupBadgeColorText" type="text" placeholder="#5865f2 or blue" aria-label="Group DM badge color text">
+            </div>
+          </div>
+
+          <div class="row" style="margin-top:6px;">
+            <button class="btn" id="saveBadgePrefsBtn" type="button">Save badge colors</button>
+          </div>
+
+          <div class="msgline" id="customizeMsg"></div>
         </div>
       </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -50,6 +50,8 @@ button{ font-family:inherit; }
   outline:none;
 }
 textarea{ min-height:90px; resize:vertical; }
+.colorInputRow{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.colorInputRow input[type="text"]{ flex:1; min-width:140px; }
 .row{ display:flex; gap:10px; flex-wrap:wrap; align-items:center; }
 .btn{
   border:0;
@@ -138,7 +140,19 @@ textarea{ min-height:90px; resize:vertical; }
   border:1px solid rgba(255,255,255,.08);
   display:flex; align-items:center; justify-content:center;
   font-size:16px; font-weight:900; cursor:pointer; user-select:none;
+  position:relative;
 }
+.iconBtn.withBadge{ padding:0 2px; }
+.notifDot{
+  position:absolute;
+  width:12px; height:12px;
+  border-radius:50%;
+  background:var(--danger);
+  top:-4px; left:-4px;
+  border:2px solid var(--panel2);
+  display:none;
+}
+.notifDot.right{ left:auto; right:-4px; }
 .iconBtn.secondary{ background:#3f4148; }
 .iconBtn:hover{ filter:brightness(1.05); }
 
@@ -573,7 +587,7 @@ textarea{ min-height:90px; resize:vertical; }
     display: flex;
     flex-direction: column;
   }
-  #viewInfo, #viewAbout, #viewMedia, #viewModeration{
+  #viewInfo, #viewAbout, #viewCustomize, #viewModeration{
     overflow:auto;
     -webkit-overflow-scrolling: touch;
     padding-right: 2px;


### PR DESCRIPTION
## Summary
- add color picker plus free-form text inputs for DM and group DM badge colors in the customization tab
- validate and sanitize arbitrary CSS color values before saving and preview them in badge dots

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f7a4af0588333a84d0ca38b0b7fd7)