### PR TITLE
Fix DM bubble alignment and composer visibility

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2894,12 +2894,6 @@ function renderDmMessages(threadId){
     text.innerHTML = applyMentions(m.text || "");
     bubble.appendChild(text);
 
-    const reacts = document.createElement("div");
-    reacts.className = "reacts";
-    reacts.id = "dm-reacts-" + (m.messageId || m.id);
-    reacts.dataset.threadId = String(threadId);
-    bubble.appendChild(reacts);
-
     const meta = document.createElement("div");
     meta.className = "dmMetaRow";
     const u = document.createElement("span");
@@ -2915,6 +2909,12 @@ function renderDmMessages(threadId){
     t.textContent = m.ts ? new Date(m.ts).toLocaleTimeString([], {hour:"2-digit", minute:"2-digit"}) : "";
     meta.appendChild(u);
     meta.appendChild(t);
+
+    const reacts = document.createElement("div");
+    reacts.className = "reacts";
+    reacts.id = "dm-reacts-" + (m.messageId || m.id);
+    reacts.dataset.threadId = String(threadId);
+    meta.appendChild(reacts);
 
     // Read receipt: show "Seen" only on your latest message, when the other user has marked it read.
     const midForSeen = (m.messageId || m.id);

--- a/public/styles.css
+++ b/public/styles.css
@@ -2767,9 +2767,9 @@ body.lockScroll{ overflow:hidden; }
 .dmBubbleWrap{
   display:flex;
   flex-direction:column;
-  flex: 1 1 auto;
+  flex: 0 1 auto;
   min-width:0;
-  max-width: min(calc(100% - var(--dmActionsW)), 78%, 560px);
+  max-width:66%;
 }
 .dmBubble{
   display:inline-block;
@@ -2791,6 +2791,7 @@ body.lockScroll{ overflow:hidden; }
   justify-content:flex-start;
   align-items:baseline;
   gap:6px;
+  flex-wrap:wrap;
   margin-top:4px;
   font-size:12px;
   color: var(--muted);
@@ -2921,13 +2922,12 @@ body.lockScroll{ overflow:hidden; }
   box-sizing:border-box;
 }
 .dmBubbleWrap{
-  flex:1 1 auto;
+  flex:0 1 auto;
   min-width:0;
-  max-width: min(calc(100% - var(--dmActionsW)), 78%, 560px);
+  max-width:66%;
 }
 .dmMetaRow{
   max-width:100%;
-  overflow:hidden;
 }
 .dmMetaUser, .dmMetaTime{
   max-width:100%;
@@ -4506,6 +4506,8 @@ body.kb-open #typing{ display:none !important; }
   justify-content:flex-start;
 }
 .dmBubbleWrap{
+  flex:0 1 auto;
+  min-width:0;
   max-width:66%;
 }
 .dmBubble{
@@ -4530,6 +4532,23 @@ body.kb-open #typing{ display:none !important; }
     bottom:0;
     z-index:5;
   }
+
+  /* Keep the main room composer pinned on desktop layouts */
+  .chat{
+    display:flex;
+    flex-direction:column;
+    min-height:0;
+  }
+  .msgs{
+    flex:1 1 auto;
+    min-height:0;
+    overflow:auto;
+  }
+  .inputBar{
+    position: sticky;
+    bottom: 0;
+    z-index: 10;
+  }
 }
 
 
@@ -4549,6 +4568,13 @@ body.kb-open #typing{ display:none !important; }
 .dmMetaRow{
   display:flex;
   gap:8px;
+  align-items:baseline;
+  flex-wrap:wrap;
+}
+.dmMetaRow .reacts{
+  display:inline-flex;
+  gap:6px;
+  margin-left:8px;
   align-items:center;
   flex-wrap:wrap;
 }


### PR DESCRIPTION
## Summary
- adjust DM bubble wrapping and alignment to cap outgoing width and prevent overflow
- reposition DM reactions and seen indicators into the meta row with appropriate styling
- keep the main desktop chat composer pinned and visible at the bottom of the layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957b5d808748333b0b419699aa6634d)