### PR TITLE
Add DM media thumbnails and viewer support

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1793,6 +1793,62 @@ function closeDmPanel(){
   closeDmSettingsMenu();
 }
 
+function createDmAttachmentElement(m){
+  const att = document.createElement("div");
+  const isMediaThumb = m.attachmentType === "image" || m.attachmentType === "video";
+  att.className = isMediaThumb ? "attachment dmAttachment" : "attachment";
+
+  if (!isMediaThumb) {
+    const a = document.createElement("a");
+    a.href = m.attachmentUrl;
+    a.textContent = "Download file";
+    a.target = "_blank";
+    a.rel = "noreferrer";
+    att.appendChild(a);
+    return att;
+  }
+
+  if (m.attachmentType === "image") {
+    const img = document.createElement("img");
+    img.src = m.attachmentUrl;
+    img.alt = "Image attachment";
+    img.loading = "lazy";
+    img.className = "dmMediaThumb";
+    att.appendChild(img);
+  } else if (m.attachmentType === "video") {
+    const thumb = document.createElement("div");
+    thumb.className = "dmVideoThumb";
+
+    const v = document.createElement("video");
+    v.src = m.attachmentUrl;
+    v.playsInline = true;
+    v.muted = true;
+    v.preload = "metadata";
+    v.className = "dmMediaThumb";
+    thumb.appendChild(v);
+
+    const play = document.createElement("div");
+    play.className = "dmPlayOverlay";
+    play.textContent = "▶";
+    thumb.appendChild(play);
+    att.appendChild(thumb);
+  }
+
+  const open = () => openMediaLightbox(m.attachmentUrl, m.attachmentType === "video" ? "video" : "image");
+  att.addEventListener("click", open);
+  att.tabIndex = 0;
+  att.setAttribute("role", "button");
+  att.setAttribute("aria-label", m.attachmentType === "video" ? "Open video attachment" : "Open image attachment");
+  att.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      open();
+    }
+  });
+
+  return att;
+}
+
 function renderDmMessages(threadId){
   if (!dmMessagesEl) return;
   const keepOffset = dmMessagesEl.scrollHeight - dmMessagesEl.scrollTop;
@@ -1844,6 +1900,10 @@ function renderDmMessages(threadId){
       displayText = `${rawText.slice(0, start)}${rawText.slice(end)}`.replace(/\s{2,}/g, " ").trim();
     }
 
+    if (m.attachmentUrl && displayText.trim() === m.attachmentUrl) {
+      displayText = "";
+    }
+
     if (displayText) {
       const text = document.createElement("div");
       if (youtubeInfo) {
@@ -1860,30 +1920,8 @@ function renderDmMessages(threadId){
     }
 
     if (m.attachmentUrl && m.attachmentType) {
-      const att = document.createElement("div");
-      att.className = "attachment";
-      if (m.attachmentType === "image") {
-        const img = document.createElement("img");
-        img.src = m.attachmentUrl;
-        img.alt = "image";
-        img.addEventListener("click", () => openMediaLightbox(m.attachmentUrl, "image"));
-        att.appendChild(img);
-      } else if (m.attachmentType === "video") {
-        const v = document.createElement("video");
-        v.src = m.attachmentUrl;
-        v.controls = true;
-        v.playsInline = true;
-        v.addEventListener("click", () => openMediaLightbox(m.attachmentUrl, "video"));
-        att.appendChild(v);
-      } else {
-        const a = document.createElement("a");
-        a.href = m.attachmentUrl;
-        a.textContent = "Download file";
-        a.target = "_blank";
-        a.rel = "noreferrer";
-        att.appendChild(a);
-      }
-      wrap.appendChild(att);
+      const att = createDmAttachmentElement(m);
+      if (att) wrap.appendChild(att);
     }
 
     const dmActions = document.createElement("div");

--- a/public/styles.css
+++ b/public/styles.css
@@ -954,7 +954,7 @@ textarea{ min-height:90px; resize:vertical; }
   padding-top:2px;
 }
 
-.attachment{
+.attachment{ 
   margin-top:6px; border-radius:var(--radiusLg); overflow:hidden;
   border:1px solid var(--border);
   max-width: min(520px, 80vw);
@@ -963,6 +963,31 @@ textarea{ min-height:90px; resize:vertical; }
 .attachment img, .attachment video{ display:block; width:100%; height:auto; }
 .attachment img, .attachment video{ user-select:none; }
 .attachment video{ background:var(--bg); }
+.dmAttachment{
+  cursor:pointer;
+  padding:0;
+  width:100%;
+  max-width:min(240px, 70vw);
+  max-height:180px;
+  background:color-mix(in srgb, var(--panel2) 85%, transparent);
+  border-color:var(--line);
+}
+.dmAttachment:focus-visible{ outline:2px solid var(--accent); outline-offset:2px; }
+.dmAttachment .dmMediaThumb{ width:100%; height:auto; max-height:180px; object-fit:cover; }
+.dmAttachment .dmVideoThumb{ position:relative; width:100%; background:color-mix(in srgb, var(--panel) 80%, transparent); }
+.dmAttachment .dmVideoThumb video{ width:100%; height:auto; max-height:180px; object-fit:cover; display:block; }
+.dmPlayOverlay{
+  position:absolute;
+  inset:0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:linear-gradient(180deg, color-mix(in srgb, #000 20%, transparent), color-mix(in srgb, #000 55%, transparent));
+  color:white;
+  font-size:28px;
+  text-shadow:0 2px 6px rgba(0,0,0,.35);
+  pointer-events:none;
+}
 
 .actions{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:2px; }
 .reactBtn{
@@ -1323,7 +1348,7 @@ textarea{ min-height:90px; resize:vertical; }
 .overlay.show{ display:block; }
 .mediaLightbox{ position:fixed; inset:0; background:rgba(0,0,0,.75); display:none; align-items:center; justify-content:center; z-index:500; padding:20px; }
 .mediaLightbox.show{ display:flex; }
-.mediaLightbox img, .mediaLightbox video{ max-width:90vw; max-height:80vh; border-radius:16px; box-shadow:var(--shadowLg); background:#000; }
+.mediaLightbox img, .mediaLightbox video{ max-width:90vw; max-height:80vh; border-radius:16px; box-shadow:var(--shadowLg); background:#000; object-fit:contain; }
 .mediaLightbox .largeClose{ position:absolute; top:16px; right:16px; }
 body.lockScroll{ overflow:hidden; }
 .drawerHeader{


### PR DESCRIPTION
## Summary
- render DM image/video attachments as compact thumbnails with tap-to-open lightbox support
- add play overlay thumbnails for videos and hide bare attachment URLs inside DM bubbles
- adjust media lightbox scaling for contained fullscreen viewing

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951bc0abe708333be47e2b45c6ba412)