### PR TITLE
Simplify DM panel layout

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -155,37 +155,12 @@
     <div class="dmHeader">
       <div>
         <div class="title">Direct Messages</div>
-        <div class="small">Start a DM from the members list or create a quick group.</div>
+        <div class="small">Start a DM from the members list.</div>
       </div>
-      <div class="row" style="gap:6px;">
-        <button class="iconBtn secondary" id="dmAddUserBtn" type="button" title="Add user to DM">➕</button>
-        <button class="iconBtn" id="dmCloseBtn" type="button" title="Close">✕</button>
-      </div>
+      <button class="iconBtn" id="dmCloseBtn" type="button" title="Close">✕</button>
     </div>
 
-    <div class="dmCreate">
-      <div class="dmCreateTop">
-        <div class="small" id="dmModeLabel">Mode: Direct Message</div>
-        <div class="dmModeSwitch">
-          <button class="chip active" id="dmDirectModeBtn" type="button">Direct</button>
-          <button class="chip" id="dmGroupModeBtn" type="button">Group</button>
-        </div>
-      </div>
-      <div class="dmHelper" id="dmDirectHelper">Click a name in Members to open a DM instantly. We only save it after the first message.</div>
-      <div class="dmHelper group" id="dmGroupHelper">Invite multiple people or give your group a title to get started.</div>
-      <div class="dmInputs" id="dmInputs">
-        <div class="dmParticipantsRow" id="dmParticipantsRow">
-          <input id="dmParticipants" placeholder="Add people (comma separated)">
-        </div>
-        <div class="dmTitleRow" id="dmTitleRow">
-          <input id="dmTitle" placeholder="Group title (optional)">
-        </div>
-      </div>
-      <div class="dmActions">
-        <button class="btn" id="dmCreateBtn" type="button">Start chat</button>
-        <div class="msgline" id="dmMsg"></div>
-      </div>
-    </div>
+    <div class="dmNotice" id="dmMsg"></div>
 
     <div class="dmContent">
       <div class="dmThreads" id="dmThreadList"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -452,34 +452,19 @@ textarea{ min-height:90px; resize:vertical; }
   padding:12px 14px;
   display:flex;
   align-items:center;
+  gap:12px;
   justify-content:space-between;
-  gap:10px;
   border-bottom:1px solid var(--line);
 }
 .dmHeader .title{ font-weight:900; letter-spacing:.01em; }
-.dmCreate{ padding:12px 14px; display:flex; flex-direction:column; gap:10px; border-bottom:1px solid var(--line); background: rgba(0,0,0,.12); }
-.dmCreateTop{ display:flex; justify-content:space-between; gap:10px; align-items:center; flex-wrap:wrap; }
-.dmModeSwitch{ display:flex; gap:8px; }
-.dmHelper{ font-size:12px; color:var(--muted); background: rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); padding:10px; border-radius:12px; display:none; }
-.dmHelper.group{ display:none; }
-.dmInputs{ display:flex; flex-direction:column; gap:10px; }
-.dmInputs input{ width:100%; }
-.dmInputs #dmTitle{ min-width:0; }
-.dmParticipantsRow{ display:block; }
-.dmParticipantsRow.hidden{ display:none; }
-.dmInputs input.readonly{ opacity:0.85; cursor:not-allowed; }
-.dmCreate.direct .dmInputs{ display:none; }
-.dmCreate.direct .dmHelper{ display:block; }
-.dmCreate.direct .dmHelper.group{ display:none; }
-.dmCreate.group .dmHelper{ display:none; }
-.dmCreate.group .dmHelper.group{ display:block; }
-.dmTitleRow{ display:block; }
-.dmAddActive{ background: rgba(255,255,255,.08); border-color: rgba(255,255,255,.2); }
-.dmActions{ display:flex; flex-direction:column; gap:6px; }
-.dmActions .btn{ align-self:flex-start; }
-.dmActions .msgline{ min-height:18px; }
-.chip{ padding:7px 12px; border-radius:12px; border:1px solid var(--line); background:var(--soft); font-weight:900; cursor:pointer; color:var(--text); }
-.chip.active{ background:#3a3c43; border-color:#00000055; }
+.dmNotice{
+  padding:10px 14px;
+  border-bottom:1px solid var(--line);
+  min-height:18px;
+  font-size:12px;
+  color:var(--muted);
+  background: rgba(255,255,255,.03);
+}
 .dmContent{ flex:1; display:grid; grid-template-columns: 220px 1fr; min-height:0; backdrop-filter: blur(4px); background:var(--dm-bg); }
 .dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; }
 .dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; flex-direction:column; gap:4px; transition: background .12s ease, border-color .12s ease; }


### PR DESCRIPTION
## Summary
- remove the DM creation controls and helper messaging from the panel
- shift the conversation area up with a compact notice bar for status updates
- present direct and group threads together with clearer section headers

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fa6d299448333a0502c1b561d0ee4)