### PR TITLE
Add slash command system with role-based responses

### DIFF
--- a/database.js
+++ b/database.js
@@ -66,6 +66,10 @@ db.serialize(() => {
     ["last_seen", "last_seen INTEGER"],
     ["last_room", "last_room TEXT"],
     ["last_status", "last_status TEXT"],
+    ["gold", "gold INTEGER NOT NULL DEFAULT 0"],
+    ["xp", "xp INTEGER NOT NULL DEFAULT 0"],
+    ["lastXpMessageAt", "lastXpMessageAt INTEGER"],
+    ["lastDailyLoginAt", "lastDailyLoginAt INTEGER"],
   ];
   for (const [col, ddl] of userColumns) addColumnIfMissing("users", col, ddl);
 
@@ -88,6 +92,41 @@ db.serialize(() => {
       attachment_size INTEGER
     )
   `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS command_audit (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      executor_id INTEGER NOT NULL,
+      executor_username TEXT NOT NULL,
+      executor_role TEXT NOT NULL,
+      command_name TEXT NOT NULL,
+      args_json TEXT,
+      target_ids TEXT,
+      room TEXT,
+      success INTEGER NOT NULL,
+      error TEXT,
+      ts INTEGER NOT NULL
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS config (
+      key TEXT PRIMARY KEY,
+      value TEXT
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS rooms (
+      name TEXT PRIMARY KEY,
+      created_by INTEGER,
+      created_at INTEGER NOT NULL
+    )
+  `);
+  addColumnIfMissing("rooms", "slowmode_seconds", "slowmode_seconds INTEGER NOT NULL DEFAULT 0");
+  addColumnIfMissing("rooms", "is_locked", "is_locked INTEGER NOT NULL DEFAULT 0");
+  addColumnIfMissing("rooms", "pinned_message_ids", "pinned_message_ids TEXT");
+  addColumnIfMissing("rooms", "maintenance_mode", "maintenance_mode INTEGER NOT NULL DEFAULT 0");
 
   db.run(`
     CREATE TABLE IF NOT EXISTS reactions (

--- a/public/index.html
+++ b/public/index.html
@@ -50,6 +50,14 @@
   <!-- will be rendered by app.js from /rooms -->
 </div>
 
+<div class="commandPopup" id="commandPopup" aria-live="polite">
+  <div class="commandPopupHeader">
+    <div class="commandPopupTitle" id="commandPopupTitle">Command</div>
+    <button class="iconBtn" id="commandPopupClose" type="button" title="Dismiss">✕</button>
+  </div>
+  <div class="commandPopupBody" id="commandPopupBody"></div>
+</div>
+
         <div class="bottomBar">
           <div class="meRow">
             <div class="meLeft">
@@ -132,6 +140,7 @@
 
       <aside class="members drawer" id="membersPane">
         <h3>Members</h3>
+        <div class="memberGold" id="memberGold" aria-live="polite"></div>
         <div id="memberList"></div>
         <div id="memberMenu" class="memberMenu">
           <div class="memberMenuHeader">
@@ -238,6 +247,18 @@
               <div class="infoItem"><div class="k">Last seen</div><div class="v" id="infoLastSeen">—</div></div>
               <div class="infoItem"><div class="k">Current room</div><div class="v" id="infoRoom">—</div></div>
               <div class="infoItem"><div class="k">Status</div><div class="v" id="infoStatus">—</div></div>
+            </div>
+
+            <div class="sectionTitle">Account Level</div>
+            <div class="panelBox" id="levelPanel">
+              <div class="row" style="align-items:center; justify-content:space-between;">
+                <div class="badge" id="levelBadge">Level 1</div>
+                <div class="small" id="xpText">XP: 0 / 100</div>
+              </div>
+              <div class="progressShell">
+                <div class="progressFill" id="xpProgress"></div>
+              </div>
+              <div class="small" id="xpNote">XP is only visible to you.</div>
             </div>
 
             <div class="row" style="gap:8px; margin-top:10px; flex-wrap:wrap;">
@@ -439,6 +460,8 @@
 
     </div>
   </div>
+
+  <div id="levelToast">🎉 <span id="levelToastText">Level up!</span></div>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="/app.js" defer></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -308,6 +308,8 @@ textarea{ min-height:90px; resize:vertical; }
   border:1px solid rgba(255,255,255,.08);
 }
 .progressBar{ height:100%; width:0%; border-radius:999px; background: rgba(255,255,255,.45); transition: width .08s linear; }
+.progressShell{ margin-top:8px; height:10px; border-radius:999px; background: rgba(255,255,255,.08); border:1px solid var(--line); overflow:hidden; }
+.progressFill{ height:100%; width:0%; background:linear-gradient(90deg, #f9d423, #ff4e50); transition: width .25s ease; }
 
 /* Members */
 .members{
@@ -319,6 +321,17 @@ textarea{ min-height:90px; resize:vertical; }
   position:relative;
 }
 .members h3{ margin:6px 6px 10px; font-size:12px; color:var(--muted); letter-spacing:.06em; text-transform:uppercase; }
+.memberGold{ margin:0 6px 10px; padding:6px 10px; border-radius:12px; background:var(--soft); border:1px solid var(--line); font-weight:900; display:none; }
+.memberGold.show{ display:block; }
+.commandPopup{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:8px;margin:8px 6px 0;display:none;max-height:260px;overflow:auto;box-shadow:var(--shadow);}
+.commandPopup.show{display:block;}
+.commandPopupHeader{display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:6px;}
+.commandPopupTitle{font-weight:900;font-size:14px;}
+.commandPopupBody{font-size:13px;line-height:1.4;white-space:pre-wrap;}
+.commandHelpList{display:flex;flex-direction:column;gap:6px;}
+.commandHelpItem{border:1px solid var(--line);padding:6px;border-radius:8px;background:var(--panel2);}
+.commandHelpItem .name{font-weight:800;}
+.commandHelpItem .usage{font-family:monospace;font-size:12px;}
 .mItem{
   padding:8px 8px;
   border-radius:14px;
@@ -390,6 +403,8 @@ textarea{ min-height:90px; resize:vertical; }
 .small{ font-size:12px; color:var(--muted); }
 .sectionTitle{ font-weight:900; margin:10px 0 6px; }
 .panelBox{ background:var(--panel2); border:1px solid var(--line); border-radius:14px; padding:10px; }
+.panelBox .badge{ background:var(--accent); color:#111; }
+.panelBox .small{ color:var(--muted); }
 
 .infoGrid{ display:grid; grid-template-columns: 1fr 1fr; gap:10px; }
 .infoItem{ background: rgba(255,255,255,.04); border:1px solid rgba(255,255,255,.08); border-radius:14px; padding:10px; }
@@ -635,6 +650,27 @@ textarea{ min-height:90px; resize:vertical; }
   font-weight:900;
 }
 .reactionMenu button:hover{ background:#00000033; }
+
+#levelToast{
+  position:fixed;
+  top:14px;
+  right:14px;
+  background:var(--panel2);
+  color:var(--text);
+  border:2px solid var(--accent);
+  border-radius:12px;
+  padding:10px 14px;
+  font-weight:900;
+  box-shadow: var(--shadow);
+  opacity:0;
+  transform: translateY(-10px);
+  transition: opacity .25s ease, transform .25s ease;
+  z-index: 120;
+  display:flex;
+  align-items:center;
+  gap:8px;
+}
+#levelToast.show{ opacity:1; transform: translateY(0); }
 
 @media (max-width: 760px){
   .modalGrid{ grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- add slash-command registry with role-based enforcement, auditing, and room slowmode/lock checks on message send
- store command audit records and new room settings in the database
- render executor-only command responses and help popup in the room list panel on the client

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fbf21dc4c833380628685c7694dd7)