### PR TITLE
Improve profile modal layout and actions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1102,6 +1102,18 @@ const modalName = document.getElementById("modalName");
 const modalRole = document.getElementById("modalRole");
 const modalMood = document.getElementById("modalMood");
 const profileVibes = document.getElementById("profileVibes");
+const profileSheetHero = document.getElementById("profileSheetHero");
+const profileSheetAvatar = document.getElementById("profileSheetAvatar");
+const profileSheetAvatarActions = document.getElementById("profileSheetAvatarActions");
+const profileSheetName = document.getElementById("profileSheetName");
+const profileSheetRoleChip = document.getElementById("profileSheetRoleChip");
+const profileSheetStats = document.getElementById("profileSheetStats");
+const profileSheetStars = document.getElementById("profileSheetStars");
+const profileSheetLikes = document.getElementById("profileSheetLikes");
+const profileSheetSub = document.getElementById("profileSheetSub");
+const profileSheetAge = document.getElementById("profileSheetAge");
+const profileSheetGender = document.getElementById("profileSheetGender");
+const profileSheetDetails = document.getElementById("profileSheetDetails");
 const mediaLightbox = document.getElementById("mediaLightbox");
 const mediaLightboxImg = document.getElementById("mediaLightboxImg");
 const mediaLightboxVideo = document.getElementById("mediaLightboxVideo");
@@ -1120,6 +1132,7 @@ const tabInfo = document.getElementById("tabInfo");
 const tabAbout = document.getElementById("tabAbout");
 const tabCustomize = document.getElementById("tabCustomize");
 const tabModeration = document.getElementById("tabModeration");
+const addFriendBtn = document.getElementById("addFriendBtn");
 
 const viewInfo = document.getElementById("viewInfo");
 const viewAbout = document.getElementById("viewAbout");
@@ -1129,6 +1142,7 @@ const viewModeration = document.getElementById("viewModeration");
 const bioRender = document.getElementById("bioRender");
 const copyUsernameBtn = document.getElementById("copyUsernameBtn");
 const mediaMsg = document.getElementById("mediaMsg");
+const profileActionMsg = document.getElementById("profileActionMsg");
 const customizeMsg = document.getElementById("customizeMsg");
 const levelBadge = document.getElementById("levelBadge");
 const xpText = document.getElementById("xpText");
@@ -5355,6 +5369,16 @@ function renderVibeOptions(selected = []){
   });
 }
 
+function isSelfProfile(p){
+  if (!p || !me) return false;
+  const meId = me.id ?? me.user_id;
+  const targetId = p.id ?? p.user_id;
+  if (meId !== undefined && targetId !== undefined && String(meId) === String(targetId)) return true;
+  const meUser = normKey(me.username || "");
+  const targetUser = normKey(p.username || "");
+  return !!meUser && meUser === targetUser;
+}
+
 function fillProfileUI(p, isSelf){
   modalAvatar.innerHTML="";
   modalAvatar.appendChild(avatarNode(p.avatar, p.username, p.role));
@@ -5375,7 +5399,10 @@ function fillProfileUI(p, isSelf){
   renderLevelProgress(p, isSelf);
   syncProfileLikes(p, isSelf);
   if (profileLikeMsg) profileLikeMsg.textContent = "";
+  if (profileActionMsg) profileActionMsg.textContent = "";
+  if (mediaMsg) mediaMsg.textContent = "";
   renderVibeChips(profileVibes, p.vibe_tags);
+  fillProfileSheetHeader(p, isSelf);
 }
 
 
@@ -5393,6 +5420,23 @@ function fillProfileSheetHeader(p, isSelf){
   if (profileSheetRoleChip){
     profileSheetRoleChip.textContent = p.role ? `${roleIcon(p.role)} ${p.role}` : "User";
     profileSheetRoleChip.style.color = roleBadgeColor(p.role || "User");
+  }
+
+  // Age + gender
+  const ageVal = p.age;
+  const genderVal = (p.gender || "").trim();
+  const showAge = ageVal !== undefined && ageVal !== null && String(ageVal).trim() !== "";
+  const showGender = !!genderVal;
+  if (profileSheetAge){
+    profileSheetAge.textContent = showAge ? `Age ${ageVal}` : "";
+    profileSheetAge.style.display = showAge ? "inline-flex" : "none";
+  }
+  if (profileSheetGender){
+    profileSheetGender.textContent = showGender ? genderVal : "";
+    profileSheetGender.style.display = showGender ? "inline-flex" : "none";
+  }
+  if (profileSheetDetails){
+    profileSheetDetails.style.display = (showAge || showGender) ? "flex" : "none";
   }
 
   // Subline: mood + status/room snapshot
@@ -5421,6 +5465,14 @@ function fillProfileSheetHeader(p, isSelf){
   if (profileSheetAvatarActions){
     profileSheetAvatarActions.style.display = isSelf ? "flex" : "none";
   }
+}
+
+function updateProfileActions({ isSelf = false, canModerate = false } = {}){
+  if (tabEdit) tabEdit.style.display = isSelf ? "" : "none";
+  if (viewEdit && !isSelf) viewEdit.style.display = "none";
+  if (addFriendBtn) addFriendBtn.style.display = isSelf ? "none" : "";
+  if (profileActionMsg) profileActionMsg.textContent = "";
+  if (tabModeration) tabModeration.style.display = canModerate ? "" : "none";
 }
 
 function applyProfileMenuVisibility(){
@@ -5664,7 +5716,8 @@ modalTargetUsername = p.username;
   avatarFile.value="";
   profileMsg.textContent="";
 
-  tabModeration.style.display = (roleRank(me.role) >= roleRank("Moderator")) ? "block" : "none";
+  const canMod = (roleRank(me.role) >= roleRank("Moderator"));
+  updateProfileActions({ isSelf: true, canModerate: canMod });
   setTab("info");
   openModal();
 }
@@ -5701,7 +5754,7 @@ async function openMemberProfile(username){
   if(!res.ok) return;
   const p=await res.json();
   modalTargetUserId = Number(p?.id) || null;
-  const isSelf = !!me && normKey(me.username) === normKey(p.username);
+  const isSelf = isSelfProfile(p);
   if (isSelf) applyProgressionPayload(p);
 
   modalTitle.textContent="Member Profile";
@@ -5709,7 +5762,7 @@ async function openMemberProfile(username){
   fillProfileUI(p, isSelf);
   syncCustomizationUI();
 
-  myProfileEdit.style.display="none";
+  myProfileEdit.style.display = isSelf ? "block" : "none";
 
   const iCanMod = (roleRank(me.role) >= roleRank("Moderator")) && (roleRank(me.role) > roleRank(p.role));
   memberModTools.style.display = iCanMod ? "block" : "none";
@@ -5721,7 +5774,7 @@ async function openMemberProfile(username){
   if(modReason) modReason.value = "";
   if(modMsg) modMsg.textContent = "";
 
-  tabModeration.style.display = (roleRank(me.role) >= roleRank("Moderator")) ? "block" : "none";
+  updateProfileActions({ isSelf, canModerate: (roleRank(me.role) >= roleRank("Moderator")) });
   setTab("info");
   openModal();
 }
@@ -5745,6 +5798,11 @@ likeProfileBtn?.addEventListener("click", async () => {
     const isSelf = normKey(modalTargetUsername) === normKey(me?.username);
     likeProfileBtn.disabled = isSelf;
   }
+});
+
+addFriendBtn?.addEventListener("click", () => {
+  if (addFriendBtn.disabled) return;
+  if (profileActionMsg) profileActionMsg.textContent = "Friend system coming soon.";
 });
 
 // media actions

--- a/public/index.html
+++ b/public/index.html
@@ -497,6 +497,10 @@
                 <span class="profileRoleChip" id="profileSheetRoleChip">Role</span>
                 <span class="profileSheetName" id="profileSheetName">—</span>
               </div>
+              <div class="profileSheetDetails" id="profileSheetDetails">
+                <span class="profileDetail" id="profileSheetAge" style="display:none;"></span>
+                <span class="profileDetail" id="profileSheetGender" style="display:none;"></span>
+              </div>
               <div class="profileSheetStats" id="profileSheetStats" style="display:none;">
                 <span class="statPill" id="profileSheetStars">⭐ 0</span>
                 <span class="statPill" id="profileSheetLikes">♡ 0</span>
@@ -506,12 +510,43 @@
             </div>
           </div>
         </div>
-<div class="tabs" id="tabs">
-  <div class="tab active" data-tab="info" id="tabInfo">Info</div>
-  <div class="tab" data-tab="about" id="tabAbout">About</div>
-  <div class="tab" data-tab="edit" id="tabEdit">Edit</div>
-  <div class="tab" data-tab="moderation" id="tabModeration" style="display:none;">Moderation</div>
-</div>
+
+          <div class="profileActions">
+            <div class="tabs profileActionTabs" id="tabs">
+            <button class="tab active" data-tab="info" id="tabInfo" type="button">
+              <span class="tabIcon" aria-hidden="true">ℹ️</span>
+              <span class="tabLabel">Info</span>
+            </button>
+            <button class="tab" data-tab="about" id="tabAbout" type="button">
+              <span class="tabIcon" aria-hidden="true">📄</span>
+              <span class="tabLabel">About</span>
+            </button>
+            <button class="tab" data-tab="edit" id="tabEdit" type="button">
+              <span class="tabIcon" aria-hidden="true">✏️</span>
+              <span class="tabLabel">Edit</span>
+            </button>
+            <button class="tab" id="addFriendBtn" type="button" style="display:none;">
+              <span class="tabIcon" aria-hidden="true">🤝</span>
+              <span class="tabLabel">Add Friend</span>
+            </button>
+            <button class="tab" data-tab="moderation" id="tabModeration" type="button" style="display:none;">
+              <span class="tabIcon" aria-hidden="true">🛡️</span>
+              <span class="tabLabel">Moderation</span>
+            </button>
+          </div>
+
+          <div class="profileQuickActions" id="profileQuickActions">
+            <div class="quickActionGroup">
+              <button class="btn secondary" id="dmUserBtn" type="button">Message</button>
+              <button class="btn secondary" id="likeProfileBtn" type="button">❤️ Like</button>
+              <div class="badge" id="likeCount">0</div>
+            </div>
+            <button class="btn secondary" id="copyUsernameBtn" type="button">Copy username</button>
+          </div>
+          <div class="msgline" id="profileActionMsg"></div>
+          <div class="msgline" id="profileLikeMsg"></div>
+          <div class="msgline" id="mediaMsg"></div>
+        </div>
 
         <div id="viewEdit" style="display:none;">
   <div class="profileMenu" id="profileMenu">
@@ -756,19 +791,7 @@
                   </div>
                   <div class="small" id="xpNote">XP is only visible to you.</div>
                 </div>
-
-                <div class="likeRow">
-                  <button class="btn secondary" id="likeProfileBtn" type="button">❤️ Like</button>
-                  <div class="badge" id="likeCount">0</div>
-                </div>
-                <div class="msgline" id="profileLikeMsg"></div>
-
-                <div class="row" style="gap:8px; margin-top:10px; flex-wrap:wrap;">
-                  <button class="btn secondary" id="dmUserBtn" type="button">Message</button>
-                  <button class="btn secondary" id="copyUsernameBtn" type="button">Copy username</button>
-                <div class="msgline" id="mediaMsg"></div>
-                  </div>
-                </div>
+              </div>
 
                 <div id="memberModTools" style="display:none; margin-top:12px;">
                   <div class="sectionTitle">Moderator tools</div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2480,7 +2480,7 @@ padding: 18px;
 }
 .tabs::-webkit-scrollbar{ display:none; }
 .tab{
-  padding:8px 10px;
+  padding:10px;
   border-radius:12px;
   background:color-mix(in srgb, var(--panel) 85%, transparent);
   border:1px solid var(--border);
@@ -2491,8 +2491,14 @@ padding: 18px;
   user-select:none;
   flex:1 1 120px;
   text-align:center;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
 }
 .tab.active{ background:var(--panel); border-color:var(--border); box-shadow: var(--shadowSm); }
+.tab .tabIcon{ font-size:18px; line-height:1; }
+.tab .tabLabel{ white-space:nowrap; }
 
 .modalGrid{ display:grid; grid-template-columns: 170px 1fr; gap:12px; }
 .pAvatar{ width:160px; height:160px; border-radius:18px; background:var(--avatar-bg); overflow:hidden; border:1px solid var(--border); }
@@ -4599,7 +4605,7 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
   gap: 14px;
   padding: 14px;
   margin-top: -64px;
-  align-items: end;
+  align-items: center;
   position: relative;
   z-index: 1;
 }
@@ -4658,6 +4664,19 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
   border: 1px solid rgba(255,255,255,.18);
   background: rgba(255,255,255,.08);
 }
+.profileSheetDetails{
+  display:flex;
+  gap:8px;
+  flex-wrap:wrap;
+  margin-top:6px;
+}
+.profileDetail{
+  padding:6px 10px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,.12);
+  background: rgba(0,0,0,.28);
+  font-size:12px;
+}
 .profileSheetSub{
   margin-top: 6px;
   font-size: 12px;
@@ -4677,6 +4696,13 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
   background: rgba(0,0,0,.25);
   font-size: 12px;
 }
+
+.profileActions{ display:flex; flex-direction:column; gap:10px; margin:6px 0 10px; }
+.profileActionTabs{ width:100%; flex-wrap:nowrap; grid-template-columns: repeat(4, minmax(72px, 1fr)); display:grid; }
+.profileActionTabs .tab{ aspect-ratio: 1; min-height:72px; }
+.profileQuickActions{ display:flex; gap:10px; align-items:center; justify-content:space-between; flex-wrap:wrap; }
+.quickActionGroup{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
+.quickActionGroup .badge{ height:100%; display:flex; align-items:center; justify-content:center; }
 
 .profileMenu{
   display: grid;


### PR DESCRIPTION
## Summary
- populate the profile modal header with avatar, role, age, gender, and status details while using existing data
- compress action buttons into a single row with conditional Edit/Add Friend handling and repositioned message/like controls
- tidy supporting styles and messaging to keep sections scrollable and responsive

## Testing
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b00fa268c833388cf5f4867e048e7)