### PR TITLE
Fix profile sheet visibility and status handling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -568,6 +568,8 @@ const Sound = (() => {
 let socket = null;
 let me = null;
 let progression = { gold: 0, xp: 0, level: 1, xpIntoLevel: 0, xpForNextLevel: 100 };
+let activeProfileTab = "info";
+let currentProfileIsSelf = false;
 let currentRoom = "main";
 function displayRoomName(room){ return room==="diceroom" ? "Dice Room" : room; }
 
@@ -1178,6 +1180,12 @@ const refreshProfileBtn = document.getElementById("refreshProfileBtn");
 const profileMsg = document.getElementById("profileMsg");
 const logoutBtn = document.getElementById("logoutBtn");
 const logoutTopBtn = document.getElementById("logoutTopBtn");
+
+setMsgline(profileActionMsg, "");
+setMsgline(profileLikeMsg, "");
+setMsgline(mediaMsg, "");
+ensureVisibleOnFocus(editBio);
+ensureVisibleOnFocus(changelogBodyInput);
 const uiScaleBtn = document.getElementById("uiScaleBtn");
 const uiScalePanel = document.getElementById("uiScalePanel");
 const uiScaleCloseBtn = document.getElementById("uiScaleCloseBtn");
@@ -2117,10 +2125,10 @@ function computeProfileTextTheme(colorA, colorB){
 function buildProfileHeaderGradient(colorA, colorB){
   const a = sanitizeHexColorInput(colorA, PROFILE_GRADIENT_DEFAULT_A) || PROFILE_GRADIENT_DEFAULT_A;
   const b = sanitizeHexColorInput(colorB, PROFILE_GRADIENT_DEFAULT_B) || PROFILE_GRADIENT_DEFAULT_B;
-  return `
-    radial-gradient(900px 260px at 70% 30%, rgba(255,180,80,.45), transparent 60%),
-    linear-gradient(135deg, ${a}, ${b})
-  `;
+  const rgb = hexToRgb(a);
+  const highlight = rgb ? `radial-gradient(900px 260px at 70% 30%, rgba(${rgb.r},${rgb.g},${rgb.b},0.28), transparent 60%)` : "";
+  const layers = [highlight, `linear-gradient(135deg, ${a}, ${b})`].filter(Boolean);
+  return layers.join(", ");
 }
 function applyProfileHeaderOverlay(role){
   if(!profileSheetOverlay) return;
@@ -3142,6 +3150,25 @@ function updateGoldUI(){
   }
 }
 
+function levelInfoClient(xpRaw){
+  let xp = Math.max(0, Math.floor(Number(xpRaw) || 0));
+  let level = 1;
+  let remaining = xp;
+  while (remaining >= level * 100) {
+    remaining -= level * 100;
+    level += 1;
+  }
+  const xpForNextLevel = level * 100;
+  return { level, xpIntoLevel: remaining, xpForNextLevel };
+}
+
+function deriveProfileLevel(info){
+  const levelVal = Number(info?.level);
+  if (Number.isFinite(levelVal) && levelVal > 0) return levelVal;
+  if (info && info.xp != null) return levelInfoClient(info.xp).level;
+  return progression.level || 1;
+}
+
 function renderLevelProgress(data, isSelf){
   const info = data || progression || {};
   const levelVal = Number(info.level || progression.level || 1);
@@ -3168,6 +3195,13 @@ function applyProgressionPayload(payload){
     if (payload.xp != null) next.xp = Number(payload.xp || 0);
     if (payload.xpIntoLevel != null) next.xpIntoLevel = Number(payload.xpIntoLevel || 0);
     if (payload.xpForNextLevel != null) next.xpForNextLevel = Number(payload.xpForNextLevel || 100);
+
+    if (payload.level == null && payload.xp != null) {
+      const calc = levelInfoClient(payload.xp);
+      next.level = calc.level;
+      if (payload.xpIntoLevel == null) next.xpIntoLevel = calc.xpIntoLevel;
+      if (payload.xpForNextLevel == null) next.xpForNextLevel = calc.xpForNextLevel;
+    }
   }
   progression = next;
   updateGoldUI();
@@ -4691,6 +4725,7 @@ function focusActiveTab(){
   active?.scrollIntoView({ behavior:"smooth", inline:"center", block:"nearest" });
 }
 function setTab(tab){
+  activeProfileTab = tab;
   for(const el of document.querySelectorAll(".tab")){
     el.classList.toggle("active", el.dataset.tab===tab);
   }
@@ -4699,6 +4734,7 @@ function setTab(tab){
   viewEdit.style.display = tab==="edit" ? "block" : "none";
   viewModeration.style.display = tab==="moderation" ? "block" : "none";
   if(tab === "edit") showEditPanel("about");
+  syncProfileEditUi();
   focusActiveTab();
 }
 tabEdit.addEventListener("click", ()=>setTab("edit"));
@@ -4747,7 +4783,7 @@ function closeModal(){
   quickModMsg.textContent="";
   modMsg.textContent="";
   logsMsg.textContent="";
-  mediaMsg.textContent="";
+  setMsgline(mediaMsg, "");
   if (customizeMsg) customizeMsg.textContent = "";
 }
 closeModalBtn.addEventListener("click", closeModal);
@@ -5425,6 +5461,29 @@ async function loadMyProfile(){
   renderVibeOptions(me.vibe_tags || []);
 }
 
+function setMsgline(el, text){
+  if(!el) return;
+  const raw = text == null ? "" : String(text);
+  const visible = raw.trim().length > 0;
+  el.textContent = raw;
+  el.style.display = visible ? "" : "none";
+}
+
+function formatLastSeen(val){
+  const hasVal = val !== undefined && val !== null && String(val).trim() !== "";
+  return hasVal ? fmtAbs(val) : "—";
+}
+
+function ensureVisibleOnFocus(el){
+  if(!el || el._visibleHooked) return;
+  el._visibleHooked = true;
+  el.addEventListener("focus", () => {
+    setTimeout(() => {
+      try { el.scrollIntoView({ block: "center", behavior: "smooth" }); } catch {}
+    }, 60);
+  });
+}
+
 function renderVibeChips(targetEl, tags){
   if(!targetEl) return;
   const vibes = sanitizeVibeTagsClient(tags);
@@ -5540,6 +5599,8 @@ function isSelfProfile(p){
 }
 
 function fillProfileUI(p, isSelf){
+  currentProfileIsSelf = !!isSelf;
+
   if (modalAvatar){
     modalAvatar.innerHTML="";
     modalAvatar.appendChild(avatarNode(p.avatar, p.username, p.role));
@@ -5554,7 +5615,7 @@ function fillProfileUI(p, isSelf){
   infoAge.textContent = (p.age ?? "—");
   infoGender.textContent = (p.gender ?? "—");
   infoCreated.textContent = fmtCreated(p.created_at);
-  infoLastSeen.textContent = p.last_seen ? fmtAbs(p.last_seen) : "—";
+  infoLastSeen.textContent = formatLastSeen(p.last_seen);
   infoRoom.textContent = p.current_room ? `#${p.current_room}` : (p.last_room ? `#${p.last_room}` : "—");
   const statusLabel = normalizeStatusLabel(p.last_status, "");
   infoStatus.textContent = statusLabel || "—";
@@ -5562,11 +5623,12 @@ function fillProfileUI(p, isSelf){
   bioRender.innerHTML = p.bio ? renderBBCode(p.bio) : "(no bio)";
   renderLevelProgress(p, isSelf);
   syncProfileLikes(p, isSelf);
-  if (profileLikeMsg) profileLikeMsg.textContent = "";
-  if (profileActionMsg) profileActionMsg.textContent = "";
-  if (mediaMsg) mediaMsg.textContent = "";
+  setMsgline(profileLikeMsg, "");
+  setMsgline(profileActionMsg, "");
+  setMsgline(mediaMsg, "");
   renderVibeChips(profileVibes, p.vibe_tags);
   fillProfileSheetHeader(p, isSelf);
+  syncProfileEditUi();
 }
 
 
@@ -5614,7 +5676,7 @@ function fillProfileSheetHeader(p, isSelf){
   if (profileSheetSub) profileSheetSub.textContent = `${mood} ${status} ${room}`.trim();
   renderVibeChips(profileSheetVibes, p.vibe_tags);
 
-  // Stats (likes are real; "stars" is a placeholder hook you can wire later)
+  // Stats (likes are real; stars show level)
   if (profileSheetStats){
     profileSheetStats.style.display = "flex";
     if (profileSheetLikes){
@@ -5622,28 +5684,28 @@ function fillProfileSheetHeader(p, isSelf){
       profileSheetLikes.textContent = `${isSelf ? "❤️" : (p.likedByMe ? "❤️" : "♡")} ${likesVal.toLocaleString()}`;
     }
     if (profileSheetStars){
-      // If you later add "stars" / "reputation", set p.stars and it will display automatically.
-      const starsVal = Number(p.stars || 0);
-      profileSheetStars.textContent = `⭐ ${starsVal.toLocaleString()}`;
+      const levelVal = deriveProfileLevel(p);
+      profileSheetStars.textContent = `⭐ ${levelVal.toLocaleString()}`;
     }
   }
+}
 
-  // Avatar action buttons only for self
-  if (profileSheetAvatarActions){
-    profileSheetAvatarActions.style.display = isSelf ? "flex" : "none";
-  }
+function syncProfileEditUi(){
+  const showAvatarActions = currentProfileIsSelf && activeProfileTab === "edit";
+  if (profileSheetAvatarActions) profileSheetAvatarActions.style.display = showAvatarActions ? "flex" : "none";
 }
 
 function updateProfileActions({ isSelf = false, canModerate = false } = {}){
   if (tabEdit) tabEdit.style.display = isSelf ? "" : "none";
   if (viewEdit && !isSelf) viewEdit.style.display = "none";
   if (addFriendBtn) addFriendBtn.style.display = isSelf ? "none" : "";
-  if (profileActionMsg) profileActionMsg.textContent = "";
+  setMsgline(profileActionMsg, "");
   if (tabModeration) tabModeration.style.display = canModerate ? "" : "none";
   const editActive = tabEdit?.classList.contains("active");
   if(!isSelf && editActive){
     setTab("info");
   }
+  syncProfileEditUi();
 }
 
 function applyProfileMenuVisibility(){
@@ -5956,19 +6018,19 @@ async function openMemberProfile(username){
 
 likeProfileBtn?.addEventListener("click", async () => {
   if (!modalTargetUsername || likeProfileBtn.disabled) return;
-  profileLikeMsg.textContent = "";
+  setMsgline(profileLikeMsg, "");
   likeProfileBtn.disabled = true;
   try {
     const res = await fetch(`/profile/${encodeURIComponent(modalTargetUsername)}/like`, { method: "POST" });
     if (!res.ok) {
       const t = await res.text().catch(() => "");
-      profileLikeMsg.textContent = t || "Could not update like.";
+      setMsgline(profileLikeMsg, t || "Could not update like.");
       return;
     }
     const data = await res.json();
     syncProfileLikes({ likes: data.likes, likedByMe: data.liked }, false);
   } catch (err) {
-    profileLikeMsg.textContent = "Could not update like.";
+    setMsgline(profileLikeMsg, "Could not update like.");
   } finally {
     const isSelf = normKey(modalTargetUsername) === normKey(me?.username);
     likeProfileBtn.disabled = isSelf;
@@ -5977,14 +6039,14 @@ likeProfileBtn?.addEventListener("click", async () => {
 
 addFriendBtn?.addEventListener("click", () => {
   if (addFriendBtn.disabled) return;
-  if (profileActionMsg) profileActionMsg.textContent = "Friend system coming soon.";
+  setMsgline(profileActionMsg, "Friend system coming soon.");
 });
 
 // media actions
 copyUsernameBtn.addEventListener("click", async ()=>{
   const u = modalTargetUsername || me?.username || "";
-  try{ await navigator.clipboard.writeText(u); mediaMsg.textContent="Copied username."; }
-  catch{ mediaMsg.textContent="Copy failed (browser blocked)."; }
+  try{ await navigator.clipboard.writeText(u); setMsgline(mediaMsg, "Copied username."); }
+  catch{ setMsgline(mediaMsg, "Copy failed (browser blocked)."); }
 });
 saveBadgePrefsBtn?.addEventListener("click", () => {
   const directRaw = directBadgeColorText?.value || directBadgeColor?.value || badgePrefs.direct || badgeDefaults.direct;

--- a/public/styles.css
+++ b/public/styles.css
@@ -2428,12 +2428,12 @@ body.dice-room .sys .diceFace{
   inset: 0;
   background: rgba(0,0,0,0.55);
   display: none;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   overflow: auto;
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
-padding: 18px;
+  padding: 18px;
   z-index: 400;
 }
 .modalCard{
@@ -2443,13 +2443,16 @@ padding: 18px;
   overflow: hidden;
   background: var(--panel);
   border-radius: 14px;
+  margin-top: 10px;
 }
 
 
 /* Wider, cleaner modal on desktop */
 @media (min-width: 761px){
+  #modal{ align-items: center; }
   .modalCard{
     width: min(980px, calc(100vw - 48px));
+    margin-top: 0;
   }
   .modalBody{
     padding: 0 18px 18px;
@@ -2663,7 +2666,11 @@ padding: 18px;
   cursor:pointer;
   font-weight:800;
 }
-.pillBtn.active{ background:var(--panel); box-shadow: var(--shadowSm); }
+.pillBtn.active{
+  background: color-mix(in srgb, var(--panel) 88%, var(--brand) 18%);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--brand) 35%, transparent), var(--shadowSm);
+  border-color: color-mix(in srgb, var(--brand) 35%, var(--border));
+}
 .themeGrid{ display:grid; grid-template-columns: 1fr 1fr; gap:14px; align-items:start; }
 
 .themeGrid.oneColumn{ grid-template-columns: 1fr; }

--- a/server.js
+++ b/server.js
@@ -1632,6 +1632,17 @@ function progressionFromRow(row, includePrivate) {
   return base;
 }
 
+function resolveLastSeen(row, live, lastStatus) {
+  const raw = row?.last_seen;
+  const hasRaw = raw !== undefined && raw !== null && String(raw).trim() !== "";
+  const num = Number(raw);
+  if (hasRaw && Number.isFinite(num)) return num;
+
+  const statusLabel = normalizeStatus(lastStatus || row?.last_status, "");
+  const isOnline = !!live || statusLabel === "Online";
+  return isOnline ? Date.now() : null;
+}
+
 function emitProgressionUpdate(userId) {
   const sid = socketIdByUserId.get(userId);
   if (!sid) return;
@@ -2813,6 +2824,7 @@ app.get("/profile", requireLogin, async (req, res) => {
 
       const live = onlineState.get(row.id);
       const lastStatus = normalizeStatus(live?.status || row.last_status, "");
+      const lastSeen = resolveLastSeen(row, live, lastStatus);
 
       // Likes are stored in sqlite in this codebase; keep using it
       db.get(
@@ -2832,7 +2844,7 @@ app.get("/profile", requireLogin, async (req, res) => {
             age: row.age,
             gender: row.gender,
           created_at: row.created_at,
-          last_seen: row.last_seen,
+          last_seen: lastSeen,
           last_room: row.last_room,
           last_status: lastStatus || null,
           current_room: live?.room || null,
@@ -2861,6 +2873,7 @@ app.get("/profile", requireLogin, async (req, res) => {
       if (err || !row) return res.status(404).send("Not found");
       const live = onlineState.get(row.id);
       const lastStatus = normalizeStatus(live?.status || row.last_status, "");
+      const lastSeen = resolveLastSeen(row, live, lastStatus);
       db.get(
         `SELECT
           (SELECT COUNT(*) FROM profile_likes WHERE target_user_id = ?) AS likes,
@@ -2878,10 +2891,12 @@ app.get("/profile", requireLogin, async (req, res) => {
             age: row.age,
             gender: row.gender,
             created_at: row.created_at,
-            last_seen: row.last_seen,
+            last_seen: lastSeen,
             last_room: row.last_room,
             last_status: lastStatus || null,
             current_room: live?.room || null,
+            header_grad_a: sanitizeHexColor(row.header_grad_a),
+            header_grad_b: sanitizeHexColor(row.header_grad_b),
             likes: Number(likesRow?.likes || 0),
             likedByMe: !!Number(likesRow?.liked || 0),
             vibe_tags: sanitizeVibeTags(row.vibe_tags || []),
@@ -2922,7 +2937,6 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
           if (row) break;
         } catch {}
       }
-      row = r.rows?.[0] || null;
     } catch {}
 
     // Fallback to SQLite
@@ -2942,6 +2956,7 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
 
     const live = onlineState.get(row.id);
     const lastStatus = normalizeStatus(live?.status || row.last_status, "");
+    const lastSeen = resolveLastSeen(row, live, lastStatus);
     const includePrivate = req.session.user.id === row.id;
 
     db.get(
@@ -2961,7 +2976,7 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
           age: row.age,
           gender: row.gender,
           created_at: row.created_at,
-          last_seen: row.last_seen,
+          last_seen: lastSeen,
           last_room: row.last_room,
           last_status: lastStatus || null,
           current_room: live?.room || null,


### PR DESCRIPTION
## Summary
- ensure profile endpoints always include sanitized gradients, robust last seen timestamps, and fix the Postgres lookup regression
- refresh profile sheet UI: level badge shows XP level, gradients drop the yellow tint, msglines hide when empty, and avatar actions only appear in edit mode
- improve mobile/editor usability with clearer vibe tag highlights and focus/layout tweaks to avoid hidden inputs while typing

## Testing
- node --check server.js
- node --check public/app.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b3cb3dff8833388a46d4ddda88d29)