### PR TITLE
Enhance profile modal header and actions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1152,6 +1152,7 @@ const xpNote = document.getElementById("xpNote");
 const levelToast = document.getElementById("levelToast");
 const levelToastText = document.getElementById("levelToastText");
 const profileSheetVibes = document.getElementById("profileSheetVibes");
+const profileSheetOverlay = document.getElementById("profileSheetOverlay");
 
 const directBadgeColor = document.getElementById("directBadgeColor");
 const groupBadgeColor = document.getElementById("groupBadgeColor");
@@ -2047,6 +2048,10 @@ function loadBadgePrefsFromStorage(){
 const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 const PROFILE_GRADIENT_DEFAULT_A = "#ff6a2b";
 const PROFILE_GRADIENT_DEFAULT_B = "#2b0f08";
+const prefersReducedMotion = window.matchMedia ? window.matchMedia("(prefers-reduced-motion: reduce)") : { matches: false };
+let headerGradientPreviewFrame = 0;
+let headerGradientPreviewNext = null;
+let currentProfileHeaderRole = "";
 function saveBadgePrefsToStorage(){
   try{ localStorage.setItem("dmBadgePrefs", JSON.stringify(badgePrefs)); }
   catch{}
@@ -2075,6 +2080,40 @@ function sanitizeColor(raw, fallback, hardDefault){
   if(isValidCssColor(hardDefault)) return hardDefault.trim();
   return hardDefault || badgeDefaults.direct;
 }
+function hexToRgb(hex){
+  const m = /^#?([0-9a-fA-F]{6})$/.exec((hex || "").trim());
+  if(!m) return null;
+  const intVal = parseInt(m[1], 16);
+  return {
+    r: (intVal >> 16) & 255,
+    g: (intVal >> 8) & 255,
+    b: intVal & 255
+  };
+}
+function relativeLuminance({ r, g, b }){
+  const toLinear = (c) => {
+    const channel = c / 255;
+    return channel <= 0.03928 ? channel / 12.92 : Math.pow((channel + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * toLinear(r) + 0.7152 * toLinear(g) + 0.0722 * toLinear(b);
+}
+function computeProfileTextTheme(colorA, colorB){
+  const a = hexToRgb(colorA) || hexToRgb(PROFILE_GRADIENT_DEFAULT_A) || { r: 255, g: 106, b: 43 };
+  const b = hexToRgb(colorB) || hexToRgb(PROFILE_GRADIENT_DEFAULT_B) || { r: 43, g: 15, b: 8 };
+  const avgLum = (relativeLuminance(a) + relativeLuminance(b)) / 2;
+  const lightText = avgLum < 0.55;
+  return lightText ? {
+    text: "#fdfdfd",
+    shadow: "0 1px 4px rgba(0,0,0,0.65)",
+    pillBg: "rgba(0,0,0,0.32)",
+    pillBorder: "rgba(255,255,255,0.22)"
+  } : {
+    text: "#0d1b24",
+    shadow: "0 1px 3px rgba(255,255,255,0.35)",
+    pillBg: "rgba(255,255,255,0.24)",
+    pillBorder: "rgba(0,0,0,0.18)"
+  };
+}
 function buildProfileHeaderGradient(colorA, colorB){
   const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
   const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
@@ -2083,9 +2122,38 @@ function buildProfileHeaderGradient(colorA, colorB){
     linear-gradient(135deg, ${a}, ${b})
   `;
 }
-function applyProfileHeaderBg(colorA, colorB){
-  if(!profileSheetBg) return;
-  profileSheetBg.style.background = buildProfileHeaderGradient(colorA, colorB);
+function applyProfileHeaderOverlay(role){
+  if(!profileSheetOverlay) return;
+  const r = (role || "").toLowerCase();
+  const overlayClass = r.includes("owner") ? (r.includes("co") ? "co-owner" : "owner")
+    : r.includes("admin") ? "admin"
+    : r.includes("mod") ? "moderator"
+    : r.includes("vip") ? "vip"
+    : r.includes("member") ? "member"
+    : r.includes("guest") ? "guest" : "";
+
+  profileSheetOverlay.className = "profileSheetOverlay";
+  if(overlayClass) profileSheetOverlay.classList.add(`role-${overlayClass}`);
+}
+function applyProfileHeaderGradient(colorA, colorB, role){
+  if(!profileSheetBg && !profileSheetHero) return;
+  const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
+  const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
+  const gradient = buildProfileHeaderGradient(a, b);
+  if(profileSheetBg){
+    profileSheetBg.style.background = gradient;
+    profileSheetBg.style.backgroundRepeat = "no-repeat";
+    profileSheetBg.style.backgroundSize = "cover";
+    profileSheetBg.style.setProperty("--profileHeaderBg", gradient);
+  }
+  if(profileSheetHero){
+    const theme = computeProfileTextTheme(a, b);
+    profileSheetHero.style.setProperty("--profileHeaderText", theme.text);
+    profileSheetHero.style.setProperty("--profileHeaderTextShadow", theme.shadow);
+    profileSheetHero.style.setProperty("--profileHeaderPillBg", theme.pillBg);
+    profileSheetHero.style.setProperty("--profileHeaderPillBorder", theme.pillBorder);
+  }
+  applyProfileHeaderOverlay(role || currentProfileHeaderRole);
 }
 function loadDmThemePrefsFromStorage(){
   try {
@@ -5402,6 +5470,21 @@ function getHeaderGradientInputValues(){
   const b = sanitizeHexColorInput(bRaw, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
   return { a, b };
 }
+function scheduleProfileHeaderPreview(colorA, colorB){
+  const next = { a: colorA, b: colorB };
+  headerGradientPreviewNext = next;
+  if(prefersReducedMotion?.matches){
+    applyProfileHeaderGradient(next.a, next.b, currentProfileHeaderRole);
+    return;
+  }
+  if(headerGradientPreviewFrame) return;
+  headerGradientPreviewFrame = requestAnimationFrame(() => {
+    headerGradientPreviewFrame = 0;
+    const vals = headerGradientPreviewNext || next;
+    headerGradientPreviewNext = null;
+    applyProfileHeaderGradient(vals.a, vals.b, currentProfileHeaderRole);
+  });
+}
 function syncHeaderGradientInputs(colorA, colorB){
   const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
   const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
@@ -5409,7 +5492,7 @@ function syncHeaderGradientInputs(colorA, colorB){
   if(headerColorAText) headerColorAText.value = a;
   if(headerColorB) headerColorB.value = normalizeColorForInput(b, PROFILE_GRADIENT_DEFAULT_B);
   if(headerColorBText) headerColorBText.value = b;
-  applyProfileHeaderBg(a, b);
+  applyProfileHeaderGradient(a, b, currentProfileHeaderRole);
 }
 function wireHeaderGradientInputs(){
   if(headerColorA && !headerColorA._wired){
@@ -5417,7 +5500,7 @@ function wireHeaderGradientInputs(){
     headerColorA.addEventListener("input", () => {
       const vals = getHeaderGradientInputValues();
       if(headerColorAText) headerColorAText.value = vals.a;
-      applyProfileHeaderBg(vals.a, vals.b);
+      scheduleProfileHeaderPreview(vals.a, vals.b);
     });
   }
   if(headerColorAText && !headerColorAText._wired){
@@ -5425,7 +5508,7 @@ function wireHeaderGradientInputs(){
     headerColorAText.addEventListener("input", () => {
       const vals = getHeaderGradientInputValues();
       if(headerColorA) headerColorA.value = normalizeColorForInput(vals.a, PROFILE_GRADIENT_DEFAULT_A);
-      applyProfileHeaderBg(vals.a, vals.b);
+      scheduleProfileHeaderPreview(vals.a, vals.b);
     });
   }
   if(headerColorB && !headerColorB._wired){
@@ -5433,7 +5516,7 @@ function wireHeaderGradientInputs(){
     headerColorB.addEventListener("input", () => {
       const vals = getHeaderGradientInputValues();
       if(headerColorBText) headerColorBText.value = vals.b;
-      applyProfileHeaderBg(vals.a, vals.b);
+      scheduleProfileHeaderPreview(vals.a, vals.b);
     });
   }
   if(headerColorBText && !headerColorBText._wired){
@@ -5441,7 +5524,7 @@ function wireHeaderGradientInputs(){
     headerColorBText.addEventListener("input", () => {
       const vals = getHeaderGradientInputValues();
       if(headerColorB) headerColorB.value = normalizeColorForInput(vals.b, PROFILE_GRADIENT_DEFAULT_B);
-      applyProfileHeaderBg(vals.a, vals.b);
+      scheduleProfileHeaderPreview(vals.a, vals.b);
     });
   }
 }
@@ -5490,7 +5573,8 @@ function fillProfileUI(p, isSelf){
 function fillProfileSheetHeader(p, isSelf){
   if (!profileSheetHero) return;
 
-  applyProfileHeaderBg(p?.header_grad_a, p?.header_grad_b);
+  currentProfileHeaderRole = p?.role || "";
+  applyProfileHeaderGradient(p?.header_grad_a, p?.header_grad_b, currentProfileHeaderRole);
 
   // Avatar
   if (profileSheetAvatar){
@@ -5556,6 +5640,10 @@ function updateProfileActions({ isSelf = false, canModerate = false } = {}){
   if (addFriendBtn) addFriendBtn.style.display = isSelf ? "none" : "";
   if (profileActionMsg) profileActionMsg.textContent = "";
   if (tabModeration) tabModeration.style.display = canModerate ? "" : "none";
+  const editActive = tabEdit?.classList.contains("active");
+  if(!isSelf && editActive){
+    setTab("info");
+  }
 }
 
 function applyProfileMenuVisibility(){

--- a/public/index.html
+++ b/public/index.html
@@ -473,6 +473,7 @@
         <!-- Profile sheet header (custom layout, not a clone) -->
         <div class="profileSheetHero" id="profileSheetHero">
           <div class="profileSheetBg" id="profileSheetBg"></div>
+          <div class="profileSheetOverlay" id="profileSheetOverlay" aria-hidden="true"></div>
 
           <div class="profileSheetContent">
             <div class="profileSheetAvatarCard">
@@ -512,7 +513,7 @@
         </div>
 
           <div class="profileActions">
-            <div class="tabs profileActionTabs" id="tabs">
+            <div class="tabs profileActionTabs profileActionGrid" id="tabs">
             <button class="tab active" data-tab="info" id="tabInfo" type="button">
               <span class="tabIcon" aria-hidden="true">ℹ️</span>
               <span class="tabLabel">Info</span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -4591,13 +4591,49 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
   overflow: hidden;
   border: 1px solid rgba(255,255,255,.08);
   background: rgba(0,0,0,.25);
+  color: var(--profileHeaderText, #fff);
+  --profileHeaderTextShadow: 0 1px 4px rgba(0,0,0,.6);
+  --profileHeaderText: #fff;
+  --profileHeaderPillBg: rgba(0,0,0,.32);
+  --profileHeaderPillBorder: rgba(255,255,255,.18);
 }
 .profileSheetBg{
   height: 170px;
-  background:
-    radial-gradient(900px 260px at 70% 30%, rgba(255,180,80,.45), transparent 60%),
-    linear-gradient(135deg, rgba(255,106,43,.75), rgba(43,15,8,.85));
+  background: var(--profileHeaderBg, linear-gradient(135deg, rgba(255,106,43,.75), rgba(43,15,8,.85)));
   filter: saturate(1.08);
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+.profileSheetOverlay{
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  opacity: .55;
+  z-index: 0;
+  background: radial-gradient(120% 80% at 50% 10%, rgba(255,255,255,0.25), transparent 65%);
+}
+.profileSheetOverlay.role-owner{ box-shadow: 0 0 32px 4px rgba(140, 255, 110, 0.35), inset 0 0 40px rgba(80, 255, 160, 0.24); }
+.profileSheetOverlay.role-co-owner{ box-shadow: 0 0 36px 4px rgba(220, 110, 255, 0.30), inset 0 0 46px rgba(160, 90, 255, 0.24); }
+.profileSheetOverlay.role-admin{ box-shadow: 0 0 32px 2px rgba(255, 196, 64, 0.32), inset 0 0 36px rgba(255, 140, 40, 0.22); }
+.profileSheetOverlay.role-moderator{ box-shadow: 0 0 28px 2px rgba(255, 90, 90, 0.30), inset 0 0 32px rgba(200, 60, 60, 0.22); }
+.profileSheetOverlay.role-vip{
+  background: linear-gradient(120deg, rgba(110,210,255,0.35), rgba(190,230,255,0.05), rgba(110,210,255,0.35));
+  background-size: 220% 220%;
+  animation: profileShimmer 8s ease-in-out infinite;
+  opacity: .55;
+}
+.profileSheetOverlay.role-member, .profileSheetOverlay.role-user{ opacity: .18; mix-blend-mode: soft-light; }
+.profileSheetOverlay.role-guest{ opacity: .12; mix-blend-mode: soft-light; }
+
+@keyframes profileShimmer{
+  0%{ background-position: 0% 50%; }
+  50%{ background-position: 100% 50%; }
+  100%{ background-position: 0% 50%; }
+}
+
+@media (prefers-reduced-motion: reduce){
+  .profileSheetOverlay{ animation: none !important; transition: none !important; }
 }
 .profileSheetContent{
   display: grid;
@@ -4654,15 +4690,17 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
 .vibeRow{ display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .vibeChip{ background: rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.08); padding:2px 8px; border-radius:999px; font-size:11px; line-height:1.2; color:var(--text,#fff); }
 .vibeChip.mini{ font-size:10px; opacity:0.85; }
-.profileSheetMeta{ color: #fff; padding-bottom: 6px; }
+.profileSheetMeta{ color: var(--profileHeaderText, #fff); padding-bottom: 6px; text-shadow: var(--profileHeaderTextShadow, none); }
 .profileSheetNameRow{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
-.profileSheetName{ font-size: 22px; font-weight: 800; letter-spacing: .2px; }
+.profileSheetName{ font-size: 22px; font-weight: 800; letter-spacing: .2px; text-shadow: var(--profileHeaderTextShadow, none); }
 .profileRoleChip{
   font-size: 12px;
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,.18);
-  background: rgba(255,255,255,.08);
+  border: 1px solid var(--profileHeaderPillBorder, rgba(255,255,255,.18));
+  background: var(--profileHeaderPillBg, rgba(255,255,255,.08));
+  color: var(--profileHeaderText, #fff);
+  text-shadow: var(--profileHeaderTextShadow, none);
 }
 .profileSheetDetails{
   display:flex;
@@ -4673,14 +4711,17 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
 .profileDetail{
   padding:6px 10px;
   border-radius:12px;
-  border:1px solid rgba(255,255,255,.12);
-  background: rgba(0,0,0,.28);
+  border:1px solid var(--profileHeaderPillBorder, rgba(255,255,255,.12));
+  background: var(--profileHeaderPillBg, rgba(0,0,0,.28));
   font-size:12px;
+  color: var(--profileHeaderText, #fff);
+  text-shadow: var(--profileHeaderTextShadow, none);
 }
 .profileSheetSub{
   margin-top: 6px;
   font-size: 12px;
   opacity: .9;
+  text-shadow: var(--profileHeaderTextShadow, none);
 }
 .profileSheetStats{
   margin-top: 6px;
@@ -4692,14 +4733,28 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
 .statPill{
   padding: 6px 10px;
   border-radius: 999px;
-  border: 1px solid rgba(255,255,255,.12);
-  background: rgba(0,0,0,.25);
+  border: 1px solid var(--profileHeaderPillBorder, rgba(255,255,255,.12));
+  background: var(--profileHeaderPillBg, rgba(0,0,0,.25));
   font-size: 12px;
+  color: var(--profileHeaderText, #fff);
+  text-shadow: var(--profileHeaderTextShadow, none);
 }
 
-.profileActions{ display:flex; flex-direction:column; gap:10px; margin:6px 0 10px; }
-.profileActionTabs{ width:100%; flex-wrap:nowrap; grid-template-columns: repeat(4, minmax(72px, 1fr)); display:grid; }
-.profileActionTabs .tab{ aspect-ratio: 1; min-height:72px; }
+.profileActions{ display:flex; flex-direction:column; gap:8px; margin:6px 0 6px; }
+.profileActionTabs{ width:100%; flex-wrap:nowrap; display:grid; grid-template-columns: repeat(auto-fit, minmax(72px, 1fr)); gap:8px; margin:6px 0 4px; }
+.profileActionTabs .tab{
+  aspect-ratio: 1;
+  min-height: 78px;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 11px;
+  line-height: 1.2;
+}
+.profileActionTabs .tab .tabIcon{ font-size: 20px; }
+.profileActionTabs .tab .tabLabel{ white-space: normal; opacity: .9; font-weight: 800; }
 .profileQuickActions{ display:flex; gap:10px; align-items:center; justify-content:space-between; flex-wrap:wrap; }
 .quickActionGroup{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 .quickActionGroup .badge{ height:100%; display:flex; align-items:center; justify-content:center; }
@@ -4707,7 +4762,7 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
 .profileMenu{
   display: grid;
   gap: 10px;
-  margin: 10px 0 14px;
+  margin: 8px 0 10px;
 }
 .profileMenuRow{
   width: 100%;


### PR DESCRIPTION
## Summary
- apply dynamic profile header gradients with live preview, contrast-aware text, and role-based overlays
- redesign profile action buttons into compact grid tiles and tighten modal spacing
- ensure profile actions swap edit/add-friend appropriately while preserving existing behaviors

## Testing
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b3429111c8333a648600812dc5f22)