### PR TITLE
Improve mobile DM picker layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -172,15 +172,19 @@ const dmThreadList = document.getElementById("dmThreadList");
 const dmMsg = document.getElementById("dmMsg");
 const dmMetaTitle = document.getElementById("dmMetaTitle");
 const dmMetaPeople = document.getElementById("dmMetaPeople");
+const dmMobileMetaTitle = document.getElementById("dmMobileMetaTitle");
+const dmMobileMetaPeople = document.getElementById("dmMobileMetaPeople");
 const dmMessagesEl = document.getElementById("dmMessages");
 const dmText = document.getElementById("dmText");
 const dmSendBtn = document.getElementById("dmSendBtn");
 const dmUploadBtn = document.getElementById("dmUploadBtn");
+const dmOpenStrip = document.getElementById("dmOpenStrip");
 
 dmMessagesEl?.addEventListener("scroll", ()=>{ dmPinned = isNearBottom(dmMessagesEl, 160); });
 const dmUserBtn = document.getElementById("dmUserBtn");
 const dmInfoBtn = document.getElementById("dmInfoBtn");
 const dmSettingsBtn = document.getElementById("dmSettingsBtn");
+const dmSettingsBtnMobile = document.getElementById("dmSettingsBtnMobile");
 const goldPill = document.getElementById("goldPill");
 const likeProfileBtn = document.getElementById("likeProfileBtn");
 const likeCount = document.getElementById("likeCount");
@@ -997,6 +1001,7 @@ function markDmNotification(threadId, isGroupHint){
   if(dmPanel?.classList.contains("open") && activeDmId === threadId) return;
   dmUnreadThreads.add(threadId);
   setBadgeVisibility(isGroup ? "group" : "direct", true);
+  renderDmThreads();
 }
 badgePrefs = loadBadgePrefsFromStorage();
 applyBadgePrefs();
@@ -1699,11 +1704,46 @@ function renderThreadItem(t){
   return div;
 }
 
+function renderDmOpenStrip(list){
+  if (!dmOpenStrip) return;
+  const threads = list || dmThreads.filter((t) => dmTab === "group" ? t.is_group : !t.is_group);
+  dmOpenStrip.innerHTML = "";
+
+  if (!threads.length) {
+    const empty = document.createElement("div");
+    empty.className = "dmEmpty dmOpenEmpty";
+    empty.textContent = "No DMs yet.";
+    dmOpenStrip.appendChild(empty);
+    return;
+  }
+
+  for (const t of threads) {
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "dmOpenAvatar" + (t.id === activeDmId ? " active" : "");
+    btn.title = threadLabel(t);
+    btn.setAttribute("aria-label", threadLabel(t));
+
+    const avatar = threadAvatarNode(t);
+    btn.appendChild(avatar);
+
+    if (dmUnreadThreads.has(t.id)) {
+      const badge = document.createElement("div");
+      badge.className = "dmAvatarBadge";
+      btn.appendChild(badge);
+    }
+
+    btn.onclick = () => openDmThread(t.id);
+    dmOpenStrip.appendChild(btn);
+  }
+}
+
 function renderDmThreads(){
   if (!dmThreadList) return;
   dmThreadList.innerHTML = "";
 
   const list = dmThreads.filter((t) => dmTab === "group" ? t.is_group : !t.is_group);
+  renderDmOpenStrip(list);
   const hideEmpty = !list.length && isMobileScreen();
   dmThreadList.classList.toggle("dmEmptyList", hideEmpty);
   if (!list.length) {
@@ -1928,13 +1968,17 @@ function setDmMeta(thread){
   if (!thread) {
     dmMetaTitle.textContent = "Pick a thread";
     dmMetaPeople.textContent = "";
+    if (dmMobileMetaTitle) dmMobileMetaTitle.textContent = "Pick a thread";
+    if (dmMobileMetaPeople) dmMobileMetaPeople.textContent = "";
     return;
   }
   dmMetaTitle.textContent = threadLabel(thread);
+  if (dmMobileMetaTitle) dmMobileMetaTitle.textContent = threadLabel(thread);
   const names = thread.participants || [];
   dmMetaPeople.textContent = thread.is_group
     ? `${names.length} member${names.length === 1 ? "" : "s"}`
     : names.join(", ");
+  if (dmMobileMetaPeople) dmMobileMetaPeople.textContent = dmMetaPeople.textContent;
 
   if (dmInfoBtn) {
     const showInfo = thread.is_group && !isMobileScreen();
@@ -2237,8 +2281,7 @@ async function leaveGroup(threadId){
     activeDmId = null;
     closeDmInfo();
     renderDmThreads();
-    dmMetaTitle.textContent = "Pick a thread";
-    dmMetaPeople.textContent = "";
+    setDmMeta(null);
     dmMessagesEl.innerHTML = "";
   } catch {
     dmMsg.textContent = "Could not leave group.";
@@ -2258,6 +2301,10 @@ dmSendBtn?.addEventListener("click", sendDmMessage);
 dmUploadBtn?.addEventListener("click", () => fileInput?.click());
 dmInfoBtn?.addEventListener("click", () => openDmInfo());
 dmSettingsBtn?.addEventListener("click", (e) => {
+  e.stopPropagation();
+  toggleDmSettingsMenu();
+});
+dmSettingsBtnMobile?.addEventListener("click", (e) => {
   e.stopPropagation();
   toggleDmSettingsMenu();
 });

--- a/public/index.html
+++ b/public/index.html
@@ -285,6 +285,16 @@
       <button class="iconBtn" id="dmCloseBtn" type="button" title="Close">✕</button>
     </div>
 
+    <div class="dmMobileTopRow mobOnly" id="dmMobileTopRow">
+      <div class="dmMetaText">
+        <div class="title" id="dmMobileMetaTitle">Pick a thread</div>
+        <div class="small" id="dmMobileMetaPeople"></div>
+      </div>
+      <div class="dmMetaActions">
+        <button class="iconBtn secondary" id="dmSettingsBtnMobile" type="button" title="DM settings">⚙️</button>
+      </div>
+    </div>
+
     <div class="dmNotice" id="dmMsg"></div>
 
     <div class="dmContent">
@@ -296,6 +306,7 @@
         <div class="dmThreadActions" id="dmThreadActions">
           <button class="btn full" id="dmCreateGroupBtn" type="button">➕ Create Group</button>
         </div>
+        <div class="dmOpenStrip mobOnly" id="dmOpenStrip"></div>
         <div class="dmThreadList" id="dmThreadList"></div>
       </div>
       <div class="dmConversation">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1363,6 +1363,7 @@ body.lockScroll{ overflow:hidden; }
   border-bottom:1px solid var(--line);
 }
 .dmHeader .title{ font-weight:900; letter-spacing:.01em; }
+.dmMobileTopRow{ display:none; padding:10px 14px; align-items:center; justify-content:space-between; gap:10px; border-bottom:1px solid var(--line); background:var(--panel2); }
 .dmNotice{
   padding:10px 14px;
   border-bottom:1px solid var(--line);
@@ -1374,6 +1375,7 @@ body.lockScroll{ overflow:hidden; }
 .dmContent{ flex:1; display:grid; grid-template-columns: 220px 1fr; min-height:0; backdrop-filter: blur(4px); background:var(--dm-bg); }
 .dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; gap:6px; padding:10px 10px 12px; }
 .dmThreadList{ border:1px solid var(--line); border-radius:14px; overflow:auto; background:var(--panel); flex:1; min-height:0; }
+.dmOpenStrip{ display:none; border:1px solid var(--line); border-radius:12px; background:var(--panel); padding:8px 10px; gap:10px; align-items:center; min-height:62px; }
 .dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; gap:10px; align-items:center; transition: background .12s ease, border-color .12s ease; }
 .dmItem:hover{ background:var(--panel); }
 .dmItem.active{ background:var(--bubble); }
@@ -1387,6 +1389,11 @@ body.lockScroll{ overflow:hidden; }
 .dmItemTime{ font-size:11px; color:var(--muted); white-space:nowrap; }
 .dmUnread{ min-width:22px; height:22px; padding:0 8px; border-radius:999px; background:var(--accent); color:white; font-size:11px; display:flex; align-items:center; justify-content:center; }
 .dmAvatar{ width:42px; height:42px; border-radius:12px; overflow:hidden; background:var(--avatar-bg); flex-shrink:0; display:flex; align-items:center; justify-content:center; }
+.dmOpenAvatar{ border:1px solid var(--line); background:var(--panel2); border-radius:50%; padding:3px; width:52px; height:52px; display:flex; align-items:center; justify-content:center; flex-shrink:0; position:relative; transition:border-color .12s ease, box-shadow .12s ease; }
+.dmOpenAvatar.active{ border-color: var(--accent); box-shadow: 0 0 0 2px rgba(0,0,0,.25); }
+.dmOpenAvatar .dmAvatar{ width:44px; height:44px; border-radius:50%; }
+.dmAvatarBadge{ position:absolute; right:6px; bottom:6px; width:12px; height:12px; border-radius:50%; background:var(--accent); border:2px solid var(--panel2); }
+.dmOpenStrip::-webkit-scrollbar{ height:6px; }
 .dmConversation{ display:flex; flex-direction:column; min-width:0; min-height:0; }
 .dmMeta{ padding:10px 12px; border-bottom:1px solid var(--line); display:flex; align-items:center; justify-content:space-between; gap:10px; }
 .dmMeta .title{ font-weight:900; }
@@ -1468,11 +1475,15 @@ body.lockScroll{ overflow:hidden; }
   .mobOnly.goldPill.show{ display:flex; }
   .members{ display:none; }
 
+  .dmMobileTopRow{ display:flex; }
+  .dmOpenStrip{ display:flex; overflow-x:auto; overflow-y:hidden; overscroll-behavior-x: contain; }
+  .dmOpenStrip .dmEmpty{ width:100%; text-align:center; }
   .dmTabs{ display:none; }
   .dmHelperText{ display:none; }
   #dmInfoBtn{ display:none !important; }
+  #dmSettingsBtn{ display:none !important; }
   .dmThreadList.dmEmptyList{ display:none; }
-  
+
   .topbar{ position: sticky; top: 0; z-index: 200; padding:0 10px; gap:8px; }
   .msgs{ padding:10px; gap:8px; }
   .msg{ gap:8px; }
@@ -1494,12 +1505,14 @@ body.lockScroll{ overflow:hidden; }
 }
   }
   .dmHeader{ position:sticky; top:0; background:var(--panel2); z-index:2; }
+  .dmMeta{ padding:4px 12px; border-bottom:0; }
+  .dmMetaText{ display:none; }
   .dmInput{
   position: sticky;
   bottom: 0;
   padding-bottom: calc(10px + env(safe-area-inset-bottom) + 16px);
 }
-  .dmContent{ grid-template-columns: 1fr; grid-template-rows: minmax(180px, 32vh) 1fr; }
+  .dmContent{ grid-template-columns: 1fr; grid-template-rows: minmax(150px, 28vh) 1fr; }
   .dmThreads{ border-right:0; border-bottom:1px solid var(--line); }
   .dmMessages{ padding-bottom:14px; }
 


### PR DESCRIPTION
## Summary
- Move the mobile DM picker prompt beneath the header and add a horizontally scrolling avatar strip for open conversations with unread badges.
- Reduce the vertical footprint of the mobile thread list while keeping desktop unchanged.
- Synchronize mobile metadata and unread indicators when switching or receiving DM threads.

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bba69f9c8333a5ce83501cf3eb21)