### PR TITLE
Add profile likes, leaderboards, and realtime gold updates

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -19,6 +19,12 @@ let directBadgePending = false;
 let groupBadgePending = false;
 const dmThemeDefaults = { background: "#1e1f22" };
 let dmThemePrefs = { ...dmThemeDefaults };
+let dmTab = "direct";
+const dmUnreadThreads = new Set();
+let dmPickerMode = "create";
+let dmPickerSelection = new Set();
+let dmPickerThreadId = null;
+let dmPickerExisting = [];
 let levelToastTimer = null;
 let rightPanelMode = "rooms";
 let activeMenuTab = "changelog";
@@ -27,6 +33,11 @@ let changelogLoaded = false;
 let changelogDirty = false;
 let editingChangelogId = null;
 let latestChangelogEntry = null;
+let leaderboardsLoaded = false;
+let leaderboardsLoading = false;
+const recentDiceRolls = new Map();
+const diceRollTimers = new Map();
+const DICE_FACES = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
 
 const THEME_LIST = [
   { name: "Minimal Dark", mode: "Dark" },
@@ -51,6 +62,10 @@ let modalTargetUsername = null;
 let pendingFile = null;
 let uploadXhr = null;
 let memberMenuUser = null;
+let replyTarget = null;
+let dmReplyTarget = null;
+let chatPinned = true;
+let dmPinned = true;
 
 // ---- DOM
 const authWrap = document.getElementById("authWrap");
@@ -113,6 +128,8 @@ const msgInput = document.getElementById("msgInput");
 const sendBtn = document.getElementById("sendBtn");
 const searchInput = document.getElementById("searchInput");
 
+msgs?.addEventListener("scroll", ()=>{ chatPinned = isNearBottom(msgs, 160); });
+
 const fileInput = document.getElementById("fileInput");
 const pickFileBtn = document.getElementById("pickFileBtn");
 
@@ -122,12 +139,18 @@ const meRole = document.getElementById("meRole");
 const meStatusText = document.getElementById("meStatusText");
 const statusSelect = document.getElementById("statusSelect");
 const profileBtn = document.getElementById("profileBtn");
+const replyPreview = document.getElementById("replyPreview");
+const replyPreviewText = document.getElementById("replyPreviewText");
+const replyPreviewClose = document.getElementById("replyPreviewClose");
+const mentionDropdown = document.getElementById("mentionDropdown");
 
 // dms
 const dmPanel = document.getElementById("dmPanel");
 const dmToggleBtn = document.getElementById("dmToggleBtn");
 const groupDmToggleBtn = document.getElementById("groupDmToggleBtn");
 const dmCloseBtn = document.getElementById("dmCloseBtn");
+const dmTabs = document.getElementById("dmTabs");
+const dmCreateGroupBtn = document.getElementById("dmCreateGroupBtn");
 const dmThreadList = document.getElementById("dmThreadList");
 const dmMsg = document.getElementById("dmMsg");
 const dmMetaTitle = document.getElementById("dmMetaTitle");
@@ -135,13 +158,45 @@ const dmMetaPeople = document.getElementById("dmMetaPeople");
 const dmMessagesEl = document.getElementById("dmMessages");
 const dmText = document.getElementById("dmText");
 const dmSendBtn = document.getElementById("dmSendBtn");
+
+dmMessagesEl?.addEventListener("scroll", ()=>{ dmPinned = isNearBottom(dmMessagesEl, 160); });
 const dmUserBtn = document.getElementById("dmUserBtn");
+const dmInfoBtn = document.getElementById("dmInfoBtn");
 const dmSettingsBtn = document.getElementById("dmSettingsBtn");
+const goldPill = document.getElementById("goldPill");
+const likeProfileBtn = document.getElementById("likeProfileBtn");
+const likeCount = document.getElementById("likeCount");
+const profileLikeMsg = document.getElementById("profileLikeMsg");
+const leaderboardXp = document.getElementById("leaderboardXp");
+const leaderboardGold = document.getElementById("leaderboardGold");
+const leaderboardDice = document.getElementById("leaderboardDice");
+const leaderboardLikes = document.getElementById("leaderboardLikes");
+const leaderboardsMsg = document.getElementById("leaderboardsMsg");
+const refreshLeaderboardsBtn = document.getElementById("refreshLeaderboardsBtn");
 const dmSettingsMenu = document.getElementById("dmSettingsMenu");
 const dmDeleteHistoryBtn = document.getElementById("dmDeleteHistoryBtn");
 const dmReportBtn = document.getElementById("dmReportBtn");
+const dmReplyPreview = document.getElementById("dmReplyPreview");
+const dmReplyPreviewText = document.getElementById("dmReplyPreviewText");
+const dmReplyClose = document.getElementById("dmReplyClose");
+const dmMentionDropdown = document.getElementById("dmMentionDropdown");
 const dmBgColor = document.getElementById("dmBgColor");
 const dmBgColorText = document.getElementById("dmBgColorText");
+const dmPickerModal = document.getElementById("dmPickerModal");
+const dmModalCloseBtn = document.getElementById("dmModalCloseBtn");
+const dmModalCancelBtn = document.getElementById("dmModalCancelBtn");
+const dmModalPrimaryBtn = document.getElementById("dmModalPrimaryBtn");
+const dmModalSearch = document.getElementById("dmModalSearch");
+const dmModalTitle = document.getElementById("dmModalTitle");
+const dmModalSubtitle = document.getElementById("dmModalSubtitle");
+const dmPickerList = document.getElementById("dmPickerList");
+const dmInfoModal = document.getElementById("dmInfoModal");
+const dmInfoCloseBtn = document.getElementById("dmInfoCloseBtn");
+const dmInfoTitle = document.getElementById("dmInfoTitle");
+const dmInfoSubtitle = document.getElementById("dmInfoSubtitle");
+const dmInfoMembers = document.getElementById("dmInfoMembers");
+const dmInfoAddBtn = document.getElementById("dmInfoAddBtn");
+const dmLeaveBtn = document.getElementById("dmLeaveBtn");
 
 const customNav = document.getElementById("customNav");
 const themeGrid = document.getElementById("themeGrid");
@@ -173,6 +228,10 @@ const modalAvatar = document.getElementById("modalAvatar");
 const modalName = document.getElementById("modalName");
 const modalRole = document.getElementById("modalRole");
 const modalMood = document.getElementById("modalMood");
+const mediaLightbox = document.getElementById("mediaLightbox");
+const mediaLightboxImg = document.getElementById("mediaLightboxImg");
+const mediaLightboxVideo = document.getElementById("mediaLightboxVideo");
+const mediaLightboxClose = document.getElementById("mediaLightboxClose");
 
 // info
 const infoAge = document.getElementById("infoAge");
@@ -227,6 +286,7 @@ const logoutBtn = document.getElementById("logoutBtn");
 // member quick mod
 const memberModTools = document.getElementById("memberModTools");
 const quickReason = document.getElementById("quickReason");
+const quickReasonPresets = document.getElementById("quickReasonPresets");
 const quickMuteMins = document.getElementById("quickMuteMins");
 const quickBanMins = document.getElementById("quickBanMins");
 const quickKickBtn = document.getElementById("quickKickBtn");
@@ -235,6 +295,7 @@ const quickBanBtn = document.getElementById("quickBanBtn");
 const quickModMsg = document.getElementById("quickModMsg");
 
 // moderation panel
+const modUserSelect = document.getElementById("modUserSelect");
 const modUser = document.getElementById("modUser");
 const modReason = document.getElementById("modReason");
 const modMuteMins = document.getElementById("modMuteMins");
@@ -246,8 +307,10 @@ const modUnmuteBtn = document.getElementById("modUnmuteBtn");
 const modUnbanBtn = document.getElementById("modUnbanBtn");
 const modWarnBtn = document.getElementById("modWarnBtn");
 const modOpenProfileBtn = document.getElementById("modOpenProfileBtn");
+const modRefreshTargetsBtn = document.getElementById("modRefreshTargetsBtn");
 const modSetRole = document.getElementById("modSetRole");
 const modSetRoleBtn = document.getElementById("modSetRoleBtn");
+const modReasonPresets = document.getElementById("modReasonPresets");
 const modMsg = document.getElementById("modMsg");
 
 // logs
@@ -258,6 +321,10 @@ const refreshLogsBtn = document.getElementById("refreshLogsBtn");
 const logsMsg = document.getElementById("logsMsg");
 const logsBody = document.getElementById("logsBody");
 
+populateReasonPresets(quickReasonPresets, quickReason);
+populateReasonPresets(modReasonPresets, modReason);
+refreshModTargetOptions();
+
 // ---- helpers
 function escapeHtml(s){
   return String(s).replace(/[&<>"']/g, m => ({
@@ -265,6 +332,7 @@ function escapeHtml(s){
   }[m]));
 }
 function normKey(u){ return String(u||"").trim().toLowerCase(); }
+function diceFace(val){ return DICE_FACES[val - 1] || val || ""; }
 function fmtAbs(ts){
   if(!ts) return "—";
   const n = Number(ts);
@@ -339,22 +407,49 @@ function roleIcon(role){
     default: return "👤";
   }
 }
+const PRESET_REASONS = [
+  "Spam / Advertising",
+  "Harassment / Bullying",
+  "Off-topic",
+  "NSFW content",
+  "Impersonation",
+  "Cheating / Exploits",
+];
+function populateReasonPresets(container, targetInput){
+  if(!container || !targetInput) return;
+  container.innerHTML = "";
+  PRESET_REASONS.forEach(reason => {
+    const btn=document.createElement("button");
+    btn.type="button";
+    btn.className="pillBtn";
+    btn.textContent=reason;
+    btn.addEventListener("click", () => {
+      targetInput.value = reason;
+      targetInput.focus();
+    });
+    container.appendChild(btn);
+  });
+}
 function avatarNode(url, fallbackText){
+  const buildFallback = () => {
+    const wrap=document.createElement("div");
+    wrap.className = "avatarFallback";
+    wrap.textContent=(fallbackText||"?").slice(0,1).toUpperCase();
+    return wrap;
+  };
+
   if(url){
     const img=document.createElement("img");
-    img.src=url; img.alt="avatar";
+    img.className = "avatarImg";
+    img.src=url;
+    img.alt="avatar";
+    img.loading="lazy";
+    img.onerror = () => {
+      img.replaceWith(buildFallback());
+    };
     return img;
   }
-  const wrap=document.createElement("div");
-  wrap.style.width="100%";
-  wrap.style.height="100%";
-  wrap.style.display="flex";
-  wrap.style.alignItems="center";
-  wrap.style.justifyContent="center";
-  wrap.style.fontWeight="900";
-  wrap.style.background="var(--avatar-bg)";
-  wrap.textContent=(fallbackText||"?").slice(0,1).toUpperCase();
-  return wrap;
+  return buildFallback();
 }
 
 function clearMsgs(){
@@ -397,11 +492,79 @@ function handleCommandResponse(payload){
   showCommandPopup(title, msg);
 }
 
+function escapeRegex(str){
+  return String(str || "").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
 function applyMentions(text){
-  const u = me?.username ? me.username.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : null;
-  if(!u) return escapeHtml(text);
-  const re = new RegExp(`@${u}\\b`, "gi");
-  return escapeHtml(text).replace(re, (m)=>`<span class="mention">${m}</span>`);
+  const safe = escapeHtml(text);
+  const names = new Set((lastUsers || []).map((u) => u.name));
+  if (me?.username) names.add(me.username);
+  const list = Array.from(names).filter(Boolean);
+  if (!list.length) return safe;
+  const pattern = list.map(escapeRegex).join("|");
+  const re = new RegExp(`@(${pattern})(?=$|[^\\S]|[.,!?:;])`, "gi");
+  return safe.replace(re, (m)=>`<span class="mention">${m}</span>`);
+}
+function isNearBottom(el, threshold = 120){
+  if(!el) return true;
+  return el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
+}
+function mentionCandidates(){
+  const names = new Set((lastUsers || []).map((u) => u.name));
+  if (me?.username) names.add(me.username);
+  return Array.from(names).filter(Boolean);
+}
+function findMentionTrigger(value, cursor){
+  const before = value.slice(0, cursor);
+  const at = before.lastIndexOf("@");
+  if (at === -1) return null;
+  if (at > 0 && /\S/.test(before[at - 1])) return null;
+  const query = before.slice(at + 1);
+  if (query.includes("@") || query.includes("\n")) return null;
+  return { start: at, query };
+}
+function renderMentionDropdown(dropdown, inputEl){
+  if (!dropdown || !inputEl) return;
+  const cursor = inputEl.selectionStart ?? inputEl.value.length;
+  const trigger = findMentionTrigger(inputEl.value, cursor);
+  if (!trigger) {
+    dropdown.classList.remove("show");
+    dropdown.innerHTML = "";
+    return;
+  }
+  const term = trigger.query.toLowerCase();
+  const matches = mentionCandidates()
+    .filter((n) => !term || n.toLowerCase().includes(term))
+    .slice(0, 6);
+  if (!matches.length) {
+    dropdown.classList.remove("show");
+    dropdown.innerHTML = "";
+    return;
+  }
+
+  dropdown.innerHTML = matches
+    .map((name) => `<button type="button" data-name="${escapeHtml(name)}">@${escapeHtml(name)}</button>`)
+    .join("");
+  dropdown.dataset.start = String(trigger.start);
+  dropdown.dataset.inputId = inputEl.id || "";
+  dropdown.classList.add("show");
+}
+function acceptMention(dropdown, name){
+  if (!dropdown) return;
+  const inputId = dropdown.dataset.inputId;
+  const start = Number(dropdown.dataset.start);
+  if (!inputId || Number.isNaN(start)) return;
+  const inputEl = document.getElementById(inputId);
+  if (!inputEl) return;
+  const value = inputEl.value;
+  const before = value.slice(0, start);
+  const after = value.slice(inputEl.selectionEnd ?? value.length);
+  const insertion = `@${name} `;
+  inputEl.value = before + insertion + after;
+  const pos = before.length + insertion.length;
+  inputEl.focus();
+  inputEl.setSelectionRange(pos, pos);
+  dropdown.classList.remove("show");
 }
 
 // BBCode render (escape HTML then whitelist a subset)
@@ -647,6 +810,7 @@ function isGroupThread(threadId){
 function markDmNotification(threadId, isGroupHint){
   const isGroup = typeof isGroupHint === "boolean" ? isGroupHint : isGroupThread(threadId);
   if(dmPanel?.classList.contains("open") && activeDmId === threadId) return;
+  dmUnreadThreads.add(threadId);
   setBadgeVisibility(isGroup ? "group" : "direct", true);
 }
 badgePrefs = loadBadgePrefsFromStorage();
@@ -722,21 +886,75 @@ function closeReactionMenu(){
   reactionMenuFor = null;
   reactionMenuRow = null;
 }
+function openMediaLightbox(src, kind){
+  if (!mediaLightbox || !mediaLightboxImg || !mediaLightboxVideo) return;
+  mediaLightbox.classList.add("show");
+  document.body.classList.add("lockScroll");
+  if (kind === "video") {
+    mediaLightboxVideo.src = src;
+    mediaLightboxVideo.style.display = "block";
+    mediaLightboxImg.style.display = "none";
+    mediaLightboxVideo.play().catch(()=>{});
+  } else {
+    mediaLightboxImg.src = src;
+    mediaLightboxImg.style.display = "block";
+    mediaLightboxVideo.pause();
+    mediaLightboxVideo.style.display = "none";
+  }
+}
+function closeMediaLightbox(){
+  if (!mediaLightbox) return;
+  mediaLightbox.classList.remove("show");
+  document.body.classList.remove("lockScroll");
+  if (mediaLightboxImg) mediaLightboxImg.src = "";
+  if (mediaLightboxVideo) {
+    mediaLightboxVideo.pause();
+    mediaLightboxVideo.src = "";
+  }
+}
+mediaLightboxClose?.addEventListener("click", closeMediaLightbox);
+mediaLightbox?.addEventListener("click", (e) => { if (e.target === mediaLightbox) closeMediaLightbox(); });
 
 function addMessage(m){
   const row = document.createElement("div");
   row.className = "msg" + (m.user === me.username ? " self" : "");
   row.dataset.mid = m.messageId;
 
+  const shouldStick = isNearBottom(msgs, 160);
+
   const av = document.createElement("div");
   av.className = "msgAvatar";
   av.appendChild(avatarNode(m.avatar, m.user));
+  av.title = `View ${m.user} profile`;
+  av.tabIndex = 0;
+  const openProfile = (e) => {
+    e.stopPropagation();
+    openMemberProfile(m.user);
+  };
+  av.addEventListener("click", openProfile);
+  av.addEventListener("keydown", (e) => { if(e.key === "Enter" || e.key === " ") openProfile(e); });
 
   const main = document.createElement("div");
   main.className = "msgMain";
 
   const bubble = document.createElement("div");
   bubble.className = "bubble";
+
+  if (m.replyToId && (m.replyToUser || m.replyToText)) {
+    const replyLink = document.createElement("button");
+    replyLink.type = "button";
+    replyLink.className = "replyContext";
+    replyLink.innerHTML = `
+      <div class="replyUser">@${escapeHtml(m.replyToUser || "")}</div>
+      <div class="replySnippet">${escapeHtml((m.replyToText || "").slice(0, 120))}</div>
+    `;
+    replyLink.onclick = (e) => {
+      e.stopPropagation();
+      const target = document.querySelector(`[data-mid="${m.replyToId}"]`);
+      if (target) target.scrollIntoView({ behavior: "smooth", block: "center" });
+    };
+    bubble.appendChild(replyLink);
+  }
 
   const meta = document.createElement("div");
   meta.className = "metaLine";
@@ -760,12 +978,14 @@ function addMessage(m){
       const img=document.createElement("img");
       img.src=m.attachmentUrl;
       img.alt="image";
+      img.addEventListener("click", ()=>openMediaLightbox(m.attachmentUrl, "image"));
       att.appendChild(img);
     }else if(m.attachmentType==="video"){
       const v=document.createElement("video");
       v.src=m.attachmentUrl;
       v.controls=true;
       v.playsInline=true;
+      v.addEventListener("click", ()=>openMediaLightbox(m.attachmentUrl, "video"));
       att.appendChild(v);
     }else{
       const a=document.createElement("a");
@@ -815,6 +1035,18 @@ function addMessage(m){
     actions.appendChild(del);
   }
 
+  const replyBtn = document.createElement("button");
+  replyBtn.className = "reactBtn";
+  replyBtn.type = "button";
+  replyBtn.textContent = "↩️";
+  replyBtn.title = "Reply";
+  replyBtn.onclick = (e)=>{
+    e.stopPropagation();
+    setReplyTarget({ id: m.messageId, user: m.user, text: m.text });
+    msgInput?.focus();
+  };
+  actions.prepend(replyBtn);
+
   // mobile: long press bubble opens reaction menu
   let pressTimer = null;
   bubble.addEventListener("touchstart", ()=>{
@@ -830,7 +1062,9 @@ function addMessage(m){
   row.appendChild(actions);
 
   msgs.appendChild(row);
-  msgs.scrollTop = msgs.scrollHeight;
+  if (shouldStick || isNearBottom(msgs, 160)) {
+    msgs.scrollTop = msgs.scrollHeight;
+  }
 
   msgIndex.push({ id: m.messageId, el: row, textLower: (m.user+" "+m.text).toLowerCase() });
 }
@@ -883,8 +1117,13 @@ function updateGoldUI(){
     const g = Number(progression.gold || 0);
     memberGold.textContent = `Gold: ${g.toLocaleString()}`;
     memberGold.classList.add("show");
+    if (goldPill) {
+      goldPill.textContent = `💰 ${g.toLocaleString()}`;
+      goldPill.classList.add("show");
+    }
   } else {
     memberGold.classList.remove("show");
+    goldPill?.classList.remove("show");
   }
 }
 
@@ -927,8 +1166,36 @@ function showLevelToast(level){
   levelToastTimer = setTimeout(() => levelToast.classList.remove("show"), 3200);
 }
 
+function refreshModTargetOptions(users = lastUsers){
+  if(!modUserSelect) return;
+  const prev = modUserSelect.value;
+  modUserSelect.innerHTML = "";
+  const placeholder=document.createElement("option");
+  placeholder.value="";
+  placeholder.textContent = users && users.length ? "Select online member" : "No members online";
+  modUserSelect.appendChild(placeholder);
+  (users || []).forEach(u => {
+    const opt=document.createElement("option");
+    opt.value=u.name;
+    opt.textContent=`${u.name} (${normalizeStatusLabel(u.status, "Online")})`;
+    modUserSelect.appendChild(opt);
+  });
+  if(prev && Array.from(modUserSelect.options).some(o => o.value === prev)){
+    modUserSelect.value = prev;
+  }
+}
+function setModTarget(username){
+  if(modUser) modUser.value = username || "";
+  if(modUserSelect && username){
+    const match = Array.from(modUserSelect.options).find(o => o.value === username);
+    if(match) modUserSelect.value = username;
+  }
+}
+
 function renderMembers(users){
   lastUsers = users || [];
+  cleanupRecentDiceRolls();
+  refreshModTargetOptions(lastUsers);
   memberList.innerHTML="";
   lastUsers.forEach(u=>{
     const row=document.createElement("div");
@@ -958,6 +1225,14 @@ function renderMembers(users){
     meta.appendChild(name);
     meta.appendChild(sub);
 
+    const roll = recentDiceRolls.get(normKey(u.name));
+    if (roll && Date.now() - (roll.ts || 0) < 7000) {
+      const rollRow = document.createElement("div");
+      rollRow.className = "mRoll";
+      rollRow.textContent = `Rolled ${diceFace(roll.value)}`;
+      meta.appendChild(rollRow);
+    }
+
     row.appendChild(av);
     row.appendChild(dot);
     row.appendChild(meta);
@@ -968,6 +1243,29 @@ function renderMembers(users){
     };
     memberList.appendChild(row);
   });
+}
+
+function cleanupRecentDiceRolls(maxAge = 7000){
+  const now = Date.now();
+  for (const [key, info] of recentDiceRolls.entries()) {
+    if (!info?.ts || now - info.ts > maxAge) {
+      recentDiceRolls.delete(key);
+    }
+  }
+}
+
+function noteDiceRoll(username, value){
+  if (!username) return;
+  const key = normKey(username);
+  const payload = { value, ts: Date.now() };
+  recentDiceRolls.set(key, payload);
+  if (diceRollTimers.has(key)) clearTimeout(diceRollTimers.get(key));
+  diceRollTimers.set(key, setTimeout(() => {
+    recentDiceRolls.delete(key);
+    diceRollTimers.delete(key);
+    renderMembers(lastUsers);
+  }, 6500));
+  renderMembers(lastUsers);
 }
 
 async function loadProgression(){
@@ -1055,51 +1353,95 @@ function threadLabel(t){
   return others[0] || "Direct Message";
 }
 
+function lockBodyScroll(lock){
+  document.body.classList.toggle("bodyLocked", !!lock);
+}
+
+function formatDmTime(ts){
+  if (!ts) return "";
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+function threadAvatarNode(t){
+  const wrap = document.createElement("div");
+  wrap.className = "dmAvatar";
+  wrap.appendChild(avatarNode(null, threadLabel(t)));
+  return wrap;
+}
+
+function syncDmTabUi(){
+  dmTabs?.querySelectorAll("[data-dm-tab]")?.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.dmTab === dmTab);
+  });
+  if (dmCreateGroupBtn) dmCreateGroupBtn.style.display = dmTab === "group" ? "block" : "none";
+}
+
+function setDmTab(tab){
+  dmTab = tab === "group" ? "group" : "direct";
+  syncDmTabUi();
+  renderDmThreads();
+}
+
 function renderThreadItem(t){
   const div = document.createElement("div");
   div.className = "dmItem" + (t.id === activeDmId ? " active" : "");
   const label = threadLabel(t);
   const preview = t.last_text ? String(t.last_text).slice(0, 80) : "No messages yet";
-  div.innerHTML = `
-    <div class="name">${escapeHtml(label)}</div>
-    <div class="small">${escapeHtml(preview)}</div>
-  `;
+
+  div.appendChild(threadAvatarNode(t));
+
+  const meta = document.createElement("div");
+  meta.className = "dmItemMeta";
+
+  const top = document.createElement("div");
+  top.className = "dmItemTop";
+  const title = document.createElement("div");
+  title.className = "name";
+  title.textContent = label;
+  const time = document.createElement("div");
+  time.className = "dmItemTime";
+  time.textContent = formatDmTime(t.last_ts);
+  top.appendChild(title);
+  top.appendChild(time);
+
+  const bottom = document.createElement("div");
+  bottom.className = "dmItemBottom";
+  const prev = document.createElement("div");
+  prev.className = "small preview";
+  prev.textContent = preview;
+  bottom.appendChild(prev);
+
+  if (dmUnreadThreads.has(t.id)) {
+    const unread = document.createElement("div");
+    unread.className = "dmUnread";
+    unread.textContent = "New";
+    bottom.appendChild(unread);
+  }
+
+  meta.appendChild(top);
+  meta.appendChild(bottom);
+
+  div.appendChild(meta);
   div.onclick = () => openDmThread(t.id);
   return div;
 }
 
 function renderDmThreads(){
+  if (!dmThreadList) return;
   dmThreadList.innerHTML = "";
 
-  const sections = [
-    {
-      title: "Direct messages",
-      emptyText: "No direct messages yet. Start one from Members.",
-      items: dmThreads.filter((t) => !t.is_group)
-    },
-    {
-      title: "Group chats",
-      emptyText: "No group chats yet.",
-      items: dmThreads.filter((t) => t.is_group)
-    }
-  ];
-
-  for (const section of sections) {
-    const head = document.createElement("div");
-    head.className = "dmSectionTitle";
-    head.textContent = section.title;
-    dmThreadList.appendChild(head);
-
-    if (!section.items.length) {
-      const empty = document.createElement("div");
-      empty.className = "dmEmpty";
-      empty.textContent = section.emptyText;
-      dmThreadList.appendChild(empty);
-      continue;
-    }
-
-    for (const t of section.items) dmThreadList.appendChild(renderThreadItem(t));
+  const list = dmThreads.filter((t) => dmTab === "group" ? t.is_group : !t.is_group);
+  if (!list.length) {
+    const empty = document.createElement("div");
+    empty.className = "dmEmpty";
+    empty.textContent = dmTab === "group"
+      ? "No group chats yet. Start one below."
+      : "No direct messages yet. Start one from Members.";
+    dmThreadList.appendChild(empty);
+    return;
   }
+
+  for (const t of list) dmThreadList.appendChild(renderThreadItem(t));
 }
 
 async function loadDmThreads(){
@@ -1111,6 +1453,7 @@ async function loadDmThreads(){
     }
     const raw = await res.json();
     dmThreads = (raw || []).map((t) => ({ ...t, is_group: !!t.is_group }));
+    syncDmTabUi();
     renderDmThreads();
   } catch {
     dmMsg.textContent = "Could not load threads.";
@@ -1120,6 +1463,7 @@ async function loadDmThreads(){
 async function startDirectMessage(username){
   if (!username || username === me?.username) return;
 
+  setDmTab("direct");
   openDmPanel();
   closeMemberMenu();
 
@@ -1161,6 +1505,7 @@ function openDmPanel(){
   dmPanel.classList.add("open");
   dmMsg.textContent = "";
   clearDmBadges();
+  syncDmTabUi();
 
   // load threads if we haven't yet
   if (!dmThreads.length) loadDmThreads();
@@ -1173,6 +1518,9 @@ function closeDmPanel(){
 }
 
 function renderDmMessages(threadId){
+  if (!dmMessagesEl) return;
+  const keepOffset = dmMessagesEl.scrollHeight - dmMessagesEl.scrollTop;
+  const stick = isNearBottom(dmMessagesEl, 160);
   dmMessagesEl.innerHTML = "";
   const msgsArr = dmMessages.get(threadId) || [];
 
@@ -1181,12 +1529,29 @@ function renderDmMessages(threadId){
     empty.className = "dmEmpty";
     empty.textContent = "No messages yet. Say hi to save this thread.";
     dmMessagesEl.appendChild(empty);
+    dmPinned = true;
     return;
   }
 
   for (const m of msgsArr) {
     const wrap = document.createElement("div");
     wrap.className = "dmBubble" + (m.user === me.username ? " self" : "");
+
+    if (m.replyToId && (m.replyToUser || m.replyToText)) {
+      const replyLink = document.createElement("button");
+      replyLink.type = "button";
+      replyLink.className = "dmReplyContext";
+      replyLink.innerHTML = `
+        <div class="replyUser">@${escapeHtml(m.replyToUser || "")}</div>
+        <div class="replySnippet">${escapeHtml((m.replyToText || "").slice(0, 120))}</div>
+      `;
+      replyLink.onclick = (e) => {
+        e.stopPropagation();
+        const target = dmMessagesEl.querySelector(`[data-dm-mid="${m.replyToId}"]`);
+        if (target) target.scrollIntoView({ behavior: "smooth", block: "center" });
+      };
+      wrap.appendChild(replyLink);
+    }
 
     const meta = document.createElement("div");
     meta.className = "dmMetaRow";
@@ -1197,10 +1562,32 @@ function renderDmMessages(threadId){
     text.innerHTML = applyMentions(m.text || "");
     wrap.appendChild(text);
 
+    const dmActions = document.createElement("div");
+    dmActions.className = "dmActions";
+    const replyBtn = document.createElement("button");
+    replyBtn.type = "button";
+    replyBtn.textContent = "↩️ Reply";
+    replyBtn.className = "smallAction";
+    replyBtn.onclick = (e) => {
+      e.stopPropagation();
+      setDmReplyTarget({ id: m.messageId || m.id, user: m.user, text: m.text });
+      dmText?.focus();
+    };
+    dmActions.appendChild(replyBtn);
+    wrap.dataset.dmMid = m.messageId || m.id;
+    wrap.appendChild(dmActions);
+
     dmMessagesEl.appendChild(wrap);
   }
 
-  dmMessagesEl.scrollTop = dmMessagesEl.scrollHeight;
+  requestAnimationFrame(() => {
+    if (stick) {
+      dmMessagesEl.scrollTop = dmMessagesEl.scrollHeight;
+    } else {
+      dmMessagesEl.scrollTop = Math.max(0, dmMessagesEl.scrollHeight - keepOffset);
+    }
+    dmPinned = stick;
+  });
 }
 
 function setDmMeta(thread){
@@ -1210,16 +1597,21 @@ function setDmMeta(thread){
     return;
   }
   dmMetaTitle.textContent = threadLabel(thread);
-  dmMetaPeople.textContent = (thread.participants || []).join(", ");
+  const names = thread.participants || [];
+  dmMetaPeople.textContent = thread.is_group
+    ? `${names.length} member${names.length === 1 ? "" : "s"}`
+    : names.join(", ");
 }
 
 function openDmThread(threadId){
   activeDmId = threadId;
-  renderDmThreads();
-
   const meta = dmThreads.find(t => t.id === threadId);
+  if (meta) setDmTab(meta.is_group ? "group" : "direct");
+  dmUnreadThreads.delete(threadId);
+  renderDmThreads();
   setDmMeta(meta);
   if (meta) setBadgeVisibility(meta.is_group ? "group" : "direct", false);
+  setDmReplyTarget(null);
 
   dmMessagesEl.innerHTML = "<div class='dmEmpty'>Loading...</div>";
   socket?.emit("dm join", { threadId });
@@ -1271,15 +1663,235 @@ function sendDmMessage(){
   if (!activeDmId) return;
   const txt = dmText.value.trim();
   if (!txt) return;
-  socket?.emit("dm message", { threadId: activeDmId, text: txt });
+  socket?.emit("dm message", { threadId: activeDmId, text: txt, replyToId: dmReplyTarget?.id || null });
   dmText.value = "";
+  setDmReplyTarget(null);
 }
 
-dmToggleBtn?.addEventListener("click", openDmPanel);
-groupDmToggleBtn?.addEventListener("click", openDmPanel);
+function filteredDmCandidates(term, excludeList){
+  const termNorm = normKey(term || "");
+  const excluded = new Set((excludeList || []).map((n) => normKey(n)));
+  const base = (lastUsers || []).filter((u) => {
+    const statusLabel = normalizeStatusLabel(u.status, "Online");
+    return statusLabel !== "Offline";
+  });
 
+  return base
+    .filter((u) => !excluded.has(normKey(u.name)))
+    .filter((u) => !termNorm || normKey(u.name).includes(termNorm))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function renderDmPickerList(){
+  if (!dmPickerList) return;
+  dmPickerList.innerHTML = "";
+  const candidates = filteredDmCandidates(dmModalSearch?.value || "", dmPickerExisting);
+
+  if (!candidates.length) {
+    const empty = document.createElement("div");
+    empty.className = "dmEmpty";
+    empty.textContent = "No members match.";
+    dmPickerList.appendChild(empty);
+    return;
+  }
+
+  for (const u of candidates) {
+    const row = document.createElement("label");
+    row.className = "dmPickerRow";
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    checkbox.checked = dmPickerSelection.has(u.name);
+    checkbox.onchange = () => {
+      if (checkbox.checked) dmPickerSelection.add(u.name); else dmPickerSelection.delete(u.name);
+      syncDmPickerCta();
+    };
+
+    const avatarWrap = document.createElement("div");
+    avatarWrap.className = "dmAvatar";
+    avatarWrap.appendChild(avatarNode(u.avatar, u.name));
+
+    const meta = document.createElement("div");
+    meta.className = "dmItemMeta";
+    const name = document.createElement("div");
+    name.className = "dmPickerName";
+    name.textContent = u.name;
+    const sub = document.createElement("div");
+    sub.className = "dmPickerSub";
+    const statusLabel = normalizeStatusLabel(u.status, "Online");
+    sub.textContent = `${u.role || ""} ${u.role ? "• " : ""}${statusLabel}`;
+    meta.appendChild(name);
+    meta.appendChild(sub);
+
+    row.appendChild(checkbox);
+    row.appendChild(avatarWrap);
+    row.appendChild(meta);
+
+    dmPickerList.appendChild(row);
+  }
+}
+
+function syncDmPickerCta(){
+  const count = dmPickerSelection.size;
+  const min = dmPickerMode === "create" ? 2 : 1;
+  const verb = dmPickerMode === "add" ? "Add" : "Create";
+  if (dmModalPrimaryBtn) {
+    dmModalPrimaryBtn.disabled = count < min;
+    dmModalPrimaryBtn.textContent = verb;
+  }
+  if (dmModalSubtitle) dmModalSubtitle.textContent = dmPickerMode === "add"
+    ? "Pick at least one person to invite"
+    : "Pick at least two people";
+}
+
+function openDmPicker(mode = "create", threadId = null, existing = []){
+  dmPickerMode = mode;
+  dmPickerThreadId = threadId;
+  dmPickerExisting = existing || [];
+  dmPickerSelection = new Set();
+  if (dmModalSearch) dmModalSearch.value = "";
+
+  if (dmModalTitle) dmModalTitle.textContent = mode === "add" ? "Add members" : "Create group";
+  syncDmPickerCta();
+  renderDmPickerList();
+  lockBodyScroll(true);
+  dmPickerModal?.classList.add("show");
+  dmModalSearch?.focus();
+}
+
+function closeDmPicker(){
+  dmPickerModal?.classList.remove("show");
+  lockBodyScroll(false);
+}
+
+async function submitDmPicker(){
+  const names = Array.from(dmPickerSelection);
+  if (!names.length) return;
+
+  if (dmPickerMode === "add" && dmPickerThreadId) {
+    await addMembersToGroup(dmPickerThreadId, names);
+    return;
+  }
+
+  try {
+    dmModalPrimaryBtn.disabled = true;
+    const res = await fetch("/dm/thread", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "group", participants: names }),
+    });
+    dmModalPrimaryBtn.disabled = false;
+    if (!res.ok) {
+      const txt = await res.text();
+      dmMsg.textContent = txt || "Could not create group.";
+      return;
+    }
+    const data = await res.json();
+    closeDmPicker();
+    await loadDmThreads();
+    if (data.threadId) openDmThread(data.threadId);
+  } catch {
+    dmMsg.textContent = "Could not create group.";
+  }
+}
+
+async function fetchDmInfo(threadId){
+  const res = await fetch(`/dm/thread/${threadId}`);
+  if (!res.ok) throw new Error("Failed info");
+  return res.json();
+}
+
+async function openDmInfo(threadId = activeDmId){
+  const meta = dmThreads.find((t) => t.id === threadId);
+  if (!meta || !meta.is_group) {
+    dmMsg.textContent = "Group info is only available inside a group chat.";
+    return;
+  }
+  try {
+    const data = await fetchDmInfo(threadId);
+    dmInfoTitle.textContent = data.title || threadLabel(meta);
+    const names = data.participants || [];
+    dmInfoSubtitle.textContent = `${names.length} member${names.length === 1 ? "" : "s"}`;
+    dmInfoMembers.innerHTML = "";
+    names.forEach((name) => {
+      const row = document.createElement("div");
+      row.className = "dmInfoMember";
+      const avatar = document.createElement("div");
+      avatar.className = "dmAvatar";
+      avatar.appendChild(avatarNode(null, name));
+      const label = document.createElement("div");
+      label.textContent = name;
+      row.appendChild(avatar);
+      row.appendChild(label);
+      dmInfoMembers.appendChild(row);
+    });
+    lockBodyScroll(true);
+    dmInfoModal?.classList.add("show");
+  } catch {
+    dmMsg.textContent = "Could not load group info.";
+  }
+}
+
+function closeDmInfo(){
+  dmInfoModal?.classList.remove("show");
+  lockBodyScroll(false);
+}
+
+async function addMembersToGroup(threadId, names){
+  if (!names?.length) return;
+  try {
+    dmModalPrimaryBtn.disabled = true;
+    const res = await fetch(`/dm/thread/${threadId}/participants`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ participants: names }),
+    });
+    dmModalPrimaryBtn.disabled = false;
+    if (!res.ok) {
+      dmMsg.textContent = (await res.text()) || "Could not add members.";
+      return;
+    }
+    closeDmPicker();
+    await loadDmThreads();
+    openDmInfo(threadId);
+  } catch {
+    dmMsg.textContent = "Could not add members.";
+  }
+}
+
+async function leaveGroup(threadId){
+  const ok = confirm("Leave this group?");
+  if (!ok) return;
+  try {
+    const res = await fetch(`/dm/thread/${threadId}/leave`, { method: "POST" });
+    if (!res.ok) {
+      dmMsg.textContent = (await res.text()) || "Could not leave group.";
+      return;
+    }
+    dmThreads = dmThreads.filter((t) => t.id !== threadId);
+    dmMessages.delete(threadId);
+    dmUnreadThreads.delete(threadId);
+    activeDmId = null;
+    closeDmInfo();
+    renderDmThreads();
+    dmMetaTitle.textContent = "Pick a thread";
+    dmMetaPeople.textContent = "";
+    dmMessagesEl.innerHTML = "";
+  } catch {
+    dmMsg.textContent = "Could not leave group.";
+  }
+}
+
+dmToggleBtn?.addEventListener("click", () => { setDmTab("direct"); openDmPanel(); });
+groupDmToggleBtn?.addEventListener("click", () => { setDmTab("group"); openDmPanel(); });
+dmTabs?.addEventListener("click", (e) => {
+  const btn = e.target.closest("[data-dm-tab]");
+  if (!btn) return;
+  setDmTab(btn.dataset.dmTab);
+});
+dmCreateGroupBtn?.addEventListener("click", () => openDmPicker("create"));
 dmCloseBtn?.addEventListener("click", closeDmPanel);
 dmSendBtn?.addEventListener("click", sendDmMessage);
+dmInfoBtn?.addEventListener("click", () => openDmInfo());
 dmSettingsBtn?.addEventListener("click", (e) => {
   e.stopPropagation();
   toggleDmSettingsMenu();
@@ -1289,6 +1901,20 @@ dmReportBtn?.addEventListener("click", () => {
   dmMsg.textContent = "Report feature coming soon.";
   closeDmSettingsMenu();
 });
+dmModalCloseBtn?.addEventListener("click", closeDmPicker);
+dmModalCancelBtn?.addEventListener("click", closeDmPicker);
+dmPickerModal?.addEventListener("click", (e) => { if (e.target === dmPickerModal) closeDmPicker(); });
+dmModalPrimaryBtn?.addEventListener("click", submitDmPicker);
+dmModalSearch?.addEventListener("input", () => { renderDmPickerList(); syncDmPickerCta(); });
+dmInfoCloseBtn?.addEventListener("click", closeDmInfo);
+dmInfoModal?.addEventListener("click", (e) => { if (e.target === dmInfoModal) closeDmInfo(); });
+dmInfoAddBtn?.addEventListener("click", () => {
+  const meta = dmThreads.find((t) => t.id === activeDmId);
+  const existing = meta?.participants || [];
+  closeDmInfo();
+  if (activeDmId) openDmPicker("add", activeDmId, existing);
+});
+dmLeaveBtn?.addEventListener("click", () => { if (activeDmId) leaveGroup(activeDmId); });
 
 document.addEventListener("click", (e) => {
   if (!dmSettingsOpen) return;
@@ -1327,12 +1953,32 @@ document.addEventListener("click", (e) => {
 });
 membersPane?.addEventListener("scroll", closeMemberMenu);
 
+mentionDropdown?.addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-name]");
+  if (!btn) return;
+  acceptMention(mentionDropdown, btn.dataset.name || "");
+});
+dmMentionDropdown?.addEventListener("click", (e) => {
+  const btn = e.target.closest("button[data-name]");
+  if (!btn) return;
+  acceptMention(dmMentionDropdown, btn.dataset.name || "");
+});
+document.addEventListener("click", (e) => {
+  if (mentionDropdown && !mentionDropdown.contains(e.target) && e.target !== msgInput) {
+    mentionDropdown.classList.remove("show");
+  }
+  if (dmMentionDropdown && !dmMentionDropdown.contains(e.target) && e.target !== dmText) {
+    dmMentionDropdown.classList.remove("show");
+  }
+});
+
 dmText?.addEventListener("keydown", (e) => {
   if (e.key === "Enter" && !e.shiftKey) {
     e.preventDefault();
     sendDmMessage();
   }
 });
+dmText?.addEventListener("input", ()=>renderMentionDropdown(dmMentionDropdown, dmText));
 
 // "Message" button on profile -> always direct DM
 dmUserBtn?.addEventListener("click", () => {
@@ -1568,6 +2214,58 @@ function ensureChangelogLoaded(force = false){
   return loadChangelog(force);
 }
 
+function renderLeaderboard(listEl, items, mapper){
+  if (!listEl) return;
+  listEl.innerHTML = "";
+  if (!items?.length) {
+    const empty = document.createElement("div");
+    empty.className = "small muted";
+    empty.textContent = "No entries yet.";
+    listEl.appendChild(empty);
+    return;
+  }
+
+  items.forEach((item, idx) => {
+    const row = document.createElement("div");
+    row.className = "leaderboardItem";
+    const label = document.createElement("div");
+    label.className = "label";
+    const meta = document.createElement("div");
+    meta.className = "meta";
+
+    const mapped = mapper?.(item, idx) || {};
+    label.textContent = mapped.label || `${idx + 1}. ${item.username}`;
+    meta.textContent = mapped.meta || "";
+
+    row.appendChild(label);
+    row.appendChild(meta);
+    listEl.appendChild(row);
+  });
+}
+
+async function loadLeaderboards(force = false){
+  if (leaderboardsLoading) return;
+  if (leaderboardsLoaded && !force) return;
+  leaderboardsLoading = true;
+  if (leaderboardsMsg) leaderboardsMsg.textContent = "Loading...";
+  try {
+    const res = await fetch("/api/leaderboards");
+    if (!res.ok) throw new Error();
+    const data = await res.json();
+    renderLeaderboard(leaderboardXp, data?.xp, (item, idx) => ({ label: `${idx + 1}. ${item.username}`, meta: `Level ${item.level}` }));
+    renderLeaderboard(leaderboardGold, data?.gold, (item, idx) => ({ label: `${idx + 1}. ${item.username}`, meta: `${Number(item.gold || 0).toLocaleString()} Gold` }));
+    renderLeaderboard(leaderboardDice, data?.dice, (item, idx) => ({ label: `${idx + 1}. ${item.username}`, meta: `${Number(item.sixes || 0)}× ${diceFace(6)}` }));
+    renderLeaderboard(leaderboardLikes, data?.likes, (item, idx) => ({ label: `${idx + 1}. ${item.username}`, meta: `${Number(item.likes || 0)} likes` }));
+    leaderboardsLoaded = true;
+    if (leaderboardsMsg) leaderboardsMsg.textContent = "";
+  } catch {
+    leaderboardsLoaded = false;
+    if (leaderboardsMsg) leaderboardsMsg.textContent = "Failed to load leaderboards.";
+  } finally {
+    leaderboardsLoading = false;
+  }
+}
+
 function setRightPanelMode(mode){
   rightPanelMode = mode === "menu" ? "menu" : "rooms";
   if(roomsPanel) roomsPanel.style.display = rightPanelMode === "rooms" ? "flex" : "none";
@@ -1587,6 +2285,7 @@ function setMenuTab(tab){
     section.classList.toggle("active", section.dataset.menuSection === activeMenuTab);
   });
   if(activeMenuTab === "changelog") ensureChangelogLoaded();
+  if(activeMenuTab === "leaderboards") loadLeaderboards();
 }
 
 function updateChangelogControlsVisibility(){
@@ -1783,6 +2482,7 @@ if(menuNav){
     setMenuTab(btn.dataset.menuTab);
   });
 }
+if(refreshLeaderboardsBtn) refreshLeaderboardsBtn.addEventListener("click", ()=> loadLeaderboards(true));
 if(latestUpdateViewBtn){
   latestUpdateViewBtn.addEventListener("click", ()=>{
     setMenuTab("changelog");
@@ -1795,6 +2495,33 @@ if(changelogCancelBtn) changelogCancelBtn.addEventListener("click", closeChangel
 if(changelogSaveBtn) changelogSaveBtn.addEventListener("click", saveChangelogEntry);
 closeChangelogEditor();
 
+function setReplyTarget(target){
+  replyTarget = target;
+  if (!replyPreview || !replyPreviewText) return;
+  if (target) {
+    const base = String(target.text || target.attachment || "").trim();
+    const snippet = base ? base.slice(0, 120) : "Attachment";
+    replyPreviewText.textContent = `Replying to ${target.user || ""}: ${snippet}`;
+    replyPreview.classList.add("show");
+  } else {
+    replyPreview.classList.remove("show");
+    replyPreviewText.textContent = "";
+  }
+}
+function setDmReplyTarget(target){
+  dmReplyTarget = target;
+  if (!dmReplyPreview || !dmReplyPreviewText) return;
+  if (target) {
+    const base = String(target.text || target.attachment || "").trim();
+    const snippet = base ? base.slice(0, 120) : "Attachment";
+    dmReplyPreviewText.textContent = `Replying to ${target.user || ""}: ${snippet}`;
+    dmReplyPreview.classList.add("show");
+  } else {
+    dmReplyPreview.classList.remove("show");
+    dmReplyPreviewText.textContent = "";
+  }
+}
+
 // typing/send
 let typingDebounce=null;
 function emitTyping(){
@@ -1803,11 +2530,17 @@ function emitTyping(){
   clearTimeout(typingDebounce);
   typingDebounce=setTimeout(()=>socket.emit("stop typing"), 900);
 }
-msgInput.addEventListener("input", emitTyping);
+msgInput.addEventListener("input", (e)=>{ emitTyping(); renderMentionDropdown(mentionDropdown, msgInput); });
 msgInput.addEventListener("keydown",(e)=>{
   if(e.key==="Enter"){ e.preventDefault(); sendMessage(); }
 });
 sendBtn.addEventListener("click", sendMessage);
+replyPreviewClose?.addEventListener("click", ()=>setReplyTarget(null));
+dmReplyClose?.addEventListener("click", ()=>setDmReplyTarget(null));
+msgInput?.addEventListener("click", ()=>renderMentionDropdown(mentionDropdown, msgInput));
+msgInput?.addEventListener("focus", ()=>renderMentionDropdown(mentionDropdown, msgInput));
+dmText?.addEventListener("click", ()=>renderMentionDropdown(dmMentionDropdown, dmText));
+dmText?.addEventListener("focus", ()=>renderMentionDropdown(dmMentionDropdown, dmText));
 
 async function sendMessage(){
   if(!socket) return;
@@ -1826,6 +2559,7 @@ async function sendMessage(){
 
     socket.emit("chat message", {
       text,
+      replyToId: replyTarget?.id || null,
       attachmentUrl: attachment?.url || "",
       attachmentType: attachment?.type || "",
       attachmentMime: attachment?.mime || "",
@@ -1833,6 +2567,7 @@ async function sendMessage(){
     });
 
     msgInput.value="";
+    setReplyTarget(null);
     socket.emit("stop typing");
 
     // keep focus on mobile
@@ -1949,6 +2684,18 @@ function fillProfileUI(p, isSelf){
 
   bioRender.innerHTML = p.bio ? renderBBCode(p.bio) : "(no bio)";
   renderLevelProgress(p, isSelf);
+  syncProfileLikes(p, isSelf);
+  if (profileLikeMsg) profileLikeMsg.textContent = "";
+}
+function syncProfileLikes(p = {}, isSelf = false){
+  const likesVal = Number(p.likes || 0);
+  if (likeCount) likeCount.textContent = likesVal.toLocaleString();
+  if (likeProfileBtn) {
+    likeProfileBtn.disabled = !!isSelf;
+    likeProfileBtn.classList.toggle("active", !!p.likedByMe);
+    likeProfileBtn.setAttribute("aria-pressed", p.likedByMe ? "true" : "false");
+    likeProfileBtn.textContent = isSelf ? "❤️ Likes" : (p.likedByMe ? "❤️ Liked" : "♡ Like");
+  }
 }
 function syncCustomizationUI(){
   badgePrefs = loadBadgePrefsFromStorage();
@@ -1961,6 +2708,7 @@ async function openMyProfile(){
   const res=await fetch("/profile");
   if(!res.ok) return;
   const p=await res.json();
+  modalTargetUsername = p.username;
   applyProgressionPayload(p);
 
   modalTitle.textContent="My Profile";
@@ -2026,12 +2774,39 @@ async function openMemberProfile(username){
 
   const iCanMod = (roleRank(me.role) >= roleRank("Moderator")) && (roleRank(me.role) > roleRank(p.role));
   memberModTools.style.display = iCanMod ? "block" : "none";
-  quickReason.value=""; quickMuteMins.value=""; quickBanMins.value=""; quickModMsg.textContent="";
+  quickReason.value=""; quickModMsg.textContent="";
+  if(quickMuteMins) quickMuteMins.value = quickMuteMins.querySelector("option")?.value || "10";
+  if(quickBanMins) quickBanMins.value = quickBanMins.querySelector("option")?.value || "0";
+
+  setModTarget(username);
+  if(modReason) modReason.value = "";
+  if(modMsg) modMsg.textContent = "";
 
   tabModeration.style.display = (roleRank(me.role) >= roleRank("Moderator")) ? "block" : "none";
   setTab("info");
   openModal();
 }
+
+likeProfileBtn?.addEventListener("click", async () => {
+  if (!modalTargetUsername || likeProfileBtn.disabled) return;
+  profileLikeMsg.textContent = "";
+  likeProfileBtn.disabled = true;
+  try {
+    const res = await fetch(`/profile/${encodeURIComponent(modalTargetUsername)}/like`, { method: "POST" });
+    if (!res.ok) {
+      const t = await res.text().catch(() => "");
+      profileLikeMsg.textContent = t || "Could not update like.";
+      return;
+    }
+    const data = await res.json();
+    syncProfileLikes({ likes: data.likes, likedByMe: data.liked }, false);
+  } catch (err) {
+    profileLikeMsg.textContent = "Could not update like.";
+  } finally {
+    const isSelf = normKey(modalTargetUsername) === normKey(me?.username);
+    likeProfileBtn.disabled = isSelf;
+  }
+});
 
 // media actions
 copyUsernameBtn.addEventListener("click", async ()=>{
@@ -2071,86 +2846,144 @@ groupBadgeColorText?.addEventListener("input", () => {
 
 // moderation quick tools
 function requireReason(reason){
-  if(!reason || !reason.trim()) return "Reason is required.";
-  if(reason.trim().length < 3) return "Reason must be at least 3 characters.";
+  const cleaned = (reason || "").trim();
+  if(!cleaned) return "Reason is required.";
+  if(cleaned.length < 3) return "Reason must be at least 3 characters.";
   return null;
 }
+function selectedModTarget(){
+  const typed = (modUser?.value || "").trim();
+  const chosen = modUserSelect?.value || "";
+  return chosen || typed;
+}
+function confirmModeration(action, target){
+  const label = target ? `${action} ${target}?` : `Confirm ${action}?`;
+  return window.confirm(label);
+}
+function ensureTarget(target){
+  if(!target) return "Select or enter a username.";
+  return null;
+}
+
 quickKickBtn.addEventListener("click", ()=>{
-  const err=requireReason(quickReason.value);
+  const reason = (quickReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ quickModMsg.textContent=err; return; }
+  if(!modalTargetUsername){ quickModMsg.textContent="No target selected."; return; }
+  if(!confirmModeration("kick", modalTargetUsername)) return;
   socket?.emit("mod kick", { username: modalTargetUsername });
   quickModMsg.textContent="Kick sent.";
 });
 quickMuteBtn.addEventListener("click", ()=>{
-  const err=requireReason(quickReason.value);
+  const reason = (quickReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ quickModMsg.textContent=err; return; }
+  if(!modalTargetUsername){ quickModMsg.textContent="No target selected."; return; }
+  if(!confirmModeration("mute", modalTargetUsername)) return;
   const mins=Number(quickMuteMins.value || 10);
-  socket?.emit("mod mute", { username: modalTargetUsername, minutes: mins, reason: quickReason.value.trim() });
+  socket?.emit("mod mute", { username: modalTargetUsername, minutes: mins, reason });
   quickModMsg.textContent="Mute sent.";
 });
 quickBanBtn.addEventListener("click", ()=>{
-  const err=requireReason(quickReason.value);
+  const reason = (quickReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ quickModMsg.textContent=err; return; }
+  if(!modalTargetUsername){ quickModMsg.textContent="No target selected."; return; }
+  if(!confirmModeration("ban", modalTargetUsername)) return;
   const mins=Number(quickBanMins.value || 0);
-  socket?.emit("mod ban", { username: modalTargetUsername, minutes: mins, reason: quickReason.value.trim() });
+  socket?.emit("mod ban", { username: modalTargetUsername, minutes: mins, reason });
   quickModMsg.textContent="Ban sent.";
 });
 
 // mod panel
+modRefreshTargetsBtn?.addEventListener("click", ()=>{
+  refreshModTargetOptions(lastUsers);
+  modMsg.textContent = "Online list refreshed.";
+});
 modKickBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
-  socket?.emit("mod kick", { username: modUser.value.trim() });
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("kick", target)) return;
+  socket?.emit("mod kick", { username: target });
   modMsg.textContent="Kick sent.";
 });
 modMuteBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("mute", target)) return;
   const mins=Number(modMuteMins.value || 10);
-  socket?.emit("mod mute", { username: modUser.value.trim(), minutes: mins, reason: modReason.value.trim() });
+  socket?.emit("mod mute", { username: target, minutes: mins, reason });
   modMsg.textContent="Mute sent.";
 });
 modBanBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("ban", target)) return;
   const mins=Number(modBanMins.value || 0);
-  socket?.emit("mod ban", { username: modUser.value.trim(), minutes: mins, reason: modReason.value.trim() });
+  socket?.emit("mod ban", { username: target, minutes: mins, reason });
   modMsg.textContent="Ban sent.";
 });
 modUnmuteBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
-  socket?.emit("mod unmute", { username: modUser.value.trim(), reason: modReason.value.trim() });
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("unmute", target)) return;
+  socket?.emit("mod unmute", { username: target, reason });
   modMsg.textContent="Unmute sent.";
 });
 modUnbanBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
-  socket?.emit("mod unban", { username: modUser.value.trim(), reason: modReason.value.trim() });
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("unban", target)) return;
+  socket?.emit("mod unban", { username: target, reason });
   modMsg.textContent="Unban sent.";
 });
 modWarnBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
-  socket?.emit("mod warn", { username: modUser.value.trim(), reason: modReason.value.trim() });
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  if(!confirmModeration("warn", target)) return;
+  socket?.emit("mod warn", { username: target, reason });
   modMsg.textContent="Warn sent.";
 });
 modOpenProfileBtn.addEventListener("click", async ()=>{
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
-  await openMemberProfile(modUser.value.trim());
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
+  await openMemberProfile(target);
 });
 modSetRoleBtn.addEventListener("click", ()=>{
-  const err=requireReason(modReason.value);
+  const reason = (modReason.value || "").trim();
+  const err=requireReason(reason);
   if(err){ modMsg.textContent=err; return; }
-  if(!modUser.value.trim()){ modMsg.textContent="Enter a target username."; return; }
+  const target = selectedModTarget();
+  const targetErr = ensureTarget(target);
+  if(targetErr){ modMsg.textContent = targetErr; return; }
   if(!modSetRole.value){ modMsg.textContent="Choose a role first."; return; }
-  socket?.emit("mod set role", { username: modUser.value.trim(), role: modSetRole.value, reason: modReason.value.trim() });
+  if(!confirmModeration("role update", target)) return;
+  socket?.emit("mod set role", { username: target, role: modSetRole.value, reason });
   modMsg.textContent="Role change sent (Owner only).";
 });
 
@@ -2313,9 +3146,10 @@ socket.on("disconnect", (reason) => {
     if (typeof refreshMe === "function") refreshMe();
   });
   socket.on("dice:error", (msg)=> addSystem(msg));
-  socket.on("dice:rolled", ({value, won}) => {
+  socket.on("dice:rolled", ({value, won, username}) => {
     // show animation for other rollers too (nice-to-have)
     showDiceAnimation(value, won);
+    if (username) noteDiceRoll(username, value);
   });
 
   socket.on("command response", handleCommandResponse);
@@ -2330,6 +3164,10 @@ socket.on("disconnect", (reason) => {
     if(level) progression.level = level;
     showLevelToast(level || "");
     loadProgression();
+    renderLevelProgress(progression, true);
+  });
+  socket.on("progression:update", (payload = {}) => {
+    applyProgressionPayload(payload);
     renderLevelProgress(progression, true);
   });
   socket.on("history", (history)=>{

--- a/public/index.html
+++ b/public/index.html
@@ -74,7 +74,7 @@
     <button class="menuTab active" data-menu-tab="changelog" type="button">Changelog</button>
     <button class="menuTab" data-menu-tab="rules" type="button">Rules</button>
     <button class="menuTab" data-menu-tab="faq" type="button">FAQ</button>
-    <button class="menuTab" data-menu-tab="credits" type="button">Credits</button>
+    <button class="menuTab" data-menu-tab="leaderboards" type="button">Leaderboards</button>
   </div>
 
   <div class="menuContent">
@@ -123,11 +123,35 @@
       <div class="card muted">Coming soon.</div>
     </div>
 
-    <div class="menuSection" data-menu-section="credits">
+    <div class="menuSection" data-menu-section="leaderboards">
       <div class="menuSectionHeader">
-        <div class="title">Credits</div>
+        <div>
+          <div class="title">Leaderboards</div>
+          <div class="small muted">XP, Gold, Dice sixes, and profile likes.</div>
+        </div>
+        <div class="menuActions">
+          <button class="btn secondary" id="refreshLeaderboardsBtn" type="button">Refresh</button>
+        </div>
       </div>
-      <div class="card muted">Coming soon.</div>
+      <div class="msgline" id="leaderboardsMsg"></div>
+      <div class="leaderboardGrid">
+        <div class="card leaderboardCard">
+          <div class="sectionTitle">XP leaderboard</div>
+          <div class="leaderboardList" id="leaderboardXp"></div>
+        </div>
+        <div class="card leaderboardCard">
+          <div class="sectionTitle">Gold leaderboard</div>
+          <div class="leaderboardList" id="leaderboardGold"></div>
+        </div>
+        <div class="card leaderboardCard">
+          <div class="sectionTitle">Dice leaderboard</div>
+          <div class="leaderboardList" id="leaderboardDice"></div>
+        </div>
+        <div class="card leaderboardCard">
+          <div class="sectionTitle">Profile likes</div>
+          <div class="leaderboardList" id="leaderboardLikes"></div>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -178,10 +202,11 @@
            <div class="roomTitle"><span id="roomTitle">main</span></div>
           </div>
 
-            <div class="row" style="align-items:center; gap:10px;">
+          <div class="row" style="align-items:center; gap:10px;">
             <div class="searchWrap">
               <input id="searchInput" placeholder="Search messages...">
             </div>
+            <div class="goldPill mobOnly" id="goldPill" aria-live="polite"></div>
             <button class="iconBtn withBadge" id="dmToggleBtn" type="button" title="Direct messages">💬<span class="notifDot" id="dmBadgeDot" title="New DMs"></span></button>
             <button class="iconBtn withBadge" id="groupDmToggleBtn" type="button" title="Group chats">👪<span class="notifDot right" id="groupDmBadgeDot" title="New group DMs"></span></button>
             <button class="iconBtn mobOnly" id="openMembersBtn" type="button" title="Members">👥</button>
@@ -207,6 +232,11 @@
           </div>
         </div>
 
+        <div class="replyPreview" id="replyPreview">
+          <div class="replyText" id="replyPreviewText"></div>
+          <button class="iconBtn smallIcon" id="replyPreviewClose" type="button" aria-label="Cancel reply">✕</button>
+        </div>
+
         <div class="inputBar">
          <input id="msgInput" type="text" placeholder="Message main" maxlength="800">
 
@@ -217,6 +247,7 @@
           <button class="iconBtn" id="pickFileBtn" type="button" title="Upload">📷</button>
 
           <button class="btn" id="sendBtn" type="button">Send</button>
+          <div class="mentionDropdown" id="mentionDropdown"></div>
         </div>
       </main>
 
@@ -257,7 +288,16 @@
     <div class="dmNotice" id="dmMsg"></div>
 
     <div class="dmContent">
-      <div class="dmThreads" id="dmThreadList"></div>
+      <div class="dmThreads" id="dmThreads">
+        <div class="dmTabs" id="dmTabs">
+          <button class="segBtn active" data-dm-tab="direct" type="button">DMs</button>
+          <button class="segBtn" data-dm-tab="group" type="button">Group DMs</button>
+        </div>
+        <div class="dmThreadActions" id="dmThreadActions">
+          <button class="btn full" id="dmCreateGroupBtn" type="button">➕ Create Group</button>
+        </div>
+        <div class="dmThreadList" id="dmThreadList"></div>
+      </div>
       <div class="dmConversation">
         <div class="dmMeta">
           <div class="dmMetaText">
@@ -265,6 +305,7 @@
             <div class="small" id="dmMetaPeople"></div>
           </div>
           <div class="dmMetaActions">
+            <button class="iconBtn secondary" id="dmInfoBtn" type="button" title="Group info">ℹ️</button>
             <button class="iconBtn secondary" id="dmSettingsBtn" type="button" title="DM settings">⚙️</button>
             <div class="dmSettingsMenu" id="dmSettingsMenu">
               <div class="dmSettingsRow">
@@ -278,10 +319,56 @@
           </div>
         </div>
         <div class="dmMessages" id="dmMessages"></div>
+        <div class="replyPreview" id="dmReplyPreview">
+          <div class="replyText" id="dmReplyPreviewText"></div>
+          <button class="iconBtn smallIcon" id="dmReplyClose" type="button" aria-label="Cancel reply">✕</button>
+        </div>
         <div class="dmInput">
           <input id="dmText" placeholder="Message" maxlength="800">
           <button class="btn" id="dmSendBtn" type="button">Send</button>
+          <div class="mentionDropdown" id="dmMentionDropdown"></div>
         </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="dmModal" id="dmPickerModal">
+    <div class="dmModalCard">
+      <div class="dmModalHeader">
+        <div>
+          <div class="title" id="dmModalTitle">Create group</div>
+          <div class="small" id="dmModalSubtitle">Pick at least two people</div>
+        </div>
+        <button class="iconBtn" id="dmModalCloseBtn" type="button" aria-label="Close">✕</button>
+      </div>
+      <div class="field">
+        <label for="dmModalSearch">Search</label>
+        <input id="dmModalSearch" type="search" placeholder="Search by username">
+      </div>
+      <div class="dmPickerList" id="dmPickerList"></div>
+      <div class="dmModalActions">
+        <button class="btn secondary" id="dmModalCancelBtn" type="button">Cancel</button>
+        <button class="btn" id="dmModalPrimaryBtn" type="button" disabled>Create</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="dmModal" id="dmInfoModal">
+    <div class="dmModalCard">
+      <div class="dmModalHeader">
+        <div>
+          <div class="title" id="dmInfoTitle">Group info</div>
+          <div class="small" id="dmInfoSubtitle"></div>
+        </div>
+        <button class="iconBtn" id="dmInfoCloseBtn" type="button" aria-label="Close">✕</button>
+      </div>
+      <div class="dmInfoSection">
+        <div class="small">Members</div>
+        <div class="dmInfoMembers" id="dmInfoMembers"></div>
+      </div>
+      <div class="dmModalActions stacked">
+        <button class="btn secondary" id="dmInfoAddBtn" type="button">Add members</button>
+        <button class="btn danger" id="dmLeaveBtn" type="button">Leave group</button>
       </div>
     </div>
   </div>
@@ -391,6 +478,12 @@
                   <div class="small" id="xpNote">XP is only visible to you.</div>
                 </div>
 
+                <div class="likeRow">
+                  <button class="btn secondary" id="likeProfileBtn" type="button">❤️ Like</button>
+                  <div class="badge" id="likeCount">0</div>
+                </div>
+                <div class="msgline" id="profileLikeMsg"></div>
+
                 <div class="row" style="gap:8px; margin-top:10px; flex-wrap:wrap;">
                   <button class="btn secondary" id="dmUserBtn" type="button">Message</button>
                   <button class="btn secondary" id="copyUsernameBtn" type="button">Copy username</button>
@@ -448,13 +541,35 @@
 
                 <div id="memberModTools" style="display:none; margin-top:12px;">
                   <div class="sectionTitle">Moderator tools</div>
-                  <div class="panelBox">
-                    <div class="row" style="align-items:center;">
-                      <input id="quickReason" placeholder="Reason (required)" style="flex:1; min-width:220px;">
-                      <input id="quickMuteMins" type="number" min="1" max="1440" placeholder="mute mins" style="width:120px;">
-                      <input id="quickBanMins" type="number" min="0" max="999999" placeholder="ban mins (0=perm)" style="width:160px;">
+                  <div class="panelBox modCard">
+                    <div class="field">
+                      <label>Reason</label>
+                      <div class="pillRow" id="quickReasonPresets"></div>
+                      <textarea id="quickReason" rows="2" placeholder="Add context (required)"></textarea>
                     </div>
-                    <div class="row" style="margin-top:8px;">
+                    <div class="modGrid">
+                      <div class="field">
+                        <label>Mute length</label>
+                        <select id="quickMuteMins">
+                          <option value="10">10 minutes</option>
+                          <option value="30">30 minutes</option>
+                          <option value="60">1 hour</option>
+                          <option value="240">4 hours</option>
+                          <option value="1440">24 hours</option>
+                        </select>
+                      </div>
+                      <div class="field">
+                        <label>Ban length</label>
+                        <select id="quickBanMins">
+                          <option value="0">Permanent</option>
+                          <option value="60">1 hour</option>
+                          <option value="720">12 hours</option>
+                          <option value="1440">24 hours</option>
+                          <option value="10080">7 days</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="actionGrid" style="margin-top:8px;">
                       <button class="btn secondary" id="quickKickBtn" type="button">Kick</button>
                       <button class="btn secondary" id="quickMuteBtn" type="button">Mute</button>
                       <button class="btn danger" id="quickBanBtn" type="button">Ban</button>
@@ -478,39 +593,70 @@
           <div id="viewModeration" style="display:none;">
             <div class="sectionTitle">Moderation panel</div>
 
-            <div class="panelBox">
-              <div class="row" style="align-items:center;">
-                <input id="modUser" placeholder="Target username" style="flex:1; min-width:220px;">
-                <input id="modReason" placeholder="Reason (required)" style="flex:2; min-width:240px;">
+            <div class="panelBox modCard">
+              <div class="field">
+                <label>Target</label>
+                <select id="modUserSelect"></select>
+                <input id="modUser" placeholder="Search or type username" autocomplete="off">
+                <div class="row" style="gap:8px; flex-wrap:wrap;">
+                  <button class="btn secondary" id="modOpenProfileBtn" type="button">View profile</button>
+                  <button class="btn secondary" id="modRefreshTargetsBtn" type="button">Refresh list</button>
+                </div>
               </div>
 
-              <div class="row" style="align-items:center; margin-top:8px;">
-                <input id="modMuteMins" type="number" min="1" max="1440" placeholder="mute mins" style="width:140px;">
-                <input id="modBanMins" type="number" min="0" max="999999" placeholder="ban mins (0=perm)" style="width:190px;">
+              <div class="field">
+                <label>Reason</label>
+                <div class="pillRow" id="modReasonPresets"></div>
+                <textarea id="modReason" rows="2" placeholder="Choose a preset and add details (required)"></textarea>
+              </div>
 
+              <div class="modGrid">
+                <div class="field">
+                  <label>Mute length</label>
+                  <select id="modMuteMins">
+                    <option value="10">10 minutes</option>
+                    <option value="30">30 minutes</option>
+                    <option value="60">1 hour</option>
+                    <option value="240">4 hours</option>
+                    <option value="1440">24 hours</option>
+                  </select>
+                </div>
+                <div class="field">
+                  <label>Ban length</label>
+                  <select id="modBanMins">
+                    <option value="0">Permanent</option>
+                    <option value="60">1 hour</option>
+                    <option value="720">12 hours</option>
+                    <option value="1440">24 hours</option>
+                    <option value="10080">7 days</option>
+                  </select>
+                </div>
+              </div>
+
+              <div class="actionGrid" style="margin-top:8px;">
                 <button class="btn secondary" id="modKickBtn" type="button">Kick</button>
+                <button class="btn secondary" id="modWarnBtn" type="button">Warn</button>
                 <button class="btn secondary" id="modMuteBtn" type="button">Mute</button>
                 <button class="btn danger" id="modBanBtn" type="button">Ban</button>
-
                 <button class="btn secondary" id="modUnmuteBtn" type="button">Unmute</button>
                 <button class="btn secondary" id="modUnbanBtn" type="button">Unban</button>
-                <button class="btn secondary" id="modWarnBtn" type="button">Warn</button>
-
-                <button class="btn secondary" id="modOpenProfileBtn" type="button">View profile</button>
               </div>
 
-              <div class="row" style="align-items:center; margin-top:10px;">
-                <select id="modSetRole" style="width:220px;">
-                  <option value="">Set role (Owner only)</option>
-                  <option>Owner</option>
-                  <option>Co-owner</option>
-                  <option>Admin</option>
-                  <option>Moderator</option>
-                  <option>VIP</option>
-                  <option>User</option>
-                  <option>Guest</option>
-                </select>
-                <button class="btn secondary" id="modSetRoleBtn" type="button">Apply role</button>
+              <div class="field" style="margin-top:8px;">
+                <label>Role assignment</label>
+                <div class="row" style="gap:8px; flex-wrap:wrap;">
+                  <select id="modSetRole">
+                    <option value="">Set role (Owner only)</option>
+                    <option>Owner</option>
+                    <option>Co-owner</option>
+                    <option>Admin</option>
+                    <option>Moderator</option>
+                    <option>VIP</option>
+                    <option>User</option>
+                    <option>Guest</option>
+                  </select>
+                  <button class="btn secondary" id="modSetRoleBtn" type="button">Apply role</button>
+                </div>
               </div>
 
               <div class="msgline" id="modMsg"></div>
@@ -564,6 +710,12 @@
     </div>
   </div>
   <div id="levelToast">🎉 <span id="levelToastText">Level up!</span></div>
+
+  <div class="mediaLightbox" id="mediaLightbox">
+    <button class="iconBtn largeClose" id="mediaLightboxClose" type="button" aria-label="Close media">✕</button>
+    <img id="mediaLightboxImg" alt="Expanded media">
+    <video id="mediaLightboxVideo" playsinline controls></video>
+  </div>
 
   <script src="/socket.io/socket.io.js"></script>
   <script src="/app.js" defer></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -41,6 +41,7 @@
   --soft: rgba(0, 0, 0, 0.13);
   --avatar-bg: #444444;
   --dm-bg: #1e1f22;
+  --overlay-scrim: rgba(0, 0, 0, 0.6);
   --bubble: var(--messageOtherBg);
   --bubbleSelf: var(--messageSelfBg);
   --ok: var(--success);
@@ -709,6 +710,12 @@ textarea{ min-height:90px; resize:vertical; }
 .menuSection{ display:none; flex-direction:column; gap:10px; }
 .menuSection.active{ display:flex; }
 .menuSectionHeader{ display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
+.leaderboardGrid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr)); gap:12px; }
+.leaderboardCard{ display:flex; flex-direction:column; gap:6px; }
+.leaderboardList{ display:flex; flex-direction:column; gap:6px; }
+.leaderboardItem{ display:flex; align-items:center; justify-content:space-between; gap:10px; padding:8px 10px; border:1px solid var(--line); border-radius:10px; background:var(--panel); }
+.leaderboardItem .label{ font-weight:800; }
+.leaderboardItem .meta{ color:var(--muted); font-size:12px; }
 .menuActions{ display:flex; gap:8px; align-items:center; }
 .card{
   background:var(--panel);
@@ -813,6 +820,20 @@ textarea{ min-height:90px; resize:vertical; }
   border:1px solid var(--line); background:var(--panel); color:var(--text);
   outline:none;
 }
+.goldPill{
+  display:none;
+  align-items:center;
+  gap:6px;
+  padding:8px 10px;
+  border-radius:999px;
+  background:var(--panel);
+  border:1px solid var(--line);
+  font-weight:800;
+  font-size:13px;
+  line-height:1;
+  color:var(--text);
+}
+.goldPill.show{ display:inline-flex; }
 
 .msgs{ flex:1; overflow:auto; padding:14px; display:flex; flex-direction:column; gap:10px; min-height:0; }
 .sys{
@@ -868,6 +889,7 @@ textarea{ min-height:90px; resize:vertical; }
   background:var(--panel);
 }
 .attachment img, .attachment video{ display:block; width:100%; height:auto; }
+.attachment img, .attachment video{ user-select:none; }
 .attachment video{ background:var(--bg); }
 
 .actions{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:2px; }
@@ -894,6 +916,7 @@ textarea{ min-height:90px; resize:vertical; }
   gap:10px;
   align-items:center;
   flex-shrink:0;
+  position:relative;
 }
 .inputBar input[type="text"]{
   flex:1;
@@ -910,6 +933,18 @@ textarea{ min-height:90px; resize:vertical; }
   width:1px; height:1px;
   opacity:0;
 }
+
+.replyPreview{ display:none; align-items:center; gap:10px; padding:8px 12px; margin:8px 12px; background:color-mix(in srgb, var(--panel) 80%, transparent); border:1px solid var(--border); border-radius:var(--radiusLg); }
+.replyPreview.show{ display:flex; }
+.replyText{ flex:1; font-size:13px; color:var(--muted); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.replyContext{ width:100%; text-align:left; border:1px solid var(--border); background:color-mix(in srgb, var(--panel) 85%, transparent); color:var(--text); border-radius:var(--radiusMd); padding:6px 8px; margin-bottom:6px; }
+.replyContext .replyUser{ font-weight:700; color:var(--muted); }
+.replyContext .replySnippet{ font-size:13px; color:var(--text); overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+.dmReplyContext{ width:100%; text-align:left; border:1px solid var(--border); background:color-mix(in srgb, var(--panel2) 90%, transparent); color:var(--text); border-radius:var(--radiusMd); padding:6px 8px; margin-bottom:6px; }
+.mentionDropdown{ position:absolute; right:12px; bottom:58px; background:var(--panel); border:1px solid var(--border); border-radius:var(--radiusMd); box-shadow:var(--shadowLg); padding:6px; display:none; flex-direction:column; gap:4px; z-index:30; min-width:180px; }
+.mentionDropdown.show{ display:flex; }
+.mentionDropdown button{ width:100%; text-align:left; padding:8px 10px; border-radius:var(--radiusSm); border:1px solid transparent; background:transparent; color:var(--text); }
+.mentionDropdown button:hover{ border-color:var(--borderStrong); background:color-mix(in srgb, var(--panel2) 80%, transparent); }
 
 /* Upload preview */
 .uploadPreview{
@@ -984,6 +1019,7 @@ textarea{ min-height:90px; resize:vertical; }
 .mMeta{ display:flex; flex-direction:column; gap:2px; min-width:0; }
 .mName{ font-weight:900; font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .mSub{ font-size:11px; color:var(--muted); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.mRoll{ font-size:11px; color:var(--accent); font-weight:800; }
 
 .memberMenu{
   position:absolute;
@@ -1027,9 +1063,12 @@ textarea{ min-height:90px; resize:vertical; }
 }
 .modalContent{ flex:1 1 auto; overflow:auto; -webkit-overflow-scrolling: touch; padding-right:2px; min-height:0; }
 .tabs{
-  display:flex; gap:8px; flex-wrap:nowrap;
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
   margin:10px 0 12px;
-  overflow-x:auto; -webkit-overflow-scrolling:touch;
+  overflow-x:visible;
+  -webkit-overflow-scrolling:touch;
   scrollbar-width:none;
 }
 .tabs::-webkit-scrollbar{ display:none; }
@@ -1043,18 +1082,32 @@ textarea{ min-height:90px; resize:vertical; }
   font-size:12px;
   color:var(--text);
   user-select:none;
-  flex:0 0 auto;
+  flex:1 1 120px;
+  text-align:center;
 }
 .tab.active{ background:var(--panel); border-color:var(--border); box-shadow: var(--shadowSm); }
 
 .modalGrid{ display:grid; grid-template-columns: 170px 1fr; gap:12px; }
 .pAvatar{ width:160px; height:160px; border-radius:18px; background:var(--avatar-bg); overflow:hidden; border:1px solid var(--border); }
 .pAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
+.avatarImg{ width:100%; height:100%; object-fit:cover; display:block; }
+.avatarFallback{
+  width:100%;
+  height:100%;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:900;
+  background:var(--avatar-bg);
+  text-transform:uppercase;
+}
 .small{ font-size:12px; color:var(--muted); }
 .sectionTitle{ font-weight:900; margin:10px 0 6px; }
 .panelBox{ background:var(--panel2); border:1px solid var(--border); border-radius:14px; padding:10px; }
 .panelBox .badge{ background:var(--accent); color:var(--btnPrimaryText); }
 .panelBox .small{ color:var(--muted); }
+.likeRow{ display:flex; align-items:center; gap:10px; flex-wrap:wrap; margin-top:10px; }
+.likeRow .badge{ background:var(--panel); color:var(--text); border:1px solid var(--line); }
 
 .infoGrid{ display:grid; grid-template-columns: 1fr 1fr; gap:10px; }
 .infoItem{ background: color-mix(in srgb, var(--panel) 85%, transparent); border:1px solid var(--border); border-radius:14px; padding:10px; }
@@ -1088,6 +1141,13 @@ textarea{ min-height:90px; resize:vertical; }
 .logTable th, .logTable td{ border-bottom:1px solid var(--line); padding:8px 8px; text-align:left; vertical-align:top; }
 .logTable th{ color:var(--muted); font-weight:900; }
 .logTable tr:last-child td{ border-bottom:0; }
+
+.modCard{ display:flex; flex-direction:column; gap:10px; }
+.pillRow{ display:flex; flex-wrap:wrap; gap:8px; }
+.actionGrid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap:8px; }
+.modGrid{ display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:10px; }
+.modGrid select{ width:100%; }
+
 
 /* Customization */
 .customizeShell{ display:grid; grid-template-columns: 200px 1fr; gap:12px; align-items:start; }
@@ -1172,6 +1232,11 @@ textarea{ min-height:90px; resize:vertical; }
     z-index: 150;
   }
 .overlay.show{ display:block; }
+.mediaLightbox{ position:fixed; inset:0; background:rgba(0,0,0,.75); display:none; align-items:center; justify-content:center; z-index:500; padding:20px; }
+.mediaLightbox.show{ display:flex; }
+.mediaLightbox img, .mediaLightbox video{ max-width:90vw; max-height:80vh; border-radius:16px; box-shadow:var(--shadowLg); background:#000; }
+.mediaLightbox .largeClose{ position:absolute; top:16px; right:16px; }
+body.lockScroll{ overflow:hidden; }
 .drawerHeader{
   display:flex;
   align-items:center;
@@ -1218,12 +1283,21 @@ textarea{ min-height:90px; resize:vertical; }
   background: rgba(255,255,255,.03);
 }
 .dmContent{ flex:1; display:grid; grid-template-columns: 220px 1fr; min-height:0; backdrop-filter: blur(4px); background:var(--dm-bg); }
-.dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; }
-.dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; flex-direction:column; gap:4px; transition: background .12s ease, border-color .12s ease; }
+.dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; gap:6px; padding:10px 10px 12px; }
+.dmThreadList{ border:1px solid var(--line); border-radius:14px; overflow:auto; background:var(--panel); flex:1; min-height:0; }
+.dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; gap:10px; align-items:center; transition: background .12s ease, border-color .12s ease; }
 .dmItem:hover{ background:var(--panel); }
 .dmItem.active{ background:var(--bubble); }
-.dmItem .name{ font-weight:900; font-size:13px; }
+.dmItem:last-child{ border-bottom:0; }
+.dmItem .name{ font-weight:900; font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .dmItem .small{ color:var(--muted); font-size:11px; }
+.dmItem .preview{ display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.dmItemTop{ display:flex; align-items:center; gap:6px; justify-content:space-between; }
+.dmItemMeta{ display:flex; flex-direction:column; gap:6px; min-width:0; flex:1; }
+.dmItemBottom{ display:flex; align-items:center; gap:6px; justify-content:space-between; }
+.dmItemTime{ font-size:11px; color:var(--muted); white-space:nowrap; }
+.dmUnread{ min-width:22px; height:22px; padding:0 8px; border-radius:999px; background:var(--accent); color:white; font-size:11px; display:flex; align-items:center; justify-content:center; }
+.dmAvatar{ width:42px; height:42px; border-radius:12px; overflow:hidden; background:var(--avatar-bg); flex-shrink:0; display:flex; align-items:center; justify-content:center; }
 .dmConversation{ display:flex; flex-direction:column; min-width:0; min-height:0; }
 .dmMeta{ padding:10px 12px; border-bottom:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; gap:10px; }
 .dmMeta .title{ font-weight:900; }
@@ -1239,7 +1313,9 @@ textarea{ min-height:90px; resize:vertical; }
 .dmBubble{ padding:9px 11px; border-radius:12px; background:var(--panel); border:1px solid var(--line); max-width:80%; }
 .dmBubble.self{ background:var(--bubbleSelf); color:white; margin-left:auto; }
 .dmMetaRow{ display:flex; justify-content:space-between; gap:8px; font-size:12px; color:var(--muted); }
-.dmInput{ padding:10px 12px; border-top:1px solid var(--line); display:flex; gap:8px; flex-shrink:0; background: var(--panel2); }
+.dmActions{ display:flex; gap:8px; margin-top:6px; }
+.smallAction{ padding:6px 10px; border-radius:12px; border:1px solid var(--line); background:transparent; color:inherit; }
+.dmInput{ padding:10px 12px; border-top:1px solid var(--line); display:flex; gap:8px; flex-shrink:0; background: var(--panel2); position:relative; }
 .dmInput input{ flex:1; }
 .dmSectionTitle{
   padding:10px 12px;
@@ -1252,7 +1328,30 @@ textarea{ min-height:90px; resize:vertical; }
   background: rgba(255,255,255,.03);
 }
 .dmEmpty{ color:var(--muted); font-size:12px; text-align:center; padding:12px; }
+.dmTabs{ display:flex; gap:8px; padding:6px 6px 0; position:sticky; top:0; background:var(--dm-bg); z-index:1; }
+.segBtn{ flex:1; padding:10px; border-radius:12px; background:var(--panel); border:1px solid var(--line); color:inherit; font-weight:800; letter-spacing:.01em; }
+.segBtn.active{ background:var(--accent); color:#fff; border-color:var(--accent); }
+.dmThreadActions{ padding:4px 6px 6px; }
+.dmThreadActions .btn.full{ width:100%; justify-content:center; }
+.dmModal{ position:fixed; inset:0; background:var(--overlay-scrim); display:none; align-items:center; justify-content:center; padding:14px; z-index:380; }
+.dmModal.show{ display:flex; }
+.dmModalCard{ background:var(--panel2); border:1px solid var(--line); border-radius:18px; width:min(560px, 96vw); max-height:90vh; display:flex; flex-direction:column; gap:12px; padding:14px; overflow:hidden; }
+.dmModalHeader{ display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
+.dmPickerList{ flex:1; min-height:200px; border:1px solid var(--line); border-radius:12px; overflow:auto; background:var(--panel); }
+.dmPickerRow{ display:flex; align-items:center; gap:10px; padding:10px 12px; border-bottom:1px solid var(--line); }
+.dmPickerRow:last-child{ border-bottom:0; }
+.dmPickerName{ font-weight:800; }
+.dmPickerSub{ font-size:11px; color:var(--muted); }
+.dmModalActions{ display:flex; gap:8px; justify-content:flex-end; flex-wrap:wrap; }
+.dmModalActions.stacked{ flex-direction:column; align-items:stretch; }
+.dmModalActions .btn{ flex:1; justify-content:center; }
+.dmInfoMembers{ display:flex; flex-direction:column; gap:8px; margin-top:8px; max-height:260px; overflow:auto; border:1px solid var(--line); border-radius:12px; padding:8px; background:var(--panel); }
+.dmInfoMember{ display:flex; align-items:center; gap:10px; padding:8px 6px; border-bottom:1px solid var(--line); }
+.dmInfoMember:last-child{ border-bottom:0; }
+.dmInfoSection .small{ color:var(--muted); }
+.bodyLocked{ overflow:hidden; }
 .mobOnly{ display:none; }
+.mobOnly.goldPill.show{ display:flex; }
 
 @media (max-width: 1260px){
   .dmPanel{ right:16px; width:min(640px, 70vw); }
@@ -1265,6 +1364,8 @@ textarea{ min-height:90px; resize:vertical; }
 }
 @media (max-width: 980px){
   .mobOnly{ display:flex; }
+  .mobOnly.goldPill{ display:none; }
+  .mobOnly.goldPill.show{ display:flex; }
   .members{ display:none; }
   
   .topbar{ position: sticky; top: 0; z-index: 200; padding:0 10px; gap:8px; }
@@ -1422,64 +1523,44 @@ textarea{ min-height:90px; resize:vertical; }
 #levelToast.show{ opacity:1; transform: translateY(0); }
 
 @media (max-width: 760px){
-  .modalHeader{
-    overflow: hidden;
+  #modal{
+    padding: max(12px, env(safe-area-inset-top)) 10px max(12px, env(safe-area-inset-bottom)) 10px;
   }
-  /* Make the profile modal body behave properly on mobile */
-  .modal .modalBody{
-  flex: 1;
-  min-height: 0; /* REQUIRED for mobile scroll correctness */
-  overflow-y: auto;
-  -webkit-overflow-scrolling: touch;
-}
-  }
-
-  /* Tabs should fit without forcing a scroll area */
- @media (max-width: 760px){
-  .tabs{
-    display: flex;
-    flex-wrap: wrap;
-    overflow-x: hidden;     /* NO sideways scroll */
-    gap: 6px;
-    margin: 10px 0 12px;
-  }
-
-  .tab{
-    flex: 1 1 calc(50% - 6px); /* 2 columns */
-    text-align: center;
-    padding: 8px 6px;
-    font-size: 12px;
-    border-radius: 12px;
-    white-space: nowrap;
-  }
-}
-  /* Slightly reduce heading spacing in profile panels */
-  .panelBox h3{
-    margin: 10px 0 8px;
-  }
-}
-  /* If you want them NOT scrollable, allow wrapping: */
-  .tabs{ flex-wrap:wrap; }
-}
-  .modalGrid{ grid-template-columns: 1fr; }
-  .infoGrid{ grid-template-columns: 1fr; }
-
   .modalCard{
     width: 100vw;
-    height: 92vh;
-    max-height: 92vh;
+    max-width: 100vw;
+    max-height: calc(100dvh - 20px);
     border-radius: 16px;
   }
-  .modalContent{
-    padding-right: 2px;
+  @supports (height: 100svh){
+    .modalCard{ max-height: calc(100svh - 20px); }
   }
+  .modalBody{
+    padding: 0 10px 12px;
+  }
+  .modalGrid{ grid-template-columns: 1fr; }
+  .infoGrid{ grid-template-columns: 1fr; }
+  .pAvatar{ width:140px; height:140px; margin:0 auto; }
+
   .tabs{
     position: sticky;
     top: 0;
     z-index: 5;
     background: var(--panel);
-    padding-top: 6px;
-    border-bottom: 1px solid var(--line);
+    padding: 6px 2px 10px;
+    gap: 8px;
+    overflow: hidden;
+  }
+  .tab{
+    flex: 1 1 calc(50% - 8px);
+    text-align: center;
+    padding: 10px 8px;
+    font-size: 12px;
+    white-space: nowrap;
+  }
+
+  .panelBox h3{
+    margin: 10px 0 8px;
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -127,6 +127,7 @@ db.serialize(() => {
     ["lastMessageGoldAt", "lastMessageGoldAt INTEGER"],
     ["lastDailyLoginGoldAt", "lastDailyLoginGoldAt INTEGER"],
     ["lastDiceRollAt", "lastDiceRollAt INTEGER"],
+    ["dice_sixes", "dice_sixes INTEGER NOT NULL DEFAULT 0"],
   ];
   for (const [col, ddl] of userColumns) addColumnIfMissing("users", col, ddl);
 
@@ -149,6 +150,12 @@ db.serialize(() => {
       attachment_size INTEGER
     )
   `);
+
+  ensureColumns("messages", [
+    ["reply_to_id", "reply_to_id INTEGER"],
+    ["reply_to_user", "reply_to_user TEXT"],
+    ["reply_to_text", "reply_to_text TEXT"],
+  ]);
 
   db.run(`
     CREATE TABLE IF NOT EXISTS reactions (
@@ -183,6 +190,15 @@ db.serialize(() => {
       target_username TEXT,
       room TEXT,
       details TEXT
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE IF NOT EXISTS profile_likes (
+      user_id INTEGER NOT NULL,
+      target_user_id INTEGER NOT NULL,
+      created_at INTEGER NOT NULL,
+      PRIMARY KEY (user_id, target_user_id)
     )
   `);
 
@@ -252,6 +268,12 @@ db.serialize(() => {
       ts INTEGER NOT NULL
     )
   `);
+
+  ensureColumns("dm_messages", [
+    ["reply_to_id", "reply_to_id INTEGER"],
+    ["reply_to_user", "reply_to_user TEXT"],
+    ["reply_to_text", "reply_to_text TEXT"],
+  ]);
 
   ensureColumns("dm_threads", [
     ["title", "title TEXT"],
@@ -856,6 +878,7 @@ const commandRegistry = {
       if (!args[0] || !Number.isFinite(amt)) return { ok: false, message: "Missing arguments" };
       const target = await new Promise((resolve, reject) => findUserByMention(args[0], (e, u) => (e ? reject(e) : resolve(u))));
       await dbRunAsync(`UPDATE users SET gold = gold + ? WHERE id=?`, [amt, target.id]);
+      emitProgressionUpdate(target.id);
       return { ok: true, message: `Gave ${amt} gold to ${target.username}` };
     },
   },
@@ -869,6 +892,7 @@ const commandRegistry = {
       if (!args[0] || !Number.isFinite(amt)) return { ok: false, message: "Missing arguments" };
       const target = await new Promise((resolve, reject) => findUserByMention(args[0], (e, u) => (e ? reject(e) : resolve(u))));
       await dbRunAsync(`UPDATE users SET gold=? WHERE id=?`, [amt, target.id]);
+      emitProgressionUpdate(target.id);
       return { ok: true, message: `Set gold for ${target.username} to ${amt}` };
     },
   },
@@ -969,6 +993,7 @@ const commandRegistry = {
     handler: async ({ args }) => {
       if (args[0] !== "confirm") return { ok: false, message: "Missing confirm" };
       await dbRunAsync(`UPDATE users SET gold=0`);
+      for (const uid of socketIdByUserId.keys()) emitProgressionUpdate(uid);
       return { ok: true, message: "All gold reset" };
     },
   },
@@ -1165,7 +1190,10 @@ function awardPassiveGold(userId, cb) {
     db.run(
       "UPDATE users SET gold = gold + ?, lastGoldTickAt = ? WHERE id = ?",
       [ticks, newTickTs, userId],
-      (updateErr) => cb?.(updateErr, ticks)
+      (updateErr) => {
+        if (!updateErr && ticks > 0) emitProgressionUpdate(userId);
+        cb?.(updateErr, ticks);
+      }
     );
   });
 }
@@ -1180,7 +1208,10 @@ function awardMessageGold(userId, cb) {
     db.run(
       "UPDATE users SET gold = gold + 5, lastMessageGoldAt = ? WHERE id = ?",
       [now, userId],
-      (updateErr) => cb?.(updateErr, updateErr ? 0 : 5)
+      (updateErr) => {
+        if (!updateErr) emitProgressionUpdate(userId);
+        cb?.(updateErr, updateErr ? 0 : 5);
+      }
     );
   });
 }
@@ -1193,7 +1224,7 @@ function awardDailyLoginGold(user) {
   db.run(
     "UPDATE users SET gold = gold + 50, lastDailyLoginGoldAt = ? WHERE id = ?",
     [now, user.id],
-    () => {}
+    () => emitProgressionUpdate(user.id)
   );
 }
 
@@ -1207,6 +1238,15 @@ function progressionFromRow(row, includePrivate) {
     base.xpForNextLevel = info.xpForNextLevel;
   }
   return base;
+}
+
+function emitProgressionUpdate(userId) {
+  const sid = socketIdByUserId.get(userId);
+  if (!sid) return;
+  db.get("SELECT gold, xp FROM users WHERE id = ?", [userId], (err, row) => {
+    if (err || !row) return;
+    io.to(sid).emit("progression:update", progressionFromRow(row, true));
+  });
 }
 
 function fetchUsersByNames(usernames, cb) {
@@ -1516,6 +1556,33 @@ app.post("/api/me/theme", requireLogin, (req, res) => {
   });
 });
 
+app.get("/api/leaderboards", requireLogin, async (_req, res) => {
+  try {
+    const [xpRows, goldRows, diceRows, likeRows] = await Promise.all([
+      dbAllAsync(`SELECT username, xp FROM users ORDER BY xp DESC LIMIT 20`),
+      dbAllAsync(`SELECT username, gold FROM users ORDER BY gold DESC LIMIT 20`),
+      dbAllAsync(`SELECT username, dice_sixes FROM users ORDER BY dice_sixes DESC LIMIT 20`),
+      dbAllAsync(
+        `SELECT u.username, COUNT(pl.user_id) AS likes
+         FROM users u
+         LEFT JOIN profile_likes pl ON pl.target_user_id = u.id
+         GROUP BY u.id
+         ORDER BY likes DESC
+         LIMIT 20`
+      ),
+    ]);
+
+    const xp = xpRows.map((r) => ({ username: r.username, level: levelInfo(r.xp || 0).level, xp: Number(r.xp || 0) }));
+    const gold = goldRows.map((r) => ({ username: r.username, gold: Number(r.gold || 0) }));
+    const dice = diceRows.map((r) => ({ username: r.username, sixes: Number(r.dice_sixes || 0) }));
+    const likes = likeRows.map((r) => ({ username: r.username, likes: Number(r.likes || 0) }));
+
+    return res.json({ xp, gold, dice, likes });
+  } catch (err) {
+    return res.status(500).json({ ok: false });
+  }
+});
+
 app.post("/api/me/award-gold", requireLogin, (req, res) => {
   if (process.env.ALLOW_DEV_AWARD_GOLD !== "1") return res.status(404).send("Not found");
   const amount = clamp(req.body?.amount ?? req.body?.gold ?? 0, 1, 100000);
@@ -1523,6 +1590,7 @@ app.post("/api/me/award-gold", requireLogin, (req, res) => {
 
   db.run("UPDATE users SET gold = gold + ? WHERE id = ?", [amount, req.session.user.id], (err) => {
     if (err) return res.status(500).send("Failed");
+    emitProgressionUpdate(req.session.user.id);
     db.get("SELECT gold FROM users WHERE id = ?", [req.session.user.id], (_e, row) => {
       return res.json({ ok: true, gold: row?.gold || 0 });
     });
@@ -1650,23 +1718,34 @@ app.get("/profile", requireLogin, (req, res) => {
       if (err || !row) return res.status(404).send("Not found");
       const live = onlineState.get(row.id);
       const lastStatus = normalizeStatus(live?.status || row.last_status, "");
-      const payload = {
-        id: row.id,
-        username: row.username,
-        role: row.role,
-        avatar: row.avatar,
-        bio: row.bio,
-        mood: row.mood,
-        age: row.age,
-        gender: row.gender,
-        created_at: row.created_at,
-        last_seen: row.last_seen,
-        last_room: row.last_room,
-        last_status: lastStatus || null,
-        current_room: live?.room || null,
-        ...progressionFromRow(row, true),
-      };
-      return res.json(payload);
+      db.get(
+        `SELECT
+          (SELECT COUNT(*) FROM profile_likes WHERE target_user_id = ?) AS likes,
+          EXISTS(SELECT 1 FROM profile_likes WHERE user_id = ? AND target_user_id = ?) AS liked
+        `,
+        [row.id, req.session.user.id, row.id],
+        (_likeErr, likesRow) => {
+          const payload = {
+            id: row.id,
+            username: row.username,
+            role: row.role,
+            avatar: row.avatar,
+            bio: row.bio,
+            mood: row.mood,
+            age: row.age,
+            gender: row.gender,
+            created_at: row.created_at,
+            last_seen: row.last_seen,
+            last_room: row.last_room,
+            last_status: lastStatus || null,
+            current_room: live?.room || null,
+            likes: Number(likesRow?.likes || 0),
+            likedByMe: !!Number(likesRow?.liked || 0),
+            ...progressionFromRow(row, true),
+          };
+          return res.json(payload);
+        }
+      );
     }
   );
 });
@@ -1684,25 +1763,80 @@ app.get("/profile/:username", requireLogin, (req, res) => {
       const live = onlineState.get(row.id);
       const lastStatus = normalizeStatus(live?.status || row.last_status, "");
       const includePrivate = req.session.user.id === row.id;
-      const payload = {
-        id: row.id,
-        username: row.username,
-        role: row.role,
-        avatar: row.avatar,
-        bio: row.bio,
-        mood: row.mood,
-        age: row.age,
-        gender: row.gender,
-        created_at: row.created_at,
-        last_seen: row.last_seen,
-        last_room: row.last_room,
-        last_status: lastStatus || null,
-        current_room: live?.room || null,
-        ...progressionFromRow(row, includePrivate),
-      };
-      return res.json(payload);
+      db.get(
+        `SELECT
+          (SELECT COUNT(*) FROM profile_likes WHERE target_user_id = ?) AS likes,
+          EXISTS(SELECT 1 FROM profile_likes WHERE user_id = ? AND target_user_id = ?) AS liked
+        `,
+        [row.id, req.session.user.id, row.id],
+        (_likeErr, likesRow) => {
+          const payload = {
+            id: row.id,
+            username: row.username,
+            role: row.role,
+            avatar: row.avatar,
+            bio: row.bio,
+            mood: row.mood,
+            age: row.age,
+            gender: row.gender,
+            created_at: row.created_at,
+            last_seen: row.last_seen,
+            last_room: row.last_room,
+            last_status: lastStatus || null,
+            current_room: live?.room || null,
+            likes: Number(likesRow?.likes || 0),
+            likedByMe: !!Number(likesRow?.liked || 0),
+            ...progressionFromRow(row, includePrivate),
+          };
+          return res.json(payload);
+        }
+      );
     }
   );
+});
+
+app.post("/profile/:username/like", requireLogin, (req, res) => {
+  const u = sanitizeUsername(req.params.username);
+  if (!u) return res.status(400).send("Bad username");
+
+  db.get(`SELECT id FROM users WHERE lower(username) = lower(?)`, [u], (err, target) => {
+    if (err || !target) return res.status(404).send("Not found");
+    if (target.id === req.session.user.id) return res.status(400).json({ ok: false, message: "You cannot like yourself." });
+
+    db.get(
+      `SELECT 1 FROM profile_likes WHERE user_id = ? AND target_user_id = ?`,
+      [req.session.user.id, target.id],
+      (_likeErr, row) => {
+        const now = Date.now();
+        const toggle = row
+          ? dbRunAsync(`DELETE FROM profile_likes WHERE user_id = ? AND target_user_id = ?`, [req.session.user.id, target.id])
+          : dbRunAsync(`INSERT INTO profile_likes (user_id, target_user_id, created_at) VALUES (?, ?, ?)`, [
+              req.session.user.id,
+              target.id,
+              now,
+            ]);
+
+        Promise.resolve(toggle)
+          .then(() => {
+            db.get(
+              `SELECT
+                (SELECT COUNT(*) FROM profile_likes WHERE target_user_id = ?) AS likes,
+                EXISTS(SELECT 1 FROM profile_likes WHERE user_id = ? AND target_user_id = ?) AS liked
+              `,
+              [target.id, req.session.user.id, target.id],
+              (_countErr, likesRow) => {
+                return res.json({
+                  ok: true,
+                  likes: Number(likesRow?.likes || 0),
+                  liked: !!Number(likesRow?.liked || 0),
+                });
+              }
+            );
+          })
+          .catch(() => res.status(500).json({ ok: false, message: "Could not update like" }));
+      }
+    );
+  });
 });
 
 // Avatar upload for profile edits (2MB)
@@ -1855,6 +1989,15 @@ app.get("/dm/threads", requireLogin, (req, res) => {
   );
 });
 
+app.get("/dm/thread/:id", requireLogin, (req, res) => {
+  const tid = Number(req.params.id);
+  if (!Number.isInteger(tid)) return res.status(400).send("Invalid thread");
+  loadThreadForUser(tid, req.session.user.id, (err, thread) => {
+    if (err) return res.status(403).send("Not allowed");
+    return res.json(thread);
+  });
+});
+
 app.post("/dm/thread", requireLogin, (req, res) => {
   let participants = req.body?.participants;
   if (!Array.isArray(participants)) {
@@ -1963,6 +2106,90 @@ app.post("/dm/thread", requireLogin, (req, res) => {
         }
       );
     }
+  });
+});
+
+app.post("/dm/thread/:id/participants", requireLogin, (req, res) => {
+  const tid = Number(req.params.id);
+  if (!Number.isInteger(tid)) return res.status(400).send("Invalid thread");
+
+  loadThreadForUser(tid, req.session.user.id, (err, thread) => {
+    if (err) return res.status(403).send("Not allowed");
+    if (!thread.is_group) return res.status(400).send("Only group DMs can add members");
+
+    let participants = req.body?.participants;
+    if (!Array.isArray(participants)) participants = [];
+
+    const cleaned = [];
+    const seen = new Set();
+    for (const name of participants || []) {
+      const s = sanitizeUsername(name);
+      const key = normKey(s);
+      if (!s || seen.has(key)) continue;
+      if (key === normKey(req.session.user.username)) continue;
+      seen.add(key);
+      cleaned.push(s);
+    }
+
+    if (!cleaned.length) return res.status(400).send("Pick at least one new member");
+
+    fetchUsersByNames(cleaned, (fetchErr, users) => {
+      if (fetchErr) return res.status(500).send("Failed to add members");
+      if (users.length !== cleaned.length) return res.status(404).send("User not found");
+
+      db.all(
+        `SELECT user_id FROM dm_participants WHERE thread_id = ?`,
+        [tid],
+        (listErr, rows) => {
+          if (listErr) return res.status(500).send("Failed to add members");
+          const existingIds = new Set((rows || []).map((r) => r.user_id));
+          const newUsers = users.filter((u) => !existingIds.has(u.id));
+          if (!newUsers.length) return res.status(400).send("Everyone is already in the group");
+
+          const now = Date.now();
+          for (const u of newUsers) {
+            db.run(
+              `INSERT OR IGNORE INTO dm_participants (thread_id, user_id, added_by, joined_at) VALUES (?, ?, ?, ?)`,
+              [tid, u.id, req.session.user.id, now]
+            );
+            const sid = socketIdByUserId.get(u.id);
+            if (sid) {
+              const sock = io.sockets.sockets.get(sid);
+              if (sock) sock.join(`dm:${tid}`);
+              io.to(sid).emit("dm thread invited", {
+                threadId: tid,
+                title: thread.title || null,
+                isGroup: true,
+                participants: thread.participants,
+              });
+            }
+          }
+
+          loadThreadForUser(tid, req.session.user.id, (infoErr, fresh) => {
+            if (infoErr) return res.status(500).send("Added but could not refresh");
+            return res.json({ ok: true, participants: fresh.participants });
+          });
+        }
+      );
+    });
+  });
+});
+
+app.post("/dm/thread/:id/leave", requireLogin, (req, res) => {
+  const tid = Number(req.params.id);
+  if (!Number.isInteger(tid)) return res.status(400).send("Invalid thread");
+  loadThreadForUser(tid, req.session.user.id, (err, thread) => {
+    if (err) return res.status(403).send("Not allowed");
+    if (!thread.is_group) return res.status(400).send("Leaving only available in group chats");
+
+    db.run(
+      `DELETE FROM dm_participants WHERE thread_id = ? AND user_id = ?`,
+      [tid, req.session.user.id],
+      (delErr) => {
+        if (delErr) return res.status(500).send("Could not leave group");
+        return res.json({ ok: true });
+      }
+    );
   });
 });
 
@@ -2160,10 +2387,11 @@ socket.on("join room", ({ room, status }) => {
       const value = Math.floor(Math.random() * 6) + 1; // 1..6
       const won = value === 6;
       const deltaGold = won ? 500 : -50;
+      const sixGain = won ? 1 : 0;
 
       db.run(
-        `UPDATE users SET gold = MAX(0, gold + ?), lastDiceRollAt=? WHERE id=?`,
-        [deltaGold, now, socket.user.id],
+        `UPDATE users SET gold = MAX(0, gold + ?), lastDiceRollAt=?, dice_sixes = dice_sixes + ? WHERE id=?`,
+        [deltaGold, now, sixGain, socket.user.id],
         (uerr) => {
           if (uerr) {
             socket.emit("dice:error", "Could not apply dice result.");
@@ -2172,11 +2400,14 @@ socket.on("join room", ({ room, status }) => {
 
           // Inform roller (for animation + optional UI refresh)
           socket.emit("dice:result", { value, won, deltaGold });
+          emitProgressionUpdate(socket.user.id);
 
           // Broadcast a centered non-bubble system message to the room
+          const faces = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
+          const face = faces[value - 1] || value;
           const msg = won
-            ? `${socket.user.username} rolled a 6 🎉 (+500 Gold!)`
-            : `${socket.user.username} rolled a ${value} 🎲 (-50 Gold!)`;
+            ? `${socket.user.username} rolled ${face} 🎉 (+500 Gold!)`
+            : `${socket.user.username} rolled ${face} 🎲 (-50 Gold!)`;
           io.to(room).emit("system", msg);
 
           // Optional event for others to animate too
@@ -2219,7 +2450,8 @@ function doJoin(room, status) {
 
   // Send history (exclude deleted messages entirely)
   db.all(
-    `SELECT id, room, username, role, avatar, text, ts, attachment_url, attachment_type, attachment_mime, attachment_size
+    `SELECT id, room, username, role, avatar, text, ts, attachment_url, attachment_type, attachment_mime, attachment_size,
+            reply_to_id, reply_to_user, reply_to_text
      FROM messages WHERE room=? AND deleted=0 ORDER BY ts ASC LIMIT 200`,
     [room],
     (_e, rows) => {
@@ -2235,6 +2467,9 @@ function doJoin(room, status) {
         attachmentType: r.attachment_type || "",
         attachmentMime: r.attachment_mime || "",
         attachmentSize: r.attachment_size || 0,
+        replyToId: r.reply_to_id || null,
+        replyToUser: r.reply_to_user || "",
+        replyToText: r.reply_to_text || "",
       }));
       socket.emit("history", history);
 
@@ -2294,10 +2529,21 @@ function doJoin(room, status) {
       socket.join(`dm:${tid}`);
 
       db.all(
-        `SELECT id, thread_id, user_id, username, text, ts FROM dm_messages WHERE thread_id=? ORDER BY ts DESC LIMIT 50`,
+        `SELECT id, thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text FROM dm_messages WHERE thread_id=? ORDER BY ts DESC LIMIT 50`,
         [tid],
         (_e, rows) => {
-          const msgs = (rows || []).reverse();
+          const msgs = (rows || []).reverse().map((r) => ({
+            messageId: r.id,
+            id: r.id,
+            threadId: r.thread_id,
+            userId: r.user_id,
+            user: r.username,
+            text: r.text,
+            ts: r.ts,
+            replyToId: r.reply_to_id || null,
+            replyToUser: r.reply_to_user || "",
+            replyToText: r.reply_to_text || "",
+          }));
           socket.emit("dm history", {
             threadId: tid,
             title: thread.title || "",
@@ -2310,7 +2556,7 @@ function doJoin(room, status) {
     });
   });
 
-  socket.on("dm message", ({ threadId, text }) => {
+  socket.on("dm message", ({ threadId, text, replyToId }) => {
     const tid = Number(threadId);
     const body = String(text || "").trim().slice(0, 800);
     if (!Number.isInteger(tid) || !body) return;
@@ -2319,37 +2565,60 @@ function doJoin(room, status) {
       if (err) return;
       const ts = Date.now();
 
-      db.run(
-        `INSERT INTO dm_messages (thread_id, user_id, username, text, ts) VALUES (?, ?, ?, ?, ?)`,
-        [tid, socket.user.id, socket.user.username, body, ts],
-        function (insertErr) {
-          if (insertErr) return;
-          const payload = {
-            threadId: tid,
-            messageId: this.lastID,
-            userId: socket.user.id,
-            user: socket.user.username,
-            text: body,
-            ts,
-          };
-          io.to(`dm:${tid}`).emit("dm message", payload);
-          if (Array.isArray(thread.participants)) {
-            db.all(
-              `SELECT user_id FROM dm_participants WHERE thread_id = ?`,
-              [tid],
-              (_e2, rows) => {
-                for (const r of rows || []) {
-                  const sid = socketIdByUserId.get(r.user_id);
-                  const s = sid ? io.sockets.sockets.get(sid) : null;
-                  if (s && !s.rooms.has(`dm:${tid}`)) {
-                    s.emit("dm message", payload);
+      const replyId = Number(replyToId);
+      const doInsert = (replyMeta = {}) => {
+        const replyUser = replyMeta.user || null;
+        const replyText = replyMeta.text || null;
+        const replyPk = Number.isInteger(replyMeta.id) ? replyMeta.id : null;
+
+        db.run(
+          `INSERT INTO dm_messages (thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [tid, socket.user.id, socket.user.username, body, ts, replyPk, replyUser, replyText],
+          function (insertErr) {
+            if (insertErr) return;
+            const payload = {
+              threadId: tid,
+              messageId: this.lastID,
+              userId: socket.user.id,
+              user: socket.user.username,
+              text: body,
+              ts,
+              replyToId: replyPk,
+              replyToUser: replyUser || "",
+              replyToText: replyText || "",
+            };
+            io.to(`dm:${tid}`).emit("dm message", payload);
+            if (Array.isArray(thread.participants)) {
+              db.all(
+                `SELECT user_id FROM dm_participants WHERE thread_id = ?`,
+                [tid],
+                (_e2, rows) => {
+                  for (const r of rows || []) {
+                    const sid = socketIdByUserId.get(r.user_id);
+                    const s = sid ? io.sockets.sockets.get(sid) : null;
+                    if (s && !s.rooms.has(`dm:${tid}`)) {
+                      s.emit("dm message", payload);
+                    }
                   }
                 }
-              }
-            );
+              );
+            }
           }
-        }
-      );
+        );
+      };
+
+      if (Number.isInteger(replyId)) {
+        db.get(
+          `SELECT id, username, text FROM dm_messages WHERE id = ? AND thread_id = ?`,
+          [replyId, tid],
+          (_e, row) => {
+            doInsert(row || {});
+          }
+        );
+      } else {
+        doInsert();
+      }
     });
   });
 
@@ -2423,41 +2692,65 @@ function doJoin(room, status) {
               slowmodeTracker.set(key, Date.now());
             }
 
-            db.run(
-              `INSERT INTO messages (room, user_id, username, role, avatar, text, ts, attachment_url, attachment_type, attachment_mime, attachment_size)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-              [
-                room,
-                socket.user.id,
-                socket.user.username,
-                socket.user.role,
-                socket.user.avatar || "",
-                text,
-                Date.now(),
-                attachmentUrl || null,
-                attachmentType || null,
-                attachmentMime || null,
-                attachmentSize || null,
-              ],
-              function () {
-                awardMessageXp(socket.user.id);
-                awardMessageGold(socket.user.id);
-                const msg = {
-                  messageId: this.lastID,
+            const replyId = Number(payload?.replyToId);
+            const insertWithReply = (replyMeta = {}) => {
+              const replyPk = Number.isInteger(replyMeta.id) ? replyMeta.id : null;
+              const replyUser = replyMeta.username || replyMeta.user || null;
+              const replyText = replyMeta.text || null;
+              const tsNow = Date.now();
+
+              db.run(
+                `INSERT INTO messages (room, user_id, username, role, avatar, text, ts, attachment_url, attachment_type, attachment_mime, attachment_size, reply_to_id, reply_to_user, reply_to_text)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                [
                   room,
-                  user: socket.user.username,
-                  role: socket.user.role,
-                  avatar: socket.user.avatar || "",
+                  socket.user.id,
+                  socket.user.username,
+                  socket.user.role,
+                  socket.user.avatar || "",
                   text,
-                  ts: Date.now(),
-                  attachmentUrl: attachmentUrl || "",
-                  attachmentType: attachmentType || "",
-                  attachmentMime: attachmentMime || "",
-                  attachmentSize: attachmentSize || 0,
-                };
-                io.to(room).emit("chat message", msg);
-              }
-            );
+                  tsNow,
+                  attachmentUrl || null,
+                  attachmentType || null,
+                  attachmentMime || null,
+                  attachmentSize || null,
+                  replyPk,
+                  replyUser,
+                  replyText,
+                ],
+                function () {
+                  awardMessageXp(socket.user.id);
+                  awardMessageGold(socket.user.id);
+                  const msg = {
+                    messageId: this.lastID,
+                    room,
+                    user: socket.user.username,
+                    role: socket.user.role,
+                    avatar: socket.user.avatar || "",
+                    text,
+                    ts: tsNow,
+                    attachmentUrl: attachmentUrl || "",
+                    attachmentType: attachmentType || "",
+                    attachmentMime: attachmentMime || "",
+                    attachmentSize: attachmentSize || 0,
+                    replyToId: replyPk,
+                    replyToUser: replyUser || "",
+                    replyToText: replyText || "",
+                  };
+                  io.to(room).emit("chat message", msg);
+                }
+              );
+            };
+
+            if (Number.isInteger(replyId)) {
+              db.get(
+                `SELECT id, username, text FROM messages WHERE id=? AND room=? AND deleted=0`,
+                [replyId, room],
+                (_rErr, row) => insertWithReply(row || {})
+              );
+            } else {
+              insertWithReply();
+            }
           }
         );
       });


### PR DESCRIPTION
## Summary
- add a leaderboards tab covering XP, gold, dice sixes, and profile likes plus a mobile gold pill in the chat header
- enable profile like toggles with backend storage and expose the new stats in profile views and leaderboards
- push realtime progression updates, track dice six counts, and show dice roll indicators with dice-face messaging in the member list

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69511f92adc08333b3be68efd76c00a3)