### PR TITLE
Allow inline styles in CSP for client UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "bcrypt": "^6.0.0",
+        "connect-sqlite3": "^0.9.0",
         "dotenv": "^17.2.3",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
@@ -450,6 +451,17 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/connect-sqlite3": {
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/connect-sqlite3/-/connect-sqlite3-0.9.16.tgz",
+      "integrity": "sha512-2gqo0QmcBBL8p8+eqpBETn7RgM/PaoKvpQGl8PfjEgwlr0VuMYNMxRJRrRCo3KR3fxMYeSsCw2tGNG0JKN9Nvg==",
+      "dependencies": {
+        "sqlite3": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
@@ -804,7 +816,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",

--- a/server.js
+++ b/server.js
@@ -351,8 +351,9 @@ app.use((req, res, next) => {
       "default-src 'self'",
       "script-src 'self'",
       "script-src-elem 'self'",
-      // we use an external stylesheet, so no unsafe-inline required
-      "style-src 'self'",
+      // Inline style attributes are set by the client JS (e.g. show/hide panels),
+      // so allow them alongside our external stylesheet.
+      "style-src 'self' 'unsafe-inline'",
       // allow avatars/uploads + blob previews on client
       "img-src 'self' data: blob:",
       "media-src 'self' blob:",


### PR DESCRIPTION
## Summary
- allow inline styles in the Content Security Policy so client-side display toggles work again
- update lockfile after installing dependencies

## Testing
- npm start


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fda3328e483339dd0cf3e8e6ce9d1)