### PR TITLE
Fix YouTube embeds and mobile layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -22,35 +22,49 @@ const THEMES = [
 /* ---- Mobile viewport height fix (prevents input bars being hidden by browser UI) */
 (function initViewportHeightVar(){
   let raf = 0;
+  let lastComposerH = 0;
+
+  function measureComposer(){
+    const root = document.documentElement;
+    const composer = document.querySelector(".inputBar");
+    let h = 0;
+
+    if(composer){
+      const rect = composer.getBoundingClientRect?.();
+      h = Math.round(rect?.height || composer.offsetHeight || 0);
+    }
+
+    if(!Number.isFinite(h) || h <= 0) h = 72;
+
+    if(h !== lastComposerH){
+      lastComposerH = h;
+      root.style.setProperty("--composerH", `${h}px`);
+    }
+  }
 
   function setVhNow(){
+    const root = document.documentElement;
     const vv = window.visualViewport;
     // visualViewport.height is the most accurate on iOS when the keyboard opens,
     // but it can briefly report 0 during transitions. Guard + fallback.
     let h = (vv && typeof vv.height === "number" && vv.height > 100) ? vv.height : window.innerHeight;
     // Clamp to avoid negative/near-zero layouts during keyboard transitions.
     h = Math.max(200, Math.min(h, window.screen?.height ? window.screen.height : h));
-    document.documentElement.style.setProperty("--vh", (h * 0.01) + "px");
+    root.style.setProperty("--vh", (h * 0.01) + "px");
 
-    // Helpful extra vars for iOS keyboard-safe layouts (optional use in CSS)
+    let kbOffset = 0;
     if(vv){
       const offsetTop = Number(vv.offsetTop || 0);
-      const inset = Math.max(0, (window.innerHeight - vv.height - offsetTop));
-      document.documentElement.style.setProperty("--vv-offset-top", offsetTop + "px");
-      document.documentElement.style.setProperty("--kb-inset", inset + "px");
+      kbOffset = Math.max(0, Math.round(window.innerHeight - vv.height - offsetTop));
+      root.style.setProperty("--vv-offset-top", offsetTop + "px");
     }else{
-      document.documentElement.style.setProperty("--vv-offset-top", "0px");
-      document.documentElement.style.setProperty("--kb-inset", "0px");
+      root.style.setProperty("--vv-offset-top", "0px");
     }
-  }
 
-    // Toggle keyboard-open state for iOS Safari layouts (used by CSS to hide typing overlay)
-    try {
-      const kbInsetStr = getComputedStyle(document.documentElement).getPropertyValue("--kb-inset") || "0px";
-      const kbInset = Math.max(0, Math.round(parseFloat(kbInsetStr) || 0));
-      document.documentElement.style.setProperty("--kbOffset", kbInset + "px");
-      if (document.body) document.body.classList.toggle("kb-open", kbInset > 80);
-    } catch (e) { /* no-op */ }
+    root.style.setProperty("--kbOffset", kbOffset + "px");
+    if (document.body) document.body.classList.toggle("kb-open", kbOffset > 80);
+    measureComposer();
+  }
 
   function scheduleSetVh(){
     if(raf) cancelAnimationFrame(raf);
@@ -63,6 +77,8 @@ const THEMES = [
     window.visualViewport.addEventListener("resize", scheduleSetVh, { passive:true });
     window.visualViewport.addEventListener("scroll", scheduleSetVh, { passive:true });
   }
+
+  window.addEventListener("load", scheduleSetVh, { passive:true, once:true });
 
   // When the page becomes visible again (Safari sometimes restores wrong values)
   document.addEventListener("visibilitychange", ()=>{ if(!document.hidden) scheduleSetVh(); });
@@ -212,7 +228,8 @@ const Sound = (() => {
     const el = document.getElementById("ytSticky");
     if(!el) return;
     el.classList.add("is-hidden");
-    el.classList.remove("is-minimized");
+    el.classList.remove("yt-compact", "yt-collapsed");
+    el.classList.add("yt-expanded");
   }
   if(document.readyState === "loading"){
     document.addEventListener("DOMContentLoaded", hide, { once:true });
@@ -801,6 +818,7 @@ const StickyYouTubePlayer = (()=>{
   let progressTimer = null;
   let currentVideoId = null;
   let pendingAutoplay = false;
+  let state = "expanded";
 
   function loadApi(){
     if(window.YT?.Player) return Promise.resolve(window.YT);
@@ -838,8 +856,16 @@ const StickyYouTubePlayer = (()=>{
     volumeSlider?.addEventListener("input", handleVolumeChange, { passive:true });
     seekSlider?.addEventListener("input", handleSeek, { passive:true });
     qualitySelect?.addEventListener("change", applyQuality);
-    minimizeBtn?.addEventListener("click", toggleMinimize);
+    minimizeBtn?.addEventListener("click", cycleState);
     closeBtn?.addEventListener("click", close);
+    applyState("expanded");
+  }
+
+  function applyState(next){
+    state = next || "expanded";
+    if(!container) return;
+    container.classList.remove("yt-expanded", "yt-compact", "yt-collapsed");
+    container.classList.add(`yt-${state}`);
   }
 
   function ensurePlayer(){
@@ -962,12 +988,14 @@ const StickyYouTubePlayer = (()=>{
   function reveal(expanded=true){
     if(!container) return;
     container.classList.remove("is-hidden");
-    container.classList.toggle("is-minimized", !expanded);
+    applyState(expanded ? "expanded" : state);
   }
-  function toggleMinimize(){
+  function cycleState(){
     if(!container) return;
-    const willMinimize = !container.classList.contains("is-minimized");
-    container.classList.toggle("is-minimized", willMinimize);
+    const order = ["expanded", "compact", "collapsed"];
+    const idx = Math.max(0, order.indexOf(state));
+    const next = order[(idx + 1) % order.length];
+    applyState(next);
   }
   function close(){
     stopProgress();
@@ -979,7 +1007,7 @@ const StickyYouTubePlayer = (()=>{
     currentVideoId = null;
     if(container){
       container.classList.add("is-hidden");
-      container.classList.remove("is-minimized");
+      applyState("expanded");
     }
     if(titleEl) titleEl.textContent = "YouTube player";
     if(channelEl) channelEl.textContent = "";
@@ -1016,7 +1044,7 @@ const StickyYouTubePlayer = (()=>{
 
   initDom();
 
-  return { loadVideo, close, minimize: toggleMinimize };
+  return { loadVideo, close, minimize: cycleState };
 })();
 
 function buildYouTubePreview(videoId){

--- a/public/styles.css
+++ b/public/styles.css
@@ -1508,6 +1508,9 @@ body[data-theme="420 Friendly (Light)"]{
 
   /* Desktop DM dock offset (prevents the DM composer falling off-screen on shorter viewports) */
   --dmDockBottom: 72px;
+
+  /* Dynamic: set by JS for the composer + keyboard safe padding */
+  --composerH: 72px;
 }
 @media (max-width: 360px){
   :root{ --uiScaleAuto: 0.92; }
@@ -1942,11 +1945,27 @@ textarea{ min-height:90px; resize:vertical; }
 }
 .goldPill.show{ display:inline-flex; }
 
-.msgs{ flex:1; overflow:auto; padding:14px; display:flex; flex-direction:column; gap:10px; min-height:0; }
+.msgs{
+  flex:1;
+  overflow:auto;
+  padding:14px;
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom));
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  min-height:0;
+  justify-content:flex-start;
+}
 .sys{
   align-self:center; color:var(--messageSystemText); font-size:12px;
   padding:6px 10px; border-radius:999px;
   background:var(--messageSystemBg); border:1px solid var(--border);
+}
+
+.dmMessages,
+.dmMsgs,
+.messages{
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom));
 }
 
 /* Dice Room: scale system messages + dice faces ONLY in that room */
@@ -2041,6 +2060,10 @@ body.dice-room .sys .diceFace{
   display:flex;
   align-items:center;
   flex:0 0 auto;
+}
+.typing:empty{
+  height:0;
+  padding:0;
 }
 
 .inputBar{
@@ -2882,7 +2905,7 @@ body.lockScroll{ overflow:hidden; }
   .members{ display:none; }
   
   .topbar{ position: sticky; top: 0; z-index: 200; padding:0 10px; gap:8px; }
-  .msgs{ padding:10px; gap:8px; }
+  .msgs{ padding:10px; gap:8px; padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom)); }
   .msg{ gap:8px; }
   .msgAvatar{ width:34px; height:34px; }
   .bubble{
@@ -2911,7 +2934,7 @@ body.lockScroll{ overflow:hidden; }
   /* DM is single-pane on mobile as well; keep full-height conversation */
   .dmContent{ display:flex; flex-direction:column; }
   .dmThreads{ display:none; }
-  .dmMessages{ padding-bottom:14px; }
+  .dmMessages{ padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom)); }
 
  .channels{
   position:fixed; top: var(--topbarH); left:0; height: calc((var(--vh, 1vh) * 100) - var(--topbarH));
@@ -2978,7 +3001,7 @@ body.lockScroll{ overflow:hidden; }
     position:fixed;
     left:0;
     right:0;
-    bottom: calc(62px + env(safe-area-inset-bottom));
+    bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom));
     height:auto;
     padding:6px 12px;
     display:none;
@@ -3254,7 +3277,8 @@ main.chat{ position: relative; }
 .ytStickyChannel{ color:var(--muted, #9aa3b1); font-size:12px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ytStickyHeaderActions{ display:flex; align-items:center; gap:6px; }
 .ytStickyBody{ padding:0 12px 12px; display:flex; flex-direction:column; gap:10px; }
-.ytSticky.is-minimized .ytStickyBody{ display:none; }
+.ytSticky.yt-collapsed .ytStickyBody{ display:none; }
+.ytSticky.yt-compact .ytStickyControls{ display:none; }
 .ytStickyControls{ display:flex; flex-direction:column; gap:10px; }
 .ytSeekRow{ display:grid; grid-template-columns:auto 1fr auto; align-items:center; gap:8px; }
 .ytControlRow{ display:flex; align-items:center; gap:12px; flex-wrap:wrap; justify-content:space-between; }
@@ -3271,11 +3295,15 @@ main.chat{ position: relative; }
 .ytMiniTitle{ font-weight:700; font-size:15px; color:var(--text, #fff); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ytMiniChannel{ font-size:12px; color:var(--muted, #9aa3b1); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .ytMiniAction{ font-weight:700; color:var(--accent, #ff4f6d); }
-.ytSticky.is-minimized .ytStickyInner{ border-radius:12px; }
-.ytSticky.is-minimized .ytStickyHeader{ padding-bottom:10px; }
-.ytSticky.is-minimized .ytStickyThumb{ width:52px; height:40px; }
-.ytSticky.is-minimized .ytStickyTitle{ font-size:14px; }
-.ytSticky.is-minimized .ytStickyChannel{ display:none; }
+.ytSticky.yt-compact .ytStickyInner,
+.ytSticky.yt-collapsed .ytStickyInner{ border-radius:12px; }
+.ytSticky.yt-compact .ytStickyHeader,
+.ytSticky.yt-collapsed .ytStickyHeader{ padding-bottom:10px; }
+.ytSticky.yt-compact .ytStickyThumb,
+.ytSticky.yt-collapsed .ytStickyThumb{ width:52px; height:40px; }
+.ytSticky.yt-compact .ytStickyTitle,
+.ytSticky.yt-collapsed .ytStickyTitle{ font-size:14px; }
+.ytSticky.yt-compact .ytStickyChannel{ display:none; }
 
 .ytSticky .iconBtn{ min-width:34px; height:34px; }
 
@@ -3342,11 +3370,6 @@ main.chat{ position: relative; }
     padding-bottom: calc(12px + env(safe-area-inset-bottom));
   }
 
-  /* Give the scroll areas room so the fixed composer doesn't cover the last message */
-  .msgs{
-    padding-bottom: calc(72px + env(safe-area-inset-bottom));
-  }
-
   /* DM composer pinned to bottom on mobile */
   #dmModal .dmInputRow,
   #dmModal .dmComposer,
@@ -3367,7 +3390,7 @@ main.chat{ position: relative; }
   #dmModal .dmMsgs,
   .dmPanel .dmMessages,
   .dmPanel .dmMsgs{
-    padding-bottom: calc(72px + env(safe-area-inset-bottom));
+    padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom));
   }
 
   /* Ensure DM content uses the full black area and can scroll correctly */
@@ -3411,8 +3434,6 @@ body.drawer-right-open { --rightDrawerW: min(86vw, 340px); }
     padding-left: calc(12px + env(safe-area-inset-left, 0px));
     padding-right: calc(12px + env(safe-area-inset-right, 0px));
   }
-  /* Ensure the chat list never tucks under the fixed composer */
-  .msgs{ padding-bottom: calc(96px + var(--safeB)); }
 }
 
 
@@ -4476,7 +4497,7 @@ body.kb-open #typing{
 /* When iOS keyboard opens, the composer is lifted by --kbOffset.
    Add matching scroll padding so messages still use the full area and never get covered. */
 body.kb-open .msgs{
-  padding-bottom: calc(72px + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
 }
 body.kb-open #dmModal .dmMessages,
 body.kb-open #dmModal .dmMsgs,
@@ -4484,7 +4505,7 @@ body.kb-open #dmModal .messages,
 body.kb-open .dmPanel .dmMessages,
 body.kb-open .dmPanel .dmMsgs,
 body.kb-open .dmPanel .messages{
-  padding-bottom: calc(72px + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
 }
 
 
@@ -4773,10 +4794,6 @@ body.kb-open #typing{ display:none !important; }
   }
 }
 
-/* === Main chat messages were getting visually cut off: ensure scroll area accounts for composer height === */
-.msgs{
-  padding-bottom: calc(160px + var(--safeB)) !important;
-}
 /* === MAIN CHAT: fix message area being constrained/cut off === */
 /* Ensure the center chat column can actually give height to the scroll area */
 .chat,

--- a/server.js
+++ b/server.js
@@ -310,16 +310,16 @@ app.use((req, res, next) => {
     "Content-Security-Policy",
     [
       "default-src 'self'",
-      "script-src 'self' 'unsafe-eval' 'unsafe-inline'",
-      "script-src-elem 'self' 'unsafe-eval' 'unsafe-inline'",
+      "script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.youtube.com https://www.youtube-nocookie.com https://s.ytimg.com",
+      "script-src-elem 'self' 'unsafe-eval' 'unsafe-inline' https://www.youtube.com https://www.youtube-nocookie.com https://s.ytimg.com",
       // Inline style attributes are set by the client JS (e.g. show/hide panels),
       // so allow them alongside our external stylesheet.
       "style-src 'self' 'unsafe-inline'",
       // allow avatars/uploads + blob previews on client
-      "img-src 'self' data: blob:",
+      "img-src 'self' data: blob: https://i.ytimg.com",
       "media-src 'self' blob:",
       // socket.io
-      "connect-src 'self' ws: wss:",
+      "connect-src 'self' ws: wss: https://noembed.com",
       "object-src 'none'",
       "base-uri 'self'",
       "frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com",


### PR DESCRIPTION
## Summary
- allow YouTube scripts, thumbnails, and metadata requests through CSP so embeds can load and play
- refresh viewport/composer sizing logic to track keyboard offsets and keep the chat view unobstructed
- adjust sticky YouTube player states and message padding so the video and messages render correctly across layouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69585f8151f08333b97684fc390b9b46)