### PR TITLE
Add changelog reactions and bio helper, improve iOS touch handling

### DIFF
--- a/database.js
+++ b/database.js
@@ -225,6 +225,18 @@ async function runSqliteMigrations() {
   await run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_changelog_seq ON changelog_entries(seq)`);
 
   await run(`
+    CREATE TABLE IF NOT EXISTS changelog_reactions (
+      entry_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      reaction TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      UNIQUE(entry_id, user_id, reaction)
+    )
+  `);
+  await run(`CREATE INDEX IF NOT EXISTS idx_changelog_react_entry ON changelog_reactions(entry_id)`);
+  await run(`CREATE INDEX IF NOT EXISTS idx_changelog_react_user ON changelog_reactions(user_id)`);
+
+  await run(`
     CREATE TABLE IF NOT EXISTS command_audit (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       executor_id INTEGER NOT NULL,

--- a/public/app.js
+++ b/public/app.js
@@ -3,6 +3,7 @@
 
 // Debug hook: enable tap hit-testing logs by setting `window.__TAP_DEBUG__ = true` in the console.
 window.__TAP_DEBUG__ = window.__TAP_DEBUG__ ?? false;
+const IS_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 
 // ---- Theme registry with tiers
 const THEMES = [
@@ -41,7 +42,7 @@ const THEMES = [
     dmScroller: ".dmPanel .dmMessages, #dmModal .dmMessages, .dmMsgs, .messages"
   };
 
-  const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+  const isIOS = IS_IOS;
   if(body) body.classList.toggle("ios", isIOS);
 
   let raf = 0;
@@ -330,6 +331,45 @@ const THEMES = [
   ["pointerdown", "touchstart"].forEach(evt => {
     document.addEventListener(evt, logTap, { capture:true, passive:true });
   });
+})();
+
+// ---- iOS double-tap zoom guard (layered atop CSS/meta)
+(function initIosDoubleTapGuard(){
+  try{
+    if(!IS_IOS || !document?.addEventListener) return;
+    let lastTapTs = 0;
+    let lastX = 0;
+    let lastY = 0;
+    const radius = 20;
+    const thresholdMs = 320;
+    const formSelector = "input, textarea, select, option, [contenteditable='true']";
+    const linkSelector = "a[href]";
+
+    const onTouchEnd = (ev) => {
+      try{
+        if(ev.touches && ev.touches.length > 1) { lastTapTs = 0; return; }
+        const touch = ev.changedTouches && ev.changedTouches[0];
+        if(!touch) return;
+        const target = ev.target;
+        const now = Date.now();
+        const dx = touch.clientX - lastX;
+        const dy = touch.clientY - lastY;
+        const dist = Math.hypot(dx, dy);
+        const isForm = !!(target && target.closest && target.closest(formSelector));
+        const isLink = !!(target && target.closest && target.closest(linkSelector));
+
+        if(!isForm && !isLink && now - lastTapTs > 0 && now - lastTapTs < thresholdMs && dist < radius){
+          ev.preventDefault();
+        }
+
+        lastTapTs = now;
+        lastX = touch.clientX;
+        lastY = touch.clientY;
+      }catch{}
+    };
+
+    document.addEventListener("touchend", onTouchEnd, { passive:false, capture:true });
+  }catch{}
 })();
 
 /* ---- Focus visibility helper (keep inputs inside their scroll shells) ---- */
@@ -730,6 +770,9 @@ let activeMenuTab = "changelog";
 let changelogEntries = [];
 let changelogLoaded = false;
 let changelogDirty = false;
+const CHANGELOG_REACTION_KEYS = ["heart", "clap", "down", "eyes"];
+const CHANGELOG_REACTION_EMOJI = { heart:"♥️", clap:"👏", down:"👎", eyes:"👀" };
+const changelogReactionBusy = new Set();
 let editingChangelogId = null;
 let latestChangelogEntry = null;
 let leaderboardsLoaded = false;
@@ -1175,6 +1218,10 @@ const editAge = document.getElementById("editAge");
 const editGender = document.getElementById("editGender");
 const vibeTagOptions = document.getElementById("vibeTagOptions");
 const editBio = document.getElementById("editBio");
+const bioHelperToggle = document.getElementById("bioHelperToggle");
+const bioHelper = document.getElementById("bioHelper");
+const bioHelperPreview = document.getElementById("bioHelperPreview");
+const bioHelperButtons = document.getElementById("bioHelperButtons");
 const saveProfileBtn = document.getElementById("saveProfileBtn");
 const refreshProfileBtn = document.getElementById("refreshProfileBtn");
 const profileMsg = document.getElementById("profileMsg");
@@ -1192,6 +1239,92 @@ const uiScaleCloseBtn = document.getElementById("uiScaleCloseBtn");
 const uiScaleRange = document.getElementById("uiScaleRange");
 const uiScaleValue = document.getElementById("uiScaleValue");
 const uiScaleResetBtn = document.getElementById("uiScaleResetBtn");
+
+let bioPreviewTimer = null;
+function renderBioPreview(){
+  if(!bioHelperPreview || !editBio) return;
+  bioHelperPreview.innerHTML = renderBBCode(editBio.value || "");
+}
+
+function scheduleBioPreview(){
+  if(bioPreviewTimer) clearTimeout(bioPreviewTimer);
+  bioPreviewTimer = setTimeout(renderBioPreview, 90);
+}
+
+function toggleBioHelperPanel(){
+  if(!bioHelper) return;
+  const isHidden = bioHelper.hasAttribute("hidden");
+  if(isHidden){
+    bioHelper.removeAttribute("hidden");
+    scheduleBioPreview();
+  } else {
+    bioHelper.setAttribute("hidden", "");
+  }
+}
+
+function insertBioTag(tag){
+  if(!editBio) return;
+  const start = editBio.selectionStart ?? editBio.value.length;
+  const end = editBio.selectionEnd ?? start;
+  const selection = editBio.value.slice(start, end);
+  let before = "";
+  let after = "";
+  let body = selection;
+
+  switch(tag){
+    case "b": before = "[b]"; after = "[/b]"; break;
+    case "i": before = "[i]"; after = "[/i]"; break;
+    case "u": before = "[u]"; after = "[/u]"; break;
+    case "s": before = "[s]"; after = "[/s]"; break;
+    case "quote": before = "[quote]"; after = "[/quote]"; break;
+    case "code": before = "[code]"; after = "[/code]"; break;
+    case "url": {
+      const url = prompt("Enter URL", selection || "https://");
+      if(!url) return;
+      before = `[url=${url}]`;
+      after = "[/url]";
+      body = selection || "link text";
+      break;
+    }
+    case "color": {
+      const color = prompt("Color (hex or name)", selection || "#ff6b6b");
+      if(!color) return;
+      before = `[color=${color}]`;
+      after = "[/color]";
+      body = selection || "text";
+      break;
+    }
+    case "img": {
+      const url = selection || prompt("Image URL", "https://");
+      if(!url) return;
+      before = "[img]";
+      after = "[/img]";
+      body = url;
+      break;
+    }
+    default: return;
+  }
+
+  const snippet = `${before}${body || ""}${after}`;
+  editBio.setRangeText(snippet, start, end, "end");
+  scheduleBioPreview();
+  editBio.focus();
+}
+
+if(bioHelperButtons){
+  bioHelperButtons.addEventListener("click", (ev)=>{
+    const target = ev.target;
+    if(!(target instanceof HTMLElement)) return;
+    const tag = target.dataset?.bioTag;
+    if(tag) insertBioTag(tag);
+  });
+}
+if(bioHelperToggle){
+  bioHelperToggle.addEventListener("click", toggleBioHelperPanel);
+}
+if(editBio){
+  editBio.addEventListener("input", scheduleBioPreview, { passive:true });
+}
 
 // member quick mod
 const memberModTools = document.getElementById("memberModTools");
@@ -5106,6 +5239,31 @@ function closeChangelogEditor(){
   if(changelogEditMsg) changelogEditMsg.textContent = "";
 }
 
+function emptyChangelogReactions(){
+  return { heart:0, clap:0, down:0, eyes:0 };
+}
+
+function emptyMyChangelogReactions(){
+  return { heart:false, clap:false, down:false, eyes:false };
+}
+
+function normalizeChangelogEntry(entry){
+  if(!entry) return null;
+  const base = { ...entry };
+  base.reactions = { ...emptyChangelogReactions(), ...(entry.reactions || {}) };
+  base.myReactions = { ...emptyMyChangelogReactions(), ...(entry.myReactions || {}) };
+  return base;
+}
+
+function updateChangelogEntryState(entryId, next){
+  if(!entryId) return;
+  const idx = changelogEntries.findIndex(e => e && e.id === entryId);
+  if(idx >= 0){
+    const merged = normalizeChangelogEntry({ ...changelogEntries[idx], ...(next || {}) });
+    if(merged) changelogEntries[idx] = merged;
+  }
+}
+
 async function loadChangelog(force=false){
   if(!force && changelogLoaded && !changelogDirty) return;
   if(changelogMsg) changelogMsg.textContent = "Loading changelog...";
@@ -5119,7 +5277,8 @@ async function loadChangelog(force=false){
 
   try{
     const rows = JSON.parse(text || "[]");
-    changelogEntries = Array.isArray(rows) ? rows : [];
+    changelogEntries = Array.isArray(rows) ? rows.map(normalizeChangelogEntry).filter(Boolean) : [];
+    changelogReactionBusy.clear();
   }catch{
     changelogEntries = [];
   }
@@ -5222,9 +5381,56 @@ function renderChangelogList(){
     body.className = "changelogBody";
     body.innerHTML = escapeHtml(entry.body || "").replace(/\n/g, "<br>");
 
+    const reactions = entry.reactions || emptyChangelogReactions();
+    const myReactions = entry.myReactions || emptyMyChangelogReactions();
+    const reactionRow = document.createElement("div");
+    reactionRow.className = "changelogReactions";
+    const entryBusy = changelogReactionBusy.has(entry.id);
+    for(const key of CHANGELOG_REACTION_KEYS){
+      const btn = document.createElement("button");
+      btn.type = "button";
+      btn.className = "changelogReactionBtn";
+      btn.dataset.reaction = key;
+      btn.textContent = `${CHANGELOG_REACTION_EMOJI[key] || key} ${Number(reactions[key] ?? 0)}`;
+      btn.classList.toggle("active", !!myReactions[key]);
+      btn.disabled = entryBusy;
+      btn.addEventListener("click", ()=>toggleChangelogReaction(entry.id, key));
+      reactionRow.appendChild(btn);
+    }
+
     wrap.appendChild(header);
     wrap.appendChild(body);
+    wrap.appendChild(reactionRow);
     changelogList.appendChild(wrap);
+  }
+}
+
+async function toggleChangelogReaction(entryId, reaction){
+  if(!entryId || !reaction) return;
+  if(changelogReactionBusy.has(entryId)) return;
+  changelogReactionBusy.add(entryId);
+  renderChangelogList();
+
+  try{
+    const {res, text} = await api(`/api/changelog/${entryId}/reaction`, {
+      method: "POST",
+      headers:{"Content-Type":"application/json"},
+      body: JSON.stringify({ reaction })
+    });
+
+    if(!res.ok){
+      if(changelogMsg) changelogMsg.textContent = text || "Failed to update reaction.";
+    }else{
+      try{
+        const payload = JSON.parse(text || "{}") || {};
+        updateChangelogEntryState(entryId, payload);
+      }catch{}
+    }
+  }catch{
+    if(changelogMsg) changelogMsg.textContent = "Failed to update reaction.";
+  }finally{
+    changelogReactionBusy.delete(entryId);
+    renderChangelogList();
   }
 }
 
@@ -6065,6 +6271,7 @@ modalTargetUsername = p.username;
   editAge.value=(p.age ?? "");
   editGender.value=p.gender||"";
   editBio.value=p.bio||"";
+  scheduleBioPreview();
   selectedVibeTags = sanitizeVibeTagsClient(p.vibe_tags);
   renderVibeOptions(selectedVibeTags);
   syncHeaderGradientInputs(p.header_grad_a, p.header_grad_b);
@@ -6448,6 +6655,10 @@ socket.on("disconnect", (reason) => {
     changelogDirty = true;
     if(rightPanelMode === "menu" && activeMenuTab === "changelog") loadChangelog(true);
     loadLatestUpdateSnippet();
+  });
+  socket.on("changelog reactions updated", ()=>{
+    changelogDirty = true;
+    if(rightPanelMode === "menu" && activeMenuTab === "changelog") loadChangelog(true);
   });
   await loadRooms();
   await loadLatestUpdateSnippet();

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
 <title>Banter &amp; Brats</title>
   <script src="/theme-init.js"></script>
   <link rel="stylesheet" href="/styles.css">
@@ -709,8 +709,26 @@
                         </div>
 
                         <div class="field">
-                          <label>Bio (BBCode supported)</label>
+                          <div class="fieldLabelRow">
+                            <label>Bio (BBCode supported)</label>
+                            <button class="pillBtn small" id="bioHelperToggle" type="button">BBCode help &amp; preview</button>
+                          </div>
                           <textarea id="editBio" placeholder="[b]bold[/b] [i]italics[/i] [url=https://...]link[/url] [quote]...[/quote]"></textarea>
+                          <div class="bioHelper" id="bioHelper" hidden>
+                            <div class="bioHelperRow" id="bioHelperButtons">
+                              <button type="button" class="pillBtn tiny" data-bio-tag="b">[b][/b]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="i">[i][/i]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="u">[u][/u]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="s">[s][/s]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="quote">[quote][/quote]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="code">[code][/code]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="url">[url]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="color">[color]</button>
+                              <button type="button" class="pillBtn tiny" data-bio-tag="img">[img]</button>
+                            </div>
+                            <div class="bioHelperPreview" id="bioHelperPreview"></div>
+                            <div class="small muted">Use BBCode for simple formatting. Links/images require full URLs.</div>
+                          </div>
                         </div>
 
                         <div class="row">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1531,6 +1531,7 @@ body{
   color:var(--text);
   height: var(--vvhPx);
   overflow:hidden;
+  touch-action: manipulation;
 }
 .msgs,
 .dmMessages,
@@ -1641,6 +1642,7 @@ button{ font-family:inherit; }
 /* Shared form primitives */
 .field{ display:flex; flex-direction:column; gap:6px; margin:10px 0; }
 .field label{ font-size:12px; color:var(--muted); }
+.fieldLabelRow{ display:flex; align-items:center; justify-content:space-between; gap:8px; flex-wrap:wrap; }
 .field input, textarea, select{
   padding:11px 12px;
   border-radius:var(--radiusMd);
@@ -1676,6 +1678,29 @@ button{ font-family:inherit; }
   border-color: color-mix(in oklab, var(--brand) 55%, var(--border));
   box-shadow: 0 0 0 3px rgba(120,120,255,0.15);
 }
+.bioHelper{
+  margin-top:8px;
+  padding:10px;
+  border:1px solid var(--border);
+  border-radius:var(--radiusMd);
+  background:color-mix(in srgb, var(--panel) 85%, transparent);
+  box-shadow: var(--shadowSm);
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  max-height:260px;
+  overflow:auto;
+}
+.bioHelperRow{ display:flex; flex-wrap:wrap; gap:6px; }
+.bioHelperPreview{
+  border:1px dashed var(--border);
+  border-radius:var(--radiusSm);
+  padding:8px;
+  min-height:42px;
+  background:var(--panel);
+  overflow:auto;
+}
+.pillBtn.tiny{ padding:4px 8px; font-size:12px; }
 textarea{ min-height:90px; resize:vertical; }
 
 .colorInputRow{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
@@ -1815,8 +1840,8 @@ main.chat{
   color:var(--text);
 }
 .menuTab.active{ background:var(--panel2); box-shadow:var(--shadowSm); }
-.menuContent{ flex:1; display:flex; flex-direction:column; gap:10px; min-height:0; overflow:auto; padding:2px; }
-.menuSection{ display:none; flex-direction:column; gap:10px; }
+.menuContent{ flex:1; display:flex; flex-direction:column; gap:10px; min-height:0; overflow-y:auto; padding:2px; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
+.menuSection{ display:none; flex-direction:column; gap:10px; min-height:0; }
 .menuSection.active{ display:flex; }
 .menuSectionHeader{ display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
 .leaderboardGrid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(240px, 1fr)); gap:12px; }
@@ -1861,13 +1886,30 @@ main.chat{
   max-width: 100%;
 }
 
-.changelogList{ display:flex; flex-direction:column; gap:10px; min-height:0; }
+.changelogList{ display:flex; flex-direction:column; gap:10px; min-height:0; touch-action: pan-y; }
 .changelogEntry{ padding:10px; border-radius:var(--radiusLg); border:1px solid var(--border); background:var(--panel); box-shadow:var(--shadowSm); }
 .changelogEntryHeader{ display:flex; align-items:center; justify-content:space-between; gap:10px; flex-wrap:wrap; }
 .changelogEntryTitle{ font-weight:800; }
 .changelogEntryMeta{ font-size:12px; color:var(--muted); }
 .changelogBody{ margin-top:6px; white-space:pre-line; }
 .changelogActions{ display:flex; gap:6px; flex-wrap:wrap; }
+.changelogReactions{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:10px; }
+.changelogReactionBtn{
+  display:inline-flex;
+  gap:6px;
+  align-items:center;
+  border-radius:999px;
+  border:1px solid var(--border);
+  background:color-mix(in srgb, var(--panel) 80%, transparent);
+  color:var(--text);
+  padding:6px 10px;
+  cursor:pointer;
+  font-weight:700;
+  transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.changelogReactionBtn:hover{ background:color-mix(in srgb, var(--panel) 90%, transparent); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
+.changelogReactionBtn:disabled{ opacity:0.6; cursor:wait; }
+.changelogReactionBtn.active{ background:color-mix(in srgb, var(--accent) 28%, var(--panel)); border-color: color-mix(in srgb, var(--accent) 40%, var(--border)); box-shadow:var(--shadowSm); }
 .chan{
   padding:9px 10px;
   border-radius:var(--radiusMd);

--- a/server.js
+++ b/server.js
@@ -211,6 +211,15 @@ const pgInitPromise = (async () => {
         updated_at BIGINT,
         author_id INTEGER REFERENCES users(id) ON DELETE SET NULL
       );
+      CREATE TABLE IF NOT EXISTS changelog_reactions (
+        entry_id INTEGER NOT NULL,
+        user_id INTEGER NOT NULL,
+        reaction TEXT NOT NULL,
+        created_at BIGINT NOT NULL,
+        CONSTRAINT changelog_reactions_unique UNIQUE(entry_id, user_id, reaction)
+      );
+      CREATE INDEX IF NOT EXISTS idx_changelog_react_entry ON changelog_reactions(entry_id);
+      CREATE INDEX IF NOT EXISTS idx_changelog_react_user ON changelog_reactions(user_id);
     `);
 // Fix camelCase columns that Postgres lowercased previously
 // ---- Fix camelCase timestamp columns Postgres lowercased
@@ -1969,6 +1978,20 @@ function requireLogin(req, res, next) {
 
 const CHANGELOG_TITLE_MAX = 120;
 const CHANGELOG_BODY_MAX = 8000;
+const CHANGELOG_REACTIONS = ["heart", "clap", "down", "eyes"];
+
+function emptyChangelogReactions(){
+  return { heart:0, clap:0, down:0, eyes:0 };
+}
+
+function emptyMyChangelogReactions(){
+  return { heart:false, clap:false, down:false, eyes:false };
+}
+
+function normalizeReactionKey(reaction){
+  const key = String(reaction || "").toLowerCase();
+  return CHANGELOG_REACTIONS.includes(key) ? key : null;
+}
 
 function requireOwner(req, res, next) {
   if (!req.session?.user?.id) return res.status(401).send("Not logged in");
@@ -1991,6 +2014,8 @@ function toChangelogPayload(row) {
     createdAt: normalizeEpoch(row.created_at),
     updatedAt: normalizeEpoch(row.updated_at),
     authorId: row.author_id,
+    reactions: row.reactions || emptyChangelogReactions(),
+    myReactions: row.myReactions || emptyMyChangelogReactions(),
   };
 }
 
@@ -2033,6 +2058,65 @@ async function pgAllChangelog(limit = 0){
   return rows;
 }
 
+async function pgChangelogByIds(ids = []){
+  await pgInitPromise;
+  if(!ids?.length) return [];
+  const { rows } = await pgPool.query(
+    "SELECT id, seq, title, body, created_at, updated_at, author_id FROM changelog_entries WHERE id = ANY($1) ORDER BY seq DESC",
+    [ids]
+  );
+  return rows;
+}
+
+async function pgFetchChangelogReactionCounts(entryIds = []){
+  if(!entryIds.length) return {};
+  const map = {};
+  const { rows } = await pgPool.query(
+    "SELECT entry_id, reaction, COUNT(*) as count FROM changelog_reactions WHERE entry_id = ANY($1) GROUP BY entry_id, reaction",
+    [entryIds]
+  );
+  for(const row of rows || []){
+    const id = Number(row.entry_id);
+    const key = normalizeReactionKey(row.reaction);
+    if(!id || !key) continue;
+    if(!map[id]) map[id] = emptyChangelogReactions();
+    map[id][key] = Number(row.count) || 0;
+  }
+  return map;
+}
+
+async function pgFetchChangelogUserReactions(entryIds = [], userId){
+  if(!entryIds.length || !userId) return {};
+  const mine = {};
+  const { rows } = await pgPool.query(
+    "SELECT entry_id, reaction FROM changelog_reactions WHERE entry_id = ANY($1) AND user_id=$2",
+    [entryIds, userId]
+  );
+  for(const row of rows || []){
+    const id = Number(row.entry_id);
+    const key = normalizeReactionKey(row.reaction);
+    if(!id || !key) continue;
+    if(!mine[id]) mine[id] = emptyMyChangelogReactions();
+    mine[id][key] = true;
+  }
+  return mine;
+}
+
+async function pgFetchChangelogEntriesWithReactions({ limit = 0, ids = null, userId } = {}){
+  await pgInitPromise;
+  const rows = ids?.length ? await pgChangelogByIds(ids) : await pgAllChangelog(limit);
+  const payloads = (rows || []).map((r) => toChangelogPayload(r));
+  const entryIds = payloads.map((p) => p.id).filter(Boolean);
+  if(!entryIds.length) return payloads;
+  const counts = await pgFetchChangelogReactionCounts(entryIds);
+  const mine = await pgFetchChangelogUserReactions(entryIds, userId);
+  return payloads.map((p) => ({
+    ...p,
+    reactions: counts[p.id] || emptyChangelogReactions(),
+    myReactions: mine[p.id] || emptyMyChangelogReactions(),
+  }));
+}
+
 async function pgCreateChangelogEntry({ title, body, authorId }){
   await pgInitPromise;
   const now = Date.now();
@@ -2060,8 +2144,39 @@ async function pgUpdateChangelogEntry({ id, title, body }){
 
 async function pgDeleteChangelogEntry(id){
   await pgInitPromise;
+  await pgPool.query("DELETE FROM changelog_reactions WHERE entry_id=$1", [id]);
   const { rowCount } = await pgPool.query("DELETE FROM changelog_entries WHERE id=$1", [id]);
   return rowCount > 0;
+}
+
+async function pgChangelogEntryExists(entryId){
+  await pgInitPromise;
+  const { rowCount } = await pgPool.query("SELECT 1 FROM changelog_entries WHERE id=$1", [entryId]);
+  return rowCount > 0;
+}
+
+async function pgToggleChangelogReaction(entryId, userId, reaction){
+  await pgInitPromise;
+  const client = await pgPool.connect();
+  try{
+    await client.query("BEGIN");
+    const existing = await client.query(
+      "DELETE FROM changelog_reactions WHERE entry_id=$1 AND user_id=$2 AND reaction=$3 RETURNING 1",
+      [entryId, userId, reaction]
+    );
+    if(!existing.rowCount){
+      await client.query(
+        "INSERT INTO changelog_reactions (entry_id, user_id, reaction, created_at) VALUES ($1,$2,$3,$4)",
+        [entryId, userId, reaction, Date.now()]
+      );
+    }
+    await client.query("COMMIT");
+  }catch(err){
+    await client.query("ROLLBACK");
+    throw err;
+  }finally{
+    client.release();
+  }
 }
 
 function createChangelogEntrySqlite({ title, body, authorId }) {
@@ -2100,6 +2215,119 @@ function createChangelogEntrySqlite({ title, body, authorId }) {
       });
     });
   });
+}
+
+async function sqliteFetchChangelogEntries({ limit = 0, ids = null } = {}) {
+  if (ids?.length) {
+    const ph = ids.map(() => "?").join(",");
+    return dbAllAsync(
+      `SELECT id, seq, title, body, created_at, updated_at, author_id FROM changelog_entries WHERE id IN (${ph}) ORDER BY seq DESC`,
+      ids
+    );
+  }
+  const sql =
+    "SELECT id, seq, title, body, created_at, updated_at, author_id FROM changelog_entries ORDER BY seq DESC" +
+    (limit ? " LIMIT ?" : "");
+  return dbAllAsync(sql, limit ? [limit] : []);
+}
+
+async function sqliteFetchChangelogReactionCounts(entryIds = []) {
+  if (!entryIds.length) return {};
+  const ph = entryIds.map(() => "?").join(",");
+  const rows = await dbAllAsync(
+    `SELECT entry_id, reaction, COUNT(*) as count FROM changelog_reactions WHERE entry_id IN (${ph}) GROUP BY entry_id, reaction`,
+    entryIds
+  );
+  const map = {};
+  for (const row of rows || []) {
+    const id = Number(row.entry_id);
+    const key = normalizeReactionKey(row.reaction);
+    if (!id || !key) continue;
+    if (!map[id]) map[id] = emptyChangelogReactions();
+    map[id][key] = Number(row.count) || 0;
+  }
+  return map;
+}
+
+async function sqliteFetchChangelogUserReactions(entryIds = [], userId) {
+  if (!entryIds.length || !userId) return {};
+  const ph = entryIds.map(() => "?").join(",");
+  const rows = await dbAllAsync(
+    `SELECT entry_id, reaction FROM changelog_reactions WHERE entry_id IN (${ph}) AND user_id=?`,
+    [...entryIds, userId]
+  );
+  const mine = {};
+  for (const row of rows || []) {
+    const id = Number(row.entry_id);
+    const key = normalizeReactionKey(row.reaction);
+    if (!id || !key) continue;
+    if (!mine[id]) mine[id] = emptyMyChangelogReactions();
+    mine[id][key] = true;
+  }
+  return mine;
+}
+
+async function sqliteFetchChangelogEntriesWithReactions({ limit = 0, ids = null, userId } = {}) {
+  const rows = await sqliteFetchChangelogEntries({ limit, ids });
+  const payloads = (rows || []).map((r) => toChangelogPayload(r));
+  const entryIds = payloads.map((p) => p.id).filter(Boolean);
+  if (!entryIds.length) return payloads;
+  const counts = await sqliteFetchChangelogReactionCounts(entryIds);
+  const mine = await sqliteFetchChangelogUserReactions(entryIds, userId);
+  return payloads.map((p) => ({
+    ...p,
+    reactions: counts[p.id] || emptyChangelogReactions(),
+    myReactions: mine[p.id] || emptyMyChangelogReactions(),
+  }));
+}
+
+async function sqliteToggleChangelogReaction(entryId, userId, reaction) {
+  await dbRunAsync("BEGIN");
+  try {
+    const existing = await dbGetAsync(
+      `SELECT 1 FROM changelog_reactions WHERE entry_id=? AND user_id=? AND reaction=?`,
+      [entryId, userId, reaction]
+    );
+    if (existing) {
+      await dbRunAsync(`DELETE FROM changelog_reactions WHERE entry_id=? AND user_id=? AND reaction=?`, [entryId, userId, reaction]);
+    } else {
+      await dbRunAsync(
+        `INSERT INTO changelog_reactions (entry_id, user_id, reaction, created_at) VALUES (?, ?, ?, ?)`,
+        [entryId, userId, reaction, Date.now()]
+      );
+    }
+    await dbRunAsync("COMMIT");
+  } catch (e) {
+    await dbRunAsync("ROLLBACK");
+    throw e;
+  }
+}
+
+async function sqliteChangelogEntryExists(entryId) {
+  const row = await dbGetAsync(`SELECT 1 FROM changelog_entries WHERE id=?`, [entryId]);
+  return !!row;
+}
+
+async function fetchChangelogEntriesWithReactions({ limit = 0, ids = null, userId } = {}) {
+  if (await pgChangelogEnabled()) {
+    try {
+      return await pgFetchChangelogEntriesWithReactions({ limit, ids, userId });
+    } catch (e) {
+      console.warn("[changelog] PG reactions fallback:", e?.message || e);
+    }
+  }
+
+  return sqliteFetchChangelogEntriesWithReactions({ limit, ids, userId });
+}
+
+async function pgChangelogReactionPayload(entryId, userId) {
+  const rows = await pgFetchChangelogEntriesWithReactions({ ids: [entryId], userId });
+  return rows?.[0] || null;
+}
+
+async function sqliteChangelogReactionPayload(entryId, userId) {
+  const rows = await sqliteFetchChangelogEntriesWithReactions({ ids: [entryId], userId });
+  return rows?.[0] || null;
 }
 
 // ---- Auth routes
@@ -2662,25 +2890,11 @@ app.post("/rooms", requireLogin, (req, res) => {
 // ---- Changelog API
 app.get("/api/changelog", requireLogin, async (req, res) => {
   const limit = clamp(req.query?.limit || 0, 0, 200);
-
-  // Prefer Postgres for persistence on Render; fall back to sqlite on any PG error.
-  if (await pgChangelogEnabled()) {
-    try {
-      const rows = await pgAllChangelog(limit);
-      return res.json((rows || []).map((r) => toChangelogPayload(r)));
-    } catch (e) {
-      console.warn("[changelog] PG GET failed, falling back to sqlite:", e?.message || e);
-    }
-  }
-
   try {
-    const sql =
-      "SELECT id, seq, title, body, created_at, updated_at, author_id FROM changelog_entries ORDER BY seq DESC" +
-      (limit ? " LIMIT ?" : "");
-    const rows = await dbAllAsync(sql, limit ? [limit] : []);
-    return res.json((rows || []).map((r) => toChangelogPayload(r)));
+    const rows = await fetchChangelogEntriesWithReactions({ limit, userId: req.session?.user?.id });
+    return res.json(rows || []);
   } catch (e) {
-    console.error("[changelog] sqlite GET failed:", e?.message || e);
+    console.error("[changelog] load failed:", e?.message || e);
     return res.status(500).send("Failed to load changelog");
   }
 });
@@ -2782,6 +2996,7 @@ app.delete("/api/changelog/:id", requireOwner, async (req, res) => {
     }
 
     // sqlite fallback
+    await dbRunAsync(`DELETE FROM changelog_reactions WHERE entry_id=?`, [id]);
     const result = await dbRunAsync(`DELETE FROM changelog_entries WHERE id=?`, [id]);
     if (!result?.changes) return res.status(404).send("Entry not found");
     io.emit("changelog updated");
@@ -2790,6 +3005,44 @@ app.delete("/api/changelog/:id", requireOwner, async (req, res) => {
     console.error("[changelog] delete failed:", err?.message || err);
     return res.status(500).send("Failed to delete changelog entry");
   }
+});
+
+app.post("/api/changelog/:id/reaction", requireLogin, async (req, res) => {
+  const entryId = Number(req.params?.id);
+  const reaction = normalizeReactionKey(req.body?.reaction);
+  if (!Number.isFinite(entryId) || entryId <= 0) return res.status(400).send("Invalid entry id");
+  if (!reaction) return res.status(400).send("Invalid reaction");
+
+  const userId = req.session.user.id;
+  let payload = null;
+  let usedPg = false;
+
+  if (await pgChangelogEnabled()) {
+    try {
+      const exists = await pgChangelogEntryExists(entryId);
+      if (!exists) return res.status(404).send("Entry not found");
+      await pgToggleChangelogReaction(entryId, userId, reaction);
+      usedPg = true;
+      payload = await pgChangelogReactionPayload(entryId, userId);
+    } catch (e) {
+      console.warn("[changelog] PG reaction toggle fallback:", e?.message || e);
+      if (usedPg) return res.status(500).send("Failed to update reaction");
+    }
+  }
+
+  if (!payload && !usedPg) {
+    const exists = await sqliteChangelogEntryExists(entryId);
+    if (!exists) return res.status(404).send("Entry not found");
+    await sqliteToggleChangelogReaction(entryId, userId, reaction);
+    payload = await sqliteChangelogReactionPayload(entryId, userId);
+  } else if (!payload && usedPg) {
+    return res.status(500).send("Failed to update reaction");
+  }
+
+  if (!payload) return res.status(500).send("Failed to update reaction");
+
+  io.emit("changelog reactions updated");
+  return res.json(payload);
 });
 // ---- Profile routes
 app.get("/api/profile", requireLogin, (req, res) => res.redirect(307, "/profile"));


### PR DESCRIPTION
## Summary
- prevent iOS double-tap zoom with viewport, touch-action, and a defensive touch guard
- add scrollable changelog panel with reaction toggles and persistent counts
- add BBCode helper and live preview for editing bios

## Testing
- npm run check
- npm run verify

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695c324c2dd08333bbd7766b9f7c78ba)