### PR TITLE
Fix message padding when keyboard open on iOS

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -4497,7 +4497,7 @@ body.kb-open #typing{
 /* When iOS keyboard opens, the composer is lifted by --kbOffset.
    Add matching scroll padding so messages still use the full area and never get covered. */
 body.kb-open .msgs{
-  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom)) !important;
 }
 body.kb-open #dmModal .dmMessages,
 body.kb-open #dmModal .dmMsgs,
@@ -4505,7 +4505,7 @@ body.kb-open #dmModal .messages,
 body.kb-open .dmPanel .dmMessages,
 body.kb-open .dmPanel .dmMsgs,
 body.kb-open .dmPanel .messages{
-  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom) + var(--kbOffset, 0px)) !important;
+  padding-bottom: calc(var(--composerH, 72px) + env(safe-area-inset-bottom)) !important;
 }
 
 


### PR DESCRIPTION
## Summary
- remove kbOffset from kb-open message padding to avoid double-counting the keyboard height

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958669f5b448333a11bc86575e27e06)