### PR TITLE
Add media uploads to DMs

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -76,6 +76,14 @@ const isCoarsePointer = (() => {
   }
 })();
 
+const isMobileScreen = () => {
+  try {
+    return window.matchMedia("(max-width: 980px)")?.matches;
+  } catch {
+    return window.innerWidth <= 980;
+  }
+};
+
 // ---- DOM
 const authWrap = document.getElementById("authWrap");
 const app = document.getElementById("app");
@@ -167,6 +175,7 @@ const dmMetaPeople = document.getElementById("dmMetaPeople");
 const dmMessagesEl = document.getElementById("dmMessages");
 const dmText = document.getElementById("dmText");
 const dmSendBtn = document.getElementById("dmSendBtn");
+const dmUploadBtn = document.getElementById("dmUploadBtn");
 
 dmMessagesEl?.addEventListener("scroll", ()=>{ dmPinned = isNearBottom(dmMessagesEl, 160); });
 const dmUserBtn = document.getElementById("dmUserBtn");
@@ -1637,6 +1646,15 @@ function setDmTab(tab){
   renderDmThreads();
 }
 
+function dmPreviewText(msg){
+  if (!msg) return "";
+  if (msg.text) return msg.text;
+  if (msg.attachmentType === "image") return "[Image]";
+  if (msg.attachmentType === "video") return "[Video]";
+  if (msg.attachmentUrl) return "[Attachment]";
+  return "";
+}
+
 function renderThreadItem(t){
   const div = document.createElement("div");
   div.className = "dmItem" + (t.id === activeDmId ? " active" : "");
@@ -1686,7 +1704,10 @@ function renderDmThreads(){
   dmThreadList.innerHTML = "";
 
   const list = dmThreads.filter((t) => dmTab === "group" ? t.is_group : !t.is_group);
+  const hideEmpty = !list.length && isMobileScreen();
+  dmThreadList.classList.toggle("dmEmptyList", hideEmpty);
   if (!list.length) {
+    if (hideEmpty) return;
     const empty = document.createElement("div");
     empty.className = "dmEmpty";
     empty.textContent = dmTab === "group"
@@ -1838,6 +1859,33 @@ function renderDmMessages(threadId){
       wrap.appendChild(embedWrap);
     }
 
+    if (m.attachmentUrl && m.attachmentType) {
+      const att = document.createElement("div");
+      att.className = "attachment";
+      if (m.attachmentType === "image") {
+        const img = document.createElement("img");
+        img.src = m.attachmentUrl;
+        img.alt = "image";
+        img.addEventListener("click", () => openMediaLightbox(m.attachmentUrl, "image"));
+        att.appendChild(img);
+      } else if (m.attachmentType === "video") {
+        const v = document.createElement("video");
+        v.src = m.attachmentUrl;
+        v.controls = true;
+        v.playsInline = true;
+        v.addEventListener("click", () => openMediaLightbox(m.attachmentUrl, "video"));
+        att.appendChild(v);
+      } else {
+        const a = document.createElement("a");
+        a.href = m.attachmentUrl;
+        a.textContent = "Download file";
+        a.target = "_blank";
+        a.rel = "noreferrer";
+        att.appendChild(a);
+      }
+      wrap.appendChild(att);
+    }
+
     const dmActions = document.createElement("div");
     dmActions.className = "dmActions";
     const replyBtn = document.createElement("button");
@@ -1876,6 +1924,7 @@ function renderDmMessages(threadId){
 }
 
 function setDmMeta(thread){
+  if (dmInfoBtn) dmInfoBtn.style.display = "none";
   if (!thread) {
     dmMetaTitle.textContent = "Pick a thread";
     dmMetaPeople.textContent = "";
@@ -1886,6 +1935,11 @@ function setDmMeta(thread){
   dmMetaPeople.textContent = thread.is_group
     ? `${names.length} member${names.length === 1 ? "" : "s"}`
     : names.join(", ");
+
+  if (dmInfoBtn) {
+    const showInfo = thread.is_group && !isMobileScreen();
+    dmInfoBtn.style.display = showInfo ? "inline-flex" : "none";
+  }
 }
 
 function openDmThread(threadId){
@@ -1944,13 +1998,38 @@ function upsertThreadMeta(tid, updater){
   renderDmThreads();
 }
 
-function sendDmMessage(){
-  if (!activeDmId) return;
-  const txt = dmText.value.trim();
-  if (!txt) return;
-  socket?.emit("dm message", { threadId: activeDmId, text: txt, replyToId: dmReplyTarget?.id || null });
-  dmText.value = "";
-  setDmReplyTarget(null);
+async function sendDmMessage(){
+  if (!socket || !activeDmId) return;
+  const text = dmText.value || "";
+  const file = pendingFile;
+  if (!text.trim() && !file) return;
+
+  try {
+    let attachment = null;
+    if (file) {
+      dmMsg.textContent = `Uploading ${file.name}...`;
+      attachment = await uploadChatFileWithProgress(file);
+      fileInput.value = "";
+      clearUploadPreview();
+      dmMsg.textContent = "";
+    }
+
+    socket.emit("dm message", {
+      threadId: activeDmId,
+      text,
+      replyToId: dmReplyTarget?.id || null,
+      attachmentUrl: attachment?.url || "",
+      attachmentType: attachment?.type || "",
+      attachmentMime: attachment?.mime || "",
+      attachmentSize: attachment?.size || 0,
+    });
+
+    dmText.value = "";
+    setDmReplyTarget(null);
+    dmMsg.textContent = "";
+  } catch (e) {
+    dmMsg.textContent = `Upload failed: ${e.message}`;
+  }
 }
 
 function filteredDmCandidates(term, excludeList){
@@ -2176,6 +2255,7 @@ dmTabs?.addEventListener("click", (e) => {
 dmCreateGroupBtn?.addEventListener("click", () => openDmPicker("create"));
 dmCloseBtn?.addEventListener("click", closeDmPanel);
 dmSendBtn?.addEventListener("click", sendDmMessage);
+dmUploadBtn?.addEventListener("click", () => fileInput?.click());
 dmInfoBtn?.addEventListener("click", () => openDmInfo());
 dmSettingsBtn?.addEventListener("click", (e) => {
   e.stopPropagation();
@@ -3482,8 +3562,9 @@ socket.on("disconnect", (reason) => {
 
   socket.on("dm history", (payload) => {
     const { threadId, messages = [], participants = [], title = "" } = payload || {};
-    const lastText = messages.length
-      ? messages[messages.length - 1].text || ""
+    const lastMessage = messages.length ? messages[messages.length - 1] : null;
+    const lastText = lastMessage
+      ? dmPreviewText(lastMessage)
       : (dmThreads.find((t) => t.id === threadId)?.last_text || "");
 
     const lastTs = messages.length
@@ -3527,7 +3608,7 @@ socket.on("disconnect", (reason) => {
     arr.push(m);
     dmMessages.set(m.threadId, arr);
 
-    upsertThreadMeta(m.threadId, { last_text: m.text || "", last_ts: m.ts });
+    upsertThreadMeta(m.threadId, { last_text: dmPreviewText(m), last_ts: m.ts });
 
     if (!dmThreads.find((t) => t.id === m.threadId)) loadDmThreads();
 

--- a/public/index.html
+++ b/public/index.html
@@ -280,7 +280,7 @@
     <div class="dmHeader">
       <div>
         <div class="title">Direct Messages</div>
-        <div class="small">Start a DM from the members list.</div>
+        <div class="small dmHelperText">Start a DM from the members list.</div>
       </div>
       <button class="iconBtn" id="dmCloseBtn" type="button" title="Close">✕</button>
     </div>
@@ -325,6 +325,7 @@
         </div>
         <div class="dmInput">
           <input id="dmText" placeholder="Message" maxlength="800">
+          <button class="iconBtn" id="dmUploadBtn" type="button" title="Upload">📷</button>
           <button class="btn" id="dmSendBtn" type="button">Send</button>
           <div class="mentionDropdown" id="dmMentionDropdown"></div>
         </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1467,6 +1467,11 @@ body.lockScroll{ overflow:hidden; }
   .mobOnly.goldPill{ display:none; }
   .mobOnly.goldPill.show{ display:flex; }
   .members{ display:none; }
+
+  .dmTabs{ display:none; }
+  .dmHelperText{ display:none; }
+  #dmInfoBtn{ display:none !important; }
+  .dmThreadList.dmEmptyList{ display:none; }
   
   .topbar{ position: sticky; top: 0; z-index: 200; padding:0 10px; gap:8px; }
   .msgs{ padding:10px; gap:8px; }

--- a/server.js
+++ b/server.js
@@ -273,6 +273,10 @@ db.serialize(() => {
     ["reply_to_id", "reply_to_id INTEGER"],
     ["reply_to_user", "reply_to_user TEXT"],
     ["reply_to_text", "reply_to_text TEXT"],
+    ["attachment_url", "attachment_url TEXT"],
+    ["attachment_type", "attachment_type TEXT"],
+    ["attachment_mime", "attachment_mime TEXT"],
+    ["attachment_size", "attachment_size INTEGER"],
   ]);
 
   ensureColumns("dm_threads", [
@@ -329,7 +333,7 @@ function ensureDmSchema(cb) {
       )
     `);
 
-    let pending = 2;
+    let pending = 3;
     let done = false;
     const finish = (err) => {
       if (done) return;
@@ -359,6 +363,20 @@ function ensureDmSchema(cb) {
       [
         ["added_by", "added_by INTEGER"],
         ["joined_at", "joined_at INTEGER NOT NULL DEFAULT 0"],
+      ],
+      finish
+    );
+
+    ensureTableColumns(
+      "dm_messages",
+      [
+        ["reply_to_id", "reply_to_id INTEGER"],
+        ["reply_to_user", "reply_to_user TEXT"],
+        ["reply_to_text", "reply_to_text TEXT"],
+        ["attachment_url", "attachment_url TEXT"],
+        ["attachment_type", "attachment_type TEXT"],
+        ["attachment_mime", "attachment_mime TEXT"],
+        ["attachment_size", "attachment_size INTEGER"],
       ],
       finish
     );
@@ -1955,7 +1973,16 @@ app.get("/dm/threads", requireLogin, (req, res) => {
 
   db.all(
     `SELECT t.id, t.title, t.is_group, t.created_at,
-            (SELECT text FROM dm_messages WHERE thread_id=t.id ORDER BY ts DESC LIMIT 1) AS last_text,
+            (SELECT CASE
+                      WHEN COALESCE(text, '') <> '' THEN text
+                      WHEN attachment_type = 'image' THEN '[Image]'
+                      WHEN attachment_type = 'video' THEN '[Video]'
+                      WHEN attachment_url IS NOT NULL THEN '[Attachment]'
+                      ELSE ''
+                    END
+               FROM dm_messages
+               WHERE thread_id=t.id
+               ORDER BY ts DESC LIMIT 1) AS last_text,
             (SELECT ts FROM dm_messages WHERE thread_id=t.id ORDER BY ts DESC LIMIT 1) AS last_ts
      FROM dm_threads t
      INNER JOIN dm_participants p ON p.thread_id = t.id
@@ -2531,7 +2558,7 @@ function doJoin(room, status) {
       socket.join(`dm:${tid}`);
 
       db.all(
-        `SELECT id, thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text FROM dm_messages WHERE thread_id=? ORDER BY ts DESC LIMIT 50`,
+        `SELECT id, thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text, attachment_url, attachment_type, attachment_mime, attachment_size FROM dm_messages WHERE thread_id=? ORDER BY ts DESC LIMIT 50`,
         [tid],
         (_e, rows) => {
           const msgs = (rows || []).reverse().map((r) => ({
@@ -2545,6 +2572,10 @@ function doJoin(room, status) {
             replyToId: r.reply_to_id || null,
             replyToUser: r.reply_to_user || "",
             replyToText: r.reply_to_text || "",
+            attachmentUrl: r.attachment_url || "",
+            attachmentType: r.attachment_type || "",
+            attachmentMime: r.attachment_mime || "",
+            attachmentSize: r.attachment_size || 0,
           }));
           socket.emit("dm history", {
             threadId: tid,
@@ -2558,25 +2589,42 @@ function doJoin(room, status) {
     });
   });
 
-  socket.on("dm message", ({ threadId, text, replyToId }) => {
-    const tid = Number(threadId);
-    const body = String(text || "").trim().slice(0, 800);
-    if (!Number.isInteger(tid) || !body) return;
+  socket.on("dm message", (payload = {}) => {
+    const tid = Number(payload.threadId);
+    const body = String(payload.text || "").trim().slice(0, 800);
+    const attachmentUrl = String(payload?.attachmentUrl || "").slice(0, 400);
+    const attachmentType = String(payload?.attachmentType || "").slice(0, 20);
+    const attachmentMime = String(payload?.attachmentMime || "").slice(0, 60);
+    const attachmentSize = Number(payload?.attachmentSize || 0) || 0;
+    if (!Number.isInteger(tid) || (!body && !attachmentUrl)) return;
 
     loadThreadForUser(tid, socket.user.id, (err, thread) => {
       if (err) return;
       const ts = Date.now();
 
-      const replyId = Number(replyToId);
+      const replyId = Number(payload.replyToId);
       const doInsert = (replyMeta = {}) => {
         const replyUser = replyMeta.user || null;
         const replyText = replyMeta.text || null;
         const replyPk = Number.isInteger(replyMeta.id) ? replyMeta.id : null;
 
         db.run(
-          `INSERT INTO dm_messages (thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-          [tid, socket.user.id, socket.user.username, body, ts, replyPk, replyUser, replyText],
+          `INSERT INTO dm_messages (thread_id, user_id, username, text, ts, reply_to_id, reply_to_user, reply_to_text, attachment_url, attachment_type, attachment_mime, attachment_size)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            tid,
+            socket.user.id,
+            socket.user.username,
+            body,
+            ts,
+            replyPk,
+            replyUser,
+            replyText,
+            attachmentUrl || null,
+            attachmentType || null,
+            attachmentMime || null,
+            attachmentSize || null,
+          ],
           function (insertErr) {
             if (insertErr) return;
             const payload = {
@@ -2589,6 +2637,10 @@ function doJoin(room, status) {
               replyToId: replyPk,
               replyToUser: replyUser || "",
               replyToText: replyText || "",
+              attachmentUrl: attachmentUrl || "",
+              attachmentType: attachmentType || "",
+              attachmentMime: attachmentMime || "",
+              attachmentSize: attachmentSize || 0,
             };
             io.to(`dm:${tid}`).emit("dm message", payload);
             if (Array.isArray(thread.participants)) {


### PR DESCRIPTION
## Summary
- add DM composer upload control and attachment-aware messaging
- store and deliver DM attachments with preview placeholders in thread lists and message rendering
- extend DM message history and schema to carry attachment metadata

## Testing
- npm test
- timeout 5 npm start

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951b3b70e4c8333bbca3f04559b1977)