### PR TITLE
Add menu panel with changelog and latest update snippet

### DIFF
--- a/database.js
+++ b/database.js
@@ -165,6 +165,19 @@ db.serialize(() => {
   `);
 
   db.run(`
+    CREATE TABLE IF NOT EXISTS changelog_entries (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      seq INTEGER NOT NULL UNIQUE,
+      title TEXT NOT NULL,
+      body TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      author_id INTEGER NOT NULL
+    )
+  `);
+  db.run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_changelog_seq ON changelog_entries(seq)`);
+
+  db.run(`
     CREATE TABLE IF NOT EXISTS dm_threads (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       title TEXT,

--- a/public/index.html
+++ b/public/index.html
@@ -43,12 +43,92 @@
 </div>
 
 <div class="chanHeader">
-  <div class="small">Rooms</div>
-  <button class="iconBtn smallIcon" id="addRoomBtn" type="button" title="Create room">＋</button>
+  <div class="small" id="chanHeaderTitle">Rooms</div>
+  <div class="row" style="gap:6px;">
+    <button class="iconBtn smallIcon" id="menuToggleBtn" type="button" title="Menu">☰</button>
+    <button class="iconBtn smallIcon" id="addRoomBtn" type="button" title="Create room">＋</button>
+  </div>
 </div>
 
-<div class="chanList" id="chanList">
-  <!-- will be rendered by app.js from /rooms -->
+<div class="roomsPanel" id="roomsPanel">
+  <div class="latestUpdate" id="latestUpdate">
+    <div class="latestUpdateTop">
+      <div class="latestUpdateHeading">
+        <div class="small muted">Latest update</div>
+        <div class="latestUpdateTitle" id="latestUpdateTitle">—</div>
+        <div class="small" id="latestUpdateDate"></div>
+      </div>
+      <button class="btn secondary" id="latestUpdateViewBtn" type="button">View</button>
+    </div>
+    <div class="latestUpdateBody" id="latestUpdateBody"></div>
+  </div>
+
+  <div class="chanList" id="chanList">
+    <!-- will be rendered by app.js from /rooms -->
+  </div>
+</div>
+
+<div class="menuPanel" id="menuPanel">
+  <div class="menuNav" id="menuNav">
+    <button class="menuTab active" data-menu-tab="changelog" type="button">Changelog</button>
+    <button class="menuTab" data-menu-tab="rules" type="button">Rules</button>
+    <button class="menuTab" data-menu-tab="faq" type="button">FAQ</button>
+    <button class="menuTab" data-menu-tab="credits" type="button">Credits</button>
+  </div>
+
+  <div class="menuContent">
+    <div class="menuSection" data-menu-section="changelog">
+      <div class="menuSectionHeader">
+        <div>
+          <div class="title">Changelog</div>
+          <div class="small muted">Newest updates appear first.</div>
+        </div>
+        <div class="menuActions" id="changelogActions">
+          <button class="btn" id="changelogNewBtn" type="button">New entry</button>
+        </div>
+      </div>
+
+      <div class="card" id="changelogEditor">
+        <div class="field">
+          <label for="changelogTitleInput">Title</label>
+          <input id="changelogTitleInput" maxlength="120" placeholder="What's new?">
+        </div>
+        <div class="field">
+          <label for="changelogBodyInput">Details</label>
+          <textarea id="changelogBodyInput" rows="4" maxlength="8000" placeholder="Describe the change..."></textarea>
+        </div>
+        <div class="row" style="align-items:center; gap:10px; flex-wrap:wrap;">
+          <button class="btn" id="changelogSaveBtn" type="button">Save</button>
+          <button class="btn secondary" id="changelogCancelBtn" type="button">Cancel</button>
+          <div class="msgline" id="changelogEditMsg"></div>
+        </div>
+      </div>
+
+      <div class="msgline" id="changelogMsg"></div>
+      <div class="changelogList" id="changelogList"></div>
+    </div>
+
+    <div class="menuSection" data-menu-section="rules">
+      <div class="menuSectionHeader">
+        <div class="title">Rules</div>
+      </div>
+      <div class="card muted">Coming soon.</div>
+    </div>
+
+    <div class="menuSection" data-menu-section="faq">
+      <div class="menuSectionHeader">
+        <div class="title">FAQ</div>
+      </div>
+      <div class="card muted">Coming soon.</div>
+    </div>
+
+    <div class="menuSection" data-menu-section="credits">
+      <div class="menuSectionHeader">
+        <div class="title">Credits</div>
+      </div>
+      <div class="card muted">Coming soon.</div>
+    </div>
+  </div>
 </div>
 
 <div class="commandPopup" id="commandPopup" aria-live="polite">

--- a/public/styles.css
+++ b/public/styles.css
@@ -679,6 +679,58 @@ textarea{ min-height:90px; resize:vertical; }
   flex:1;
   overflow:auto;
 }
+.roomsPanel, .menuPanel{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  flex:1;
+  min-height:0;
+}
+.menuPanel{ display:none; }
+.menuNav{
+  display:flex;
+  gap:6px;
+  flex-wrap:wrap;
+}
+.menuTab{
+  padding:8px 10px;
+  border-radius:var(--radiusMd);
+  border:1px solid var(--border);
+  background:var(--panel);
+  cursor:pointer;
+  color:var(--text);
+}
+.menuTab.active{ background:var(--panel2); box-shadow:var(--shadowSm); }
+.menuContent{ flex:1; display:flex; flex-direction:column; gap:10px; min-height:0; overflow:auto; padding:2px; }
+.menuSection{ display:none; flex-direction:column; gap:10px; }
+.menuSection.active{ display:flex; }
+.menuSectionHeader{ display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+.menuActions{ display:flex; gap:8px; align-items:center; }
+.card{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:var(--radiusLg);
+  padding:10px;
+  box-shadow:var(--shadowSm);
+}
+.latestUpdate{
+  display:none;
+  padding:10px;
+  border-radius:var(--radiusLg);
+  border:1px solid var(--border);
+  background:var(--panel);
+  box-shadow:var(--shadowSm);
+}
+.latestUpdateTop{ display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
+.latestUpdateTitle{ font-weight:800; font-size:14px; }
+.latestUpdateBody{ margin-top:6px; color:var(--text); white-space:pre-line; }
+.changelogList{ display:flex; flex-direction:column; gap:10px; min-height:0; }
+.changelogEntry{ padding:10px; border-radius:var(--radiusLg); border:1px solid var(--border); background:var(--panel); box-shadow:var(--shadowSm); }
+.changelogEntryHeader{ display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+.changelogEntryTitle{ font-weight:800; }
+.changelogEntryMeta{ font-size:12px; color:var(--muted); }
+.changelogBody{ margin-top:6px; white-space:pre-line; }
+.changelogActions{ display:flex; gap:6px; flex-wrap:wrap; }
 .chan{
   padding:9px 10px;
   border-radius:var(--radiusMd);


### PR DESCRIPTION
## Summary
- add persistent changelog storage with sequential ordering and owner-only CRUD endpoints
- introduce a menu panel alongside the rooms list with changelog management and placeholder sections
- show a latest-update snippet above the rooms list that links into the changelog view

## Testing
- npm install *(fails: registry access returned 403 Forbidden)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fd370f290833396149e7fe0cd8206)