### PR TITLE
Handle missing customize tab element

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1453,7 +1453,7 @@ editThemesBtn?.addEventListener("click", ()=>showEditPanel("themes"));
 editDmBtn?.addEventListener("click", ()=>showEditPanel("dm"));
 tabInfo.addEventListener("click", ()=>setTab("info"));
 tabAbout.addEventListener("click", ()=>setTab("about"));
-tabCustomize.addEventListener("click", ()=>setTab("customize"));
+tabCustomize?.addEventListener("click", ()=>setTab("customize"));
 tabModeration.addEventListener("click", async ()=>{
   setTab("moderation");
   await refreshLogs();


### PR DESCRIPTION
## Summary
- guard the customize tab click handler so the script no longer crashes when that tab is absent
- allow the rest of the auth logic to run, restoring login and registration feedback

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695112d15edc8333980b9f53ea217a9c)