### PR TITLE
Restore DM badge and theme controls in edit tab

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1426,11 +1426,9 @@ function uploadChatFileWithProgress(file){
 
 // tabs
 function focusActiveTab(){
-  function focusActiveTab(){
   if (window.matchMedia("(max-width: 760px)").matches) return;
   const active=document.querySelector(".tab.active");
   active?.scrollIntoView({ behavior:"smooth", inline:"center", block:"nearest" });
-  }
 }
 function setTab(tab){
   for(const el of document.querySelectorAll(".tab")){
@@ -1438,15 +1436,19 @@ function setTab(tab){
   }
   viewInfo.style.display = tab==="info" ? "block" : "none";
   viewAbout.style.display = tab==="about" ? "block" : "none";
- viewEdit.style.display = tab==="edit" ? "block" : "none";
+  viewEdit.style.display = tab==="edit" ? "block" : "none";
   viewModeration.style.display = tab==="moderation" ? "block" : "none";
+  if(tab === "edit") showEditPanel("themes");
   focusActiveTab();
 }
 tabEdit.addEventListener("click", ()=>setTab("edit"));
 
 function showEditPanel(which){
-  editThemesPanel.style.display = which==="themes" ? "block" : "none";
+  const isThemes = which === "themes";
+  editThemesPanel.style.display = isThemes ? "block" : "none";
   editDmPanel.style.display = which==="dm" ? "block" : "none";
+  editThemesBtn?.classList.toggle("active", isThemes);
+  editDmBtn?.classList.toggle("active", which === "dm");
 }
 
 editThemesBtn?.addEventListener("click", ()=>showEditPanel("themes"));

--- a/public/index.html
+++ b/public/index.html
@@ -313,7 +313,13 @@
   </div>
 
   <div class="panelBox" id="editThemesPanel" style="display:none;">
-    <!-- MOVE your existing theme grid / theme controls here -->
+    <div class="themeFilters">
+      <button class="pillBtn active" data-theme-filter="all" type="button">All</button>
+      <button class="pillBtn" data-theme-filter="dark" type="button">Dark</button>
+      <button class="pillBtn" data-theme-filter="light" type="button">Light</button>
+    </div>
+    <div class="themeGrid" id="themeGrid"></div>
+    <div class="msgline" id="themeMsg"></div>
   </div>
 
   <div class="panelBox" id="editDmPanel" style="display:none;">
@@ -325,6 +331,28 @@
                 </div>
                 <div class="small">Change the backdrop behind your DM threads and conversation.</div>
               </div>
+
+              <div class="field">
+                <label>Direct message badge color</label>
+                <div class="colorInputRow">
+                  <input id="directBadgeColor" type="color" aria-label="Direct message badge color">
+                  <input id="directBadgeColorText" type="text" placeholder="#ed4245 or red" aria-label="Direct message badge color text">
+                </div>
+              </div>
+
+              <div class="field">
+                <label>Group DM badge color</label>
+                <div class="colorInputRow">
+                  <input id="groupBadgeColor" type="color" aria-label="Group DM badge color">
+                  <input id="groupBadgeColorText" type="text" placeholder="#5865f2 or blue" aria-label="Group DM badge color text">
+                </div>
+              </div>
+
+              <div class="row" style="margin-top:6px;">
+                <button class="btn" id="saveBadgePrefsBtn" type="button">Save badge colors</button>
+              </div>
+
+              <div class="msgline" id="customizeMsg"></div>
   </div>
 </div>
         <div class="modalContent" id="modalContent">
@@ -444,52 +472,6 @@
             <div class="bioRender" id="bioRender">(no bio)</div>
             <div class="small" style="margin-top:8px;">
               BBCode: [b] [i] [u] [s] [quote] [code] [url=] [img]
-            </div>
-          </div>
-
-          <div id="viewCustomize" style="display:none;">
-            <div class="sectionTitle">Customization</div>
-            <div class="panelBox customizeShell">
-              <div class="customNav" id="customNav">
-                <button class="customNavBtn active" data-section="themes" type="button">Themes</button>
-                <button class="customNavBtn" data-section="badges" type="button">Badges</button>
-              </div>
-
-              <div class="customContent">
-                <div class="customPanel active" id="customPanelThemes">
-                  <div class="themeFilters">
-                    <button class="pillBtn active" data-theme-filter="all" type="button">All</button>
-                    <button class="pillBtn" data-theme-filter="dark" type="button">Dark</button>
-                    <button class="pillBtn" data-theme-filter="light" type="button">Light</button>
-                  </div>
-                  <div class="themeGrid" id="themeGrid"></div>
-                  <div class="msgline" id="themeMsg"></div>
-                </div>
-
-                <div class="customPanel" id="customPanelBadges">
-                  <div class="field">
-                    <label>Direct message badge color</label>
-                    <div class="colorInputRow">
-                      <input id="directBadgeColor" type="color" aria-label="Direct message badge color">
-                      <input id="directBadgeColorText" type="text" placeholder="#ed4245 or red" aria-label="Direct message badge color text">
-                    </div>
-                  </div>
-
-                  <div class="field">
-                    <label>Group DM badge color</label>
-                    <div class="colorInputRow">
-                      <input id="groupBadgeColor" type="color" aria-label="Group DM badge color">
-                      <input id="groupBadgeColorText" type="text" placeholder="#5865f2 or blue" aria-label="Group DM badge color text">
-                    </div>
-                  </div>
-
-                  <div class="row" style="margin-top:6px;">
-                    <button class="btn" id="saveBadgePrefsBtn" type="button">Save badge colors</button>
-                  </div>
-
-                  <div class="msgline" id="customizeMsg"></div>
-                </div>
-              </div>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- add theme selection controls to the profile edit tab and remove the old customize view
- restore DM badge color controls alongside DM background settings under the edit tab
- default the edit tab to the themes panel and reflect active panel buttons

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695116e42d008333853035d87d61a2db)