### PR TITLE
Add profile gradient customization and fix member profile avatar

### DIFF
--- a/database.js
+++ b/database.js
@@ -132,6 +132,8 @@ async function runSqliteMigrations() {
     ["lastDiceRollAt", "lastDiceRollAt INTEGER"],
     ["dice_sixes", "dice_sixes INTEGER NOT NULL DEFAULT 0"],
     ["vibe_tags", "vibe_tags TEXT"],
+    ["header_grad_a", "header_grad_a TEXT"],
+    ["header_grad_b", "header_grad_b TEXT"],
   ];
   await ensureColumns("users", userColumns);
   await run("UPDATE users SET vibe_tags='[]' WHERE vibe_tags IS NULL");

--- a/public/app.js
+++ b/public/app.js
@@ -1103,6 +1103,7 @@ const modalRole = document.getElementById("modalRole");
 const modalMood = document.getElementById("modalMood");
 const profileVibes = document.getElementById("profileVibes");
 const profileSheetHero = document.getElementById("profileSheetHero");
+const profileSheetBg = document.getElementById("profileSheetBg");
 const profileSheetAvatar = document.getElementById("profileSheetAvatar");
 const profileSheetAvatarActions = document.getElementById("profileSheetAvatarActions");
 const profileSheetName = document.getElementById("profileSheetName");
@@ -1162,6 +1163,10 @@ const saveBadgePrefsBtn = document.getElementById("saveBadgePrefsBtn");
 // my profile edit
 const myProfileEdit = document.getElementById("myProfileEdit");
 const avatarFile = document.getElementById("avatarFile");
+const headerColorA = document.getElementById("headerColorA");
+const headerColorB = document.getElementById("headerColorB");
+const headerColorAText = document.getElementById("headerColorAText");
+const headerColorBText = document.getElementById("headerColorBText");
 const editMood = document.getElementById("editMood");
 const editAge = document.getElementById("editAge");
 const editGender = document.getElementById("editGender");
@@ -2039,6 +2044,9 @@ function loadBadgePrefsFromStorage(){
     return { ...badgeDefaults };
   }
 }
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+const PROFILE_GRADIENT_DEFAULT_A = "#ff6a2b";
+const PROFILE_GRADIENT_DEFAULT_B = "#2b0f08";
 function saveBadgePrefsToStorage(){
   try{ localStorage.setItem("dmBadgePrefs", JSON.stringify(badgePrefs)); }
   catch{}
@@ -2051,16 +2059,33 @@ function isValidCssColor(color){
   return s.color !== "";
 }
 function normalizeColorForInput(color, fallback){
-  const hexOk = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
-  if(hexOk.test(color || "")) return color;
-  if(hexOk.test(fallback || "")) return fallback;
+  if(HEX_COLOR_RE.test(color || "")) return color;
+  if(HEX_COLOR_RE.test(fallback || "")) return fallback;
   return "#000000";
+}
+function sanitizeHexColorInput(raw, fallback=""){
+  const c = String(raw || "").trim();
+  if(HEX_COLOR_RE.test(c)) return c;
+  if(HEX_COLOR_RE.test(fallback || "")) return fallback;
+  return "";
 }
 function sanitizeColor(raw, fallback, hardDefault){
   if(isValidCssColor(raw)) return raw.trim();
   if(isValidCssColor(fallback)) return fallback.trim();
   if(isValidCssColor(hardDefault)) return hardDefault.trim();
   return hardDefault || badgeDefaults.direct;
+}
+function buildProfileHeaderGradient(colorA, colorB){
+  const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
+  const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
+  return `
+    radial-gradient(900px 260px at 70% 30%, rgba(255,180,80,.45), transparent 60%),
+    linear-gradient(135deg, ${a}, ${b})
+  `;
+}
+function applyProfileHeaderBg(colorA, colorB){
+  if(!profileSheetBg) return;
+  profileSheetBg.style.background = buildProfileHeaderGradient(colorA, colorB);
 }
 function loadDmThemePrefsFromStorage(){
   try {
@@ -4636,6 +4661,7 @@ editDmBtn?.addEventListener("click", ()=>showEditPanel("dm"));
 wireProfileMenu();
 wireSoundPrefs();
 wireProfileAvatarActions();
+wireHeaderGradientInputs();
 tabInfo.addEventListener("click", ()=>setTab("info"));
 tabAbout.addEventListener("click", ()=>setTab("about"));
 tabCustomize?.addEventListener("click", ()=>setTab("customize"));
@@ -5365,8 +5391,59 @@ function renderVibeOptions(selected = []){
       }
       renderVibeOptions(selectedVibeTags);
     });
-    vibeTagOptions.appendChild(btn);
+  vibeTagOptions.appendChild(btn);
   });
+}
+
+function getHeaderGradientInputValues(){
+  const aRaw = headerColorAText?.value || headerColorA?.value;
+  const bRaw = headerColorBText?.value || headerColorB?.value;
+  const a = sanitizeHexColorInput(aRaw, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
+  const b = sanitizeHexColorInput(bRaw, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
+  return { a, b };
+}
+function syncHeaderGradientInputs(colorA, colorB){
+  const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
+  const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
+  if(headerColorA) headerColorA.value = normalizeColorForInput(a, PROFILE_GRADIENT_DEFAULT_A);
+  if(headerColorAText) headerColorAText.value = a;
+  if(headerColorB) headerColorB.value = normalizeColorForInput(b, PROFILE_GRADIENT_DEFAULT_B);
+  if(headerColorBText) headerColorBText.value = b;
+  applyProfileHeaderBg(a, b);
+}
+function wireHeaderGradientInputs(){
+  if(headerColorA && !headerColorA._wired){
+    headerColorA._wired = true;
+    headerColorA.addEventListener("input", () => {
+      const vals = getHeaderGradientInputValues();
+      if(headerColorAText) headerColorAText.value = vals.a;
+      applyProfileHeaderBg(vals.a, vals.b);
+    });
+  }
+  if(headerColorAText && !headerColorAText._wired){
+    headerColorAText._wired = true;
+    headerColorAText.addEventListener("input", () => {
+      const vals = getHeaderGradientInputValues();
+      if(headerColorA) headerColorA.value = normalizeColorForInput(vals.a, PROFILE_GRADIENT_DEFAULT_A);
+      applyProfileHeaderBg(vals.a, vals.b);
+    });
+  }
+  if(headerColorB && !headerColorB._wired){
+    headerColorB._wired = true;
+    headerColorB.addEventListener("input", () => {
+      const vals = getHeaderGradientInputValues();
+      if(headerColorBText) headerColorBText.value = vals.b;
+      applyProfileHeaderBg(vals.a, vals.b);
+    });
+  }
+  if(headerColorBText && !headerColorBText._wired){
+    headerColorBText._wired = true;
+    headerColorBText.addEventListener("input", () => {
+      const vals = getHeaderGradientInputValues();
+      if(headerColorB) headerColorB.value = normalizeColorForInput(vals.b, PROFILE_GRADIENT_DEFAULT_B);
+      applyProfileHeaderBg(vals.a, vals.b);
+    });
+  }
 }
 
 function isSelfProfile(p){
@@ -5380,12 +5457,16 @@ function isSelfProfile(p){
 }
 
 function fillProfileUI(p, isSelf){
-  modalAvatar.innerHTML="";
-  modalAvatar.appendChild(avatarNode(p.avatar, p.username, p.role));
-  modalName.textContent=p.username;
-  modalRole.textContent=`${roleIcon(p.role)} ${p.role}`;
-  modalRole.style.color=roleBadgeColor(p.role);
-  modalMood.textContent = p.mood ? `Mood: ${p.mood}` : "Mood: (none)";
+  if (modalAvatar){
+    modalAvatar.innerHTML="";
+    modalAvatar.appendChild(avatarNode(p.avatar, p.username, p.role));
+  }
+  if (modalName) modalName.textContent=p.username;
+  if (modalRole){
+    modalRole.textContent=`${roleIcon(p.role)} ${p.role}`;
+    modalRole.style.color=roleBadgeColor(p.role);
+  }
+  if (modalMood) modalMood.textContent = p.mood ? `Mood: ${p.mood}` : "Mood: (none)";
 
   infoAge.textContent = (p.age ?? "—");
   infoGender.textContent = (p.gender ?? "—");
@@ -5408,6 +5489,8 @@ function fillProfileUI(p, isSelf){
 
 function fillProfileSheetHeader(p, isSelf){
   if (!profileSheetHero) return;
+
+  applyProfileHeaderBg(p?.header_grad_a, p?.header_grad_b);
 
   // Avatar
   if (profileSheetAvatar){
@@ -5713,6 +5796,7 @@ modalTargetUsername = p.username;
   editBio.value=p.bio||"";
   selectedVibeTags = sanitizeVibeTagsClient(p.vibe_tags);
   renderVibeOptions(selectedVibeTags);
+  syncHeaderGradientInputs(p.header_grad_a, p.header_grad_b);
   avatarFile.value="";
   profileMsg.textContent="";
 
@@ -5731,6 +5815,9 @@ saveProfileBtn.addEventListener("click", async ()=>{
   form.append("gender", editGender.value);
   form.append("bio", editBio.value);
   form.append("vibeTags", JSON.stringify(selectedVibeTags || []));
+  const grad = getHeaderGradientInputValues();
+  form.append("headerColorA", grad.a);
+  form.append("headerColorB", grad.b);
   if(avatarFile.files[0]) form.append("avatar", avatarFile.files[0]);
 
   const res=await fetch("/profile", {method:"POST", body:form});

--- a/public/index.html
+++ b/public/index.html
@@ -472,7 +472,7 @@
      
         <!-- Profile sheet header (custom layout, not a clone) -->
         <div class="profileSheetHero" id="profileSheetHero">
-          <div class="profileSheetBg"></div>
+          <div class="profileSheetBg" id="profileSheetBg"></div>
 
           <div class="profileSheetContent">
             <div class="profileSheetAvatarCard">
@@ -531,7 +531,7 @@
             </button>
             <button class="tab" data-tab="moderation" id="tabModeration" type="button" style="display:none;">
               <span class="tabIcon" aria-hidden="true">🛡️</span>
-              <span class="tabLabel">Moderation</span>
+              <span class="tabLabel">Mod</span>
             </button>
           </div>
 
@@ -664,6 +664,19 @@
                         </div>
 
                         <div class="field">
+                          <label>Header gradient</label>
+                          <div class="colorInputRow tight">
+                            <input id="headerColorA" type="color" aria-label="Header color A">
+                            <input id="headerColorAText" type="text" placeholder="#ff6a2b" aria-label="Header color A text">
+                          </div>
+                          <div class="colorInputRow tight" style="margin-top:6px;">
+                            <input id="headerColorB" type="color" aria-label="Header color B">
+                            <input id="headerColorBText" type="text" placeholder="#2b0f08" aria-label="Header color B text">
+                          </div>
+                          <div class="small">Pick two colors for your profile header gradient.</div>
+                        </div>
+
+                        <div class="field">
                           <label>Mood</label>
                           <input id="editMood" placeholder="e.g. chilling">
                         </div>
@@ -758,18 +771,6 @@
           <div id="viewInfo">
             <div class="modalGrid">
               <div>
-        <div id="legacyProfileHeader" style="display:none">
-                <div class="pAvatar" id="modalAvatar"></div>
-              </div>
-
-              <div>
-                <div class="row" style="align-items:center;">
-                  <div style="font-weight:900; font-size:16px;" id="modalName"></div>
-                  <div class="badge" id="modalRole"></div>
-                </div>
-                <div class="vibeRow" id="profileVibes"></div>
-                <div class="small" id="modalMood"></div>
-
                 <div class="sectionTitle">Details</div>
                 <div class="infoGrid">
                   <div class="infoItem"><div class="k">Age</div><div class="v" id="infoAge">—</div></div>

--- a/server.js
+++ b/server.js
@@ -248,6 +248,8 @@ try {
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS lastDiceRollAt BIGINT`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS dice_sixes INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS vibe_tags JSONB NOT NULL DEFAULT '[]'::jsonb`,
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS header_grad_a TEXT`,
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS header_grad_b TEXT`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_bytes BYTEA`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_mime TEXT`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_updated BIGINT`,
@@ -429,6 +431,8 @@ const VIBE_TAG_OPTIONS = [
   "Chill", "Chaotic", "Night Owl", "Cozy", "Loud", "Quiet", "Curious", "Unhinged", "Friendly", "Competitive"
 ];
 
+const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
+
 function sanitizeVibeTags(raw) {
   const arr = Array.isArray(raw)
     ? raw
@@ -445,6 +449,11 @@ function sanitizeVibeTags(raw) {
     if (hit && !out.includes(hit)) out.push(hit);
   }
   return out;
+}
+function sanitizeHexColor(raw){
+  const c = String(raw || "").trim();
+  if(!c) return null;
+  return HEX_COLOR_RE.test(c) ? c : null;
 }
 function avatarUrlFromRow(row) {
   if (!row) return null;
@@ -487,6 +496,8 @@ function pgRowToUser(row) {
     lastDailyLoginGoldAt: row.lastDailyLoginGoldAt ?? null,
     lastDiceRollAt: row.lastDiceRollAt ?? null,
     vibe_tags: sanitizeVibeTags(row.vibe_tags || []),
+    header_grad_a: sanitizeHexColor(row.header_grad_a),
+    header_grad_b: sanitizeHexColor(row.header_grad_b),
   };
 }
 function dbGet(sql, params = []) {
@@ -518,7 +529,7 @@ async function pgGetUserByUsername(username) {
   const { rows } = await pgPool.query(
     `SELECT id, username, password_hash, role, created_at, avatar, avatar_updated, bio, mood, age, gender, last_seen, last_room, last_status,
             theme, gold, xp, "lastXpMessageAt", "lastDailyLoginAt", "lastGoldTickAt", "lastMessageGoldAt", "lastDailyLoginGoldAt",
-            "lastDiceRollAt", dice_sixes, vibe_tags
+            "lastDiceRollAt", dice_sixes, vibe_tags, header_grad_a, header_grad_b
        FROM users WHERE lower(username) = lower($1) LIMIT 1`,
     [username]
   );
@@ -529,7 +540,7 @@ async function pgGetUserById(id) {
   const { rows } = await pgPool.query(
     `SELECT id, username, password_hash, role, created_at, avatar, avatar_updated, bio, mood, age, gender, last_seen, last_room, last_status,
             theme, gold, xp, "lastXpMessageAt", "lastDailyLoginAt", "lastGoldTickAt", "lastMessageGoldAt", "lastDailyLoginGoldAt",
-            "lastDiceRollAt", dice_sixes, vibe_tags
+            "lastDiceRollAt", dice_sixes, vibe_tags, header_grad_a, header_grad_b
        FROM users WHERE id = $1 LIMIT 1`,
     [id]
   );
@@ -545,7 +556,7 @@ async function pgGetUserRowById(id, columns) {
     "id","username","password_hash","role","created_at","avatar","avatar_bytes","avatar_mime","avatar_updated","bio","mood","age","gender",
     "last_seen","last_room","last_status","theme","gold","xp",
     "lastXpMessageAt","lastDailyLoginAt","lastGoldTickAt","lastMessageGoldAt","lastDailyLoginGoldAt",
-    "lastDiceRollAt","dice_sixes","vibe_tags"
+    "lastDiceRollAt","dice_sixes","vibe_tags","header_grad_a","header_grad_b"
   ]);
   const cols = (Array.isArray(columns) && columns.length)
     ? columns.filter((c) => allow.has(String(c)))
@@ -2788,6 +2799,8 @@ app.get("/profile", requireLogin, async (req, res) => {
         "mood",
         "age",
         "gender",
+        "header_grad_a",
+        "header_grad_b",
         "created_at",
         "last_seen",
         "last_room",
@@ -2818,16 +2831,18 @@ app.get("/profile", requireLogin, async (req, res) => {
             mood: row.mood,
             age: row.age,
             gender: row.gender,
-            created_at: row.created_at,
-            last_seen: row.last_seen,
-            last_room: row.last_room,
-            last_status: lastStatus || null,
-            current_room: live?.room || null,
-            likes: Number(likesRow?.likes || 0),
-            likedByMe: !!Number(likesRow?.liked || 0),
-            vibe_tags: sanitizeVibeTags(row.vibe_tags || []),
-            ...progressionFromRow(row, true),
-          };
+          created_at: row.created_at,
+          last_seen: row.last_seen,
+          last_room: row.last_room,
+          last_status: lastStatus || null,
+          current_room: live?.room || null,
+          header_grad_a: sanitizeHexColor(row.header_grad_a),
+          header_grad_b: sanitizeHexColor(row.header_grad_b),
+          likes: Number(likesRow?.likes || 0),
+          likedByMe: !!Number(likesRow?.liked || 0),
+          vibe_tags: sanitizeVibeTags(row.vibe_tags || []),
+          ...progressionFromRow(row, true),
+        };
 	          return res.json(payload);
 	        }
 	      );
@@ -2839,7 +2854,7 @@ app.get("/profile", requireLogin, async (req, res) => {
 
   // SQLite fallback (original behavior)
   db.get(
-    `SELECT id, username, role, avatar, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags
+    `SELECT id, username, role, avatar, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags, header_grad_a, header_grad_b
      FROM users WHERE id = ?`,
     [userId],
     (err, row) => {
@@ -2897,7 +2912,7 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
       for (const cand of candidates) {
         try {
           const r = await pgPool.query(
-            `SELECT id, username, role, avatar, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags
+            `SELECT id, username, role, avatar, avatar_updated, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags, header_grad_a, header_grad_b
              FROM users
              WHERE username = $1 OR lower(username) = lower($1)
              LIMIT 1`,
@@ -2914,7 +2929,7 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
     if (!row) {
       for (const cand of candidates) {
         row = await dbGet(
-          `SELECT id, username, role, avatar, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags
+          `SELECT id, username, role, avatar, avatar_updated, bio, mood, age, gender, created_at, last_seen, last_room, last_status, gold, xp, vibe_tags, header_grad_a, header_grad_b
            FROM users
            WHERE username = ? OR lower(username) = lower(?)`,
           [cand, cand]
@@ -2950,6 +2965,8 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
           last_room: row.last_room,
           last_status: lastStatus || null,
           current_room: live?.room || null,
+          header_grad_a: sanitizeHexColor(row.header_grad_a),
+          header_grad_b: sanitizeHexColor(row.header_grad_b),
           likes: Number(likesRow?.likes || 0),
           likedByMe: !!Number(likesRow?.liked || 0),
           vibe_tags: sanitizeVibeTags(row.vibe_tags || []),
@@ -3035,6 +3052,8 @@ app.post("/profile", requireLogin, (req, res) => {
     const age = req.body?.age === "" || req.body?.age == null ? null : clamp(req.body.age, 18, 120);
     const gender = String(req.body?.gender || "").slice(0, 40);
     const vibeTags = sanitizeVibeTags(req.body?.vibeTags);
+    const headerGradA = sanitizeHexColor(req.body?.headerColorA);
+    const headerGradB = sanitizeHexColor(req.body?.headerColorB);
     // Postgres stores vibe_tags as JSONB. node-postgres will otherwise serialize arrays
     // as Postgres array literals, which causes the UPDATE to fail and makes changes
     // appear to "revert" on refresh (because /profile reads from Postgres first).
@@ -3068,9 +3087,11 @@ app.post("/profile", requireLogin, (req, res) => {
                    avatar_mime = $6,
                    avatar_updated = $7,
                    avatar = NULL,
-                   vibe_tags = $8::jsonb
-             WHERE id = $9`,
-            [mood, bio, age, gender, file.buffer, file.mimetype, avatarUpdated, vibeTagsJson, userId]
+                   vibe_tags = $8::jsonb,
+                   header_grad_a = COALESCE($9, header_grad_a),
+                   header_grad_b = COALESCE($10, header_grad_b)
+             WHERE id = $11`,
+            [mood, bio, age, gender, file.buffer, file.mimetype, avatarUpdated, vibeTagsJson, headerGradA, headerGradB, userId]
           );
         } else {
           await pgPool.query(
@@ -3079,9 +3100,11 @@ app.post("/profile", requireLogin, (req, res) => {
                    bio = $2,
                    age = $3,
                    gender = $4,
-                   vibe_tags = $5::jsonb
-             WHERE id = $6`,
-            [mood, bio, age, gender, vibeTagsJson, userId]
+                   vibe_tags = $5::jsonb,
+                   header_grad_a = COALESCE($6, header_grad_a),
+                   header_grad_b = COALESCE($7, header_grad_b)
+             WHERE id = $8`,
+            [mood, bio, age, gender, vibeTagsJson, headerGradA, headerGradB, userId]
           );
         }
         if (avatarUrl) req.session.user.avatar = avatarUrl;
@@ -3102,14 +3125,16 @@ app.post("/profile", requireLogin, (req, res) => {
     }
 
     // SQLite fallback (original behavior)
-    db.get("SELECT avatar, vibe_tags FROM users WHERE id = ?", [userId], (_e, old) => {
+    db.get("SELECT avatar, vibe_tags, header_grad_a, header_grad_b FROM users WHERE id = ?", [userId], (_e, old) => {
       const newAvatar = old?.avatar || null;
       const oldVibes = sanitizeVibeTags(old?.vibe_tags || []);
       const vibeJson = JSON.stringify(vibeTags.length ? vibeTags : oldVibes);
+      const newHeaderGradA = headerGradA ?? sanitizeHexColor(old?.header_grad_a);
+      const newHeaderGradB = headerGradB ?? sanitizeHexColor(old?.header_grad_b);
 
       db.run(
-        `UPDATE users SET mood=?, bio=?, age=?, gender=?, avatar=?, vibe_tags=? WHERE id=?`,
-        [mood, bio, age, gender, newAvatar, vibeJson, userId],
+        `UPDATE users SET mood=?, bio=?, age=?, gender=?, avatar=?, vibe_tags=?, header_grad_a=?, header_grad_b=? WHERE id=?`,
+        [mood, bio, age, gender, newAvatar, vibeJson, newHeaderGradA, newHeaderGradB, userId],
         (err2) => {
           if (err2) return res.status(500).send("Save failed");
           if (avatarUrl) req.session.user.avatar = avatarUrl;


### PR DESCRIPTION
## Summary
- add support for storing profile header gradient colors and expose them through profile APIs
- update the profile modal UI with gradient editors, apply backgrounds for all users, and clean up duplicated header elements
- rename the moderation tab label and ensure member avatars render when viewing other users

## Testing
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b289dd99c8333948853ce62c50729)