### PR TITLE
Handle urlencoded auth submissions

### DIFF
--- a/server.js
+++ b/server.js
@@ -368,6 +368,7 @@ function ensureDmSchema(cb) {
 // ---- Security + parsing
 app.disable("x-powered-by");
 app.use(express.json({ limit: "1mb" }));
+app.use(express.urlencoded({ extended: false, limit: "1mb" }));
 
 // IMPORTANT: CSP that blocks inline JS (good), but allows our external /public/app.js & /public/styles.css
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- add URL-encoded body parsing so login and registration work with standard form posts

## Testing
- `npm start` (manual)
- `curl -i -X POST http://localhost:3000/login -d 'username=test&password=password'`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69512d94390c83339e02a95122556744)