### PR TITLE
Rename statuses and move lurking users to bottom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -70,13 +70,13 @@
             <option>Online</option>
             <option>Away</option>
             <option>Busy</option>
-            <option>Do Not Disturb</option>
+            <option>DnD</option>
             <option>Idle</option>
             <option>Gaming</option>
-            <option>Listening to Music</option>
+            <option>Music</option>
             <option>Working</option>
-            <option>Looking to Chat</option>
-            <option>Invisible</option>
+            <option>Chatting</option>
+            <option>Lurking</option>
           </select>
         </div>
       </aside>


### PR DESCRIPTION
## Summary
- update status labels to DnD, Music, Chatting, and Lurking while normalizing legacy values
- reflect normalized statuses in status displays, dot colors, and profile views
- sort members so users marked as Lurking appear after other online members

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fb8ed446c8333ab5e97c339066c93)