### PR TITLE
Fix changelog loader init preventing realtime features

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1503,6 +1503,11 @@ function updateRoomControlsVisibility(){
   }
 }
 
+function ensureChangelogLoaded(force = false){
+  if (activeMenuTab !== "changelog") return;
+  return loadChangelog(force);
+}
+
 function setRightPanelMode(mode){
   rightPanelMode = mode === "menu" ? "menu" : "rooms";
   if(roomsPanel) roomsPanel.style.display = rightPanelMode === "rooms" ? "flex" : "none";


### PR DESCRIPTION
## Summary
- add ensureChangelogLoaded helper so opening the menu no longer throws
- ensure changelog loading calls are gated instead of crashing the app

## Testing
- node --check public/app.js


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe71523c48333aa60d647833b7c21)