### PR TITLE
Make DM settings control the DM background color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -158,7 +158,7 @@
         <div class="small">Start a DM from the members list or create a quick group.</div>
       </div>
       <div class="row" style="gap:6px;">
-        <button class="iconBtn secondary" id="dmRefreshBtn" type="button" title="Refresh">⟳</button>
+        <button class="iconBtn secondary" id="dmAddUserBtn" type="button" title="Add user to DM">➕</button>
         <button class="iconBtn" id="dmCloseBtn" type="button" title="Close">✕</button>
       </div>
     </div>
@@ -173,9 +173,13 @@
       </div>
       <div class="dmHelper" id="dmDirectHelper">Click a name in Members to open a DM instantly. We only save it after the first message.</div>
       <div class="dmHelper group" id="dmGroupHelper">Invite multiple people or give your group a title to get started.</div>
-      <div class="dmInputs">
-        <input id="dmParticipants" placeholder="Add people (comma separated)">
-        <input id="dmTitle" placeholder="Group title (optional)">
+      <div class="dmInputs" id="dmInputs">
+        <div class="dmParticipantsRow" id="dmParticipantsRow">
+          <input id="dmParticipants" placeholder="Add people (comma separated)">
+        </div>
+        <div class="dmTitleRow" id="dmTitleRow">
+          <input id="dmTitle" placeholder="Group title (optional)">
+        </div>
       </div>
       <div class="dmActions">
         <button class="btn" id="dmCreateBtn" type="button">Start chat</button>
@@ -187,8 +191,30 @@
       <div class="dmThreads" id="dmThreadList"></div>
       <div class="dmConversation">
         <div class="dmMeta">
-          <div class="title" id="dmMetaTitle">Pick a thread</div>
-          <div class="small" id="dmMetaPeople"></div>
+          <div class="dmMetaText">
+            <div class="title" id="dmMetaTitle">Pick a thread</div>
+            <div class="small" id="dmMetaPeople"></div>
+          </div>
+          <div class="dmMetaActions">
+            <button class="iconBtn secondary" id="dmSettingsBtn" type="button" title="DM settings">⚙️</button>
+            <div class="dmSettingsMenu" id="dmSettingsMenu">
+              <div class="dmSettingsRow">
+                <button class="btn danger" id="dmDeleteHistoryBtn" type="button">Delete history</button>
+                <div class="small">Remove every message in this DM for all participants.</div>
+              </div>
+              <div class="dmSettingsRow">
+                <div class="small">DM background</div>
+                <div class="colorInputRow tight">
+                  <input id="dmBgColor" type="color" aria-label="DM background color">
+                  <input id="dmBgColorText" type="text" placeholder="#1e1f22 or blue" aria-label="DM background color text">
+                </div>
+                <div class="small">Change the backdrop behind your DM threads and conversation.</div>
+              </div>
+              <div class="dmSettingsRow">
+                <button class="btn secondary" id="dmReportBtn" type="button">Report DM (coming soon)</button>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="dmMessages" id="dmMessages"></div>
         <div class="dmInput">

--- a/public/styles.css
+++ b/public/styles.css
@@ -15,6 +15,8 @@
   --line:#00000033;
   --soft:#00000022;
   --shadow: 0 18px 60px rgba(0,0,0,.45);
+  --avatar-bg:#444444;
+  --dm-bg:#1e1f22;
 }
 *{ box-sizing:border-box; }
 body{
@@ -127,7 +129,7 @@ textarea{ min-height:90px; resize:vertical; }
 }
 .meRow{ display:flex; align-items:center; justify-content:space-between; gap:10px; }
 .meLeft{ display:flex; align-items:center; gap:10px; min-width:0; }
-.meAvatar{ width:34px; height:34px; border-radius:50%; background:#444; overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
+.meAvatar{ width:34px; height:34px; border-radius:50%; background:var(--avatar-bg); overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
 .meAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
 .meMeta{ min-width:0; display:flex; flex-direction:column; gap:2px; }
 .meName{ font-size:13px; font-weight:900; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
@@ -186,7 +188,7 @@ textarea{ min-height:90px; resize:vertical; }
 }
 .msg{ display:flex; gap:10px; align-items:flex-start; max-width:900px; }
 .msg.self{ align-self:flex-end; flex-direction:row-reverse; }
-.msgAvatar{ width:38px; height:38px; border-radius:50%; background:#444; overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
+.msgAvatar{ width:38px; height:38px; border-radius:50%; background:var(--avatar-bg); overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
 .msgAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
 .bubble{
   background:var(--bubble);
@@ -327,7 +329,7 @@ textarea{ min-height:90px; resize:vertical; }
   border:1px solid transparent;
 }
 .mItem:hover{ background:var(--soft); border-color: var(--line); }
-.mAvatar{ width:30px; height:30px; border-radius:50%; background:#444; overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
+.mAvatar{ width:30px; height:30px; border-radius:50%; background:var(--avatar-bg); overflow:hidden; flex:0 0 auto; border:1px solid rgba(0,0,0,.25); }
 .mAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
 .dot{ width:10px; height:10px; border-radius:50%; flex:0 0 auto; background:var(--gray); }
 .mMeta{ display:flex; flex-direction:column; gap:2px; min-width:0; }
@@ -383,7 +385,7 @@ textarea{ min-height:90px; resize:vertical; }
 .tab.active{ background:#3a3c43; border-color:#00000055; }
 
 .modalGrid{ display:grid; grid-template-columns: 170px 1fr; gap:12px; }
-.pAvatar{ width:160px; height:160px; border-radius:18px; background:var(--panel2); overflow:hidden; border:1px solid rgba(0,0,0,.25); }
+.pAvatar{ width:160px; height:160px; border-radius:18px; background:var(--avatar-bg); overflow:hidden; border:1px solid rgba(0,0,0,.25); }
 .pAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
 .small{ font-size:12px; color:var(--muted); }
 .sectionTitle{ font-weight:900; margin:10px 0 6px; }
@@ -460,23 +462,25 @@ textarea{ min-height:90px; resize:vertical; }
 .dmModeSwitch{ display:flex; gap:8px; }
 .dmHelper{ font-size:12px; color:var(--muted); background: rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); padding:10px; border-radius:12px; display:none; }
 .dmHelper.group{ display:none; }
-.dmInputs{ display:grid; grid-template-columns: 1fr 1fr; gap:10px; }
+.dmInputs{ display:flex; flex-direction:column; gap:10px; }
 .dmInputs input{ width:100%; }
 .dmInputs #dmTitle{ min-width:0; }
-.dmCreate.direct .dmInputs{ grid-template-columns: 1fr; }
+.dmParticipantsRow{ display:block; }
+.dmParticipantsRow.hidden{ display:none; }
 .dmInputs input.readonly{ opacity:0.85; cursor:not-allowed; }
+.dmCreate.direct .dmInputs{ display:none; }
 .dmCreate.direct .dmHelper{ display:block; }
 .dmCreate.direct .dmHelper.group{ display:none; }
-.dmCreate.direct #dmTitle{ display:none; }
-.dmCreate.direct #dmParticipants{ background: rgba(255,255,255,.06); border-style:dashed; }
 .dmCreate.group .dmHelper{ display:none; }
 .dmCreate.group .dmHelper.group{ display:block; }
+.dmTitleRow{ display:block; }
+.dmAddActive{ background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.2); }
 .dmActions{ display:flex; flex-direction:column; gap:6px; }
 .dmActions .btn{ align-self:flex-start; }
 .dmActions .msgline{ min-height:18px; }
 .chip{ padding:7px 12px; border-radius:12px; border:1px solid var(--line); background:var(--soft); font-weight:900; cursor:pointer; color:var(--text); }
 .chip.active{ background:#3a3c43; border-color:#00000055; }
-.dmContent{ flex:1; display:grid; grid-template-columns: 220px 1fr; min-height:0; backdrop-filter: blur(4px); }
+.dmContent{ flex:1; display:grid; grid-template-columns: 220px 1fr; min-height:0; backdrop-filter: blur(4px); background:var(--dm-bg); }
 .dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; }
 .dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; flex-direction:column; gap:4px; transition: background .12s ease, border-color .12s ease; }
 .dmItem:hover{ background:var(--panel); }
@@ -484,8 +488,16 @@ textarea{ min-height:90px; resize:vertical; }
 .dmItem .name{ font-weight:900; font-size:13px; }
 .dmItem .small{ color:var(--muted); font-size:11px; }
 .dmConversation{ display:flex; flex-direction:column; min-width:0; min-height:0; }
-.dmMeta{ padding:10px 12px; border-bottom:1px solid var(--line); }
+.dmMeta{ padding:10px 12px; border-bottom:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; gap:10px; }
 .dmMeta .title{ font-weight:900; }
+.dmMetaText{ display:flex; flex-direction:column; gap:4px; min-width:0; }
+.dmMetaActions{ position:relative; }
+.dmSettingsMenu{ display:none; position:absolute; right:0; top:110%; background:var(--panel); border:1px solid var(--line); border-radius:14px; min-width:220px; padding:10px; box-shadow: var(--shadow); z-index:4; gap:10px; flex-direction:column; }
+.dmSettingsMenu.open{ display:flex; }
+.dmSettingsRow{ display:flex; flex-direction:column; gap:6px; padding:6px 0; border-bottom:1px solid var(--line); }
+.dmSettingsRow:last-child{ border-bottom:0; }
+.colorInputRow.tight{ gap:6px; }
+.colorInputRow.tight input[type="text"]{ min-width:120px; }
 .dmMessages{ flex:1; overflow:auto; padding:10px 12px; display:flex; flex-direction:column; gap:8px; min-height:0; }
 .dmBubble{ padding:9px 11px; border-radius:12px; background:var(--panel); border:1px solid var(--line); max-width:80%; }
 .dmBubble.self{ background:var(--bubbleSelf); color:white; margin-left:auto; }


### PR DESCRIPTION
## Summary
- replace the DM settings color picker to style the DM background instead of profile pictures
- add persistence and CSS variables for the DM background color and apply it to the DM content area
- update the settings copy to clarify the background target

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f9486925c8333a24ea5e03685988b)