### PR TITLE
Fix changelog expansion and mobile action button layout

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -5701,10 +5701,7 @@ function renderChangelogList(){
     wrap.appendChild(details);
     changelogList.appendChild(wrap);
 
-    const detailHeight = details.scrollHeight;
     details.setAttribute("aria-hidden", isOpen ? "false" : "true");
-    details.style.maxHeight = isOpen ? `${detailHeight + 16}px` : "0px";
-    reactionRow.style.visibility = isOpen ? "visible" : "hidden";
     reactionRow.setAttribute("aria-hidden", isOpen ? "false" : "true");
   }
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -1845,7 +1845,7 @@ main.chat{
   color:var(--text);
 }
 .menuTab.active{ background:var(--panel2); box-shadow:var(--shadowSm); }
-.menuContent{ flex:1; display:flex; flex-direction:column; gap:10px; min-height:0; overflow-y:auto; padding:2px 2px 160px; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
+.menuContent{ flex:1; display:flex; flex-direction:column; gap:10px; min-height:0; overflow-y:auto; padding:2px 12px 160px; -webkit-overflow-scrolling: touch; touch-action: pan-y; }
 body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + env(safe-area-inset-bottom)); }
 .menuSection{ display:none; flex-direction:column; gap:10px; min-height:0; }
 .menuSection.active{ display:flex; }
@@ -1913,15 +1913,16 @@ body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + e
   .changelogEntryHeader{ flex-direction:column; align-items:stretch; }
   .changelogSummary{ width:100%; }
   .changelogActions{ width:100%; justify-content:flex-end; }
+  .changelogActions .btn{ flex:1 1 140px; min-width:0; }
 }
 .changelogEntryHint{ font-size:12px; color:var(--muted); }
 .changelogMeta{ display:flex; flex-direction:column; gap:4px; min-width:0; }
 .changelogChevron{ flex:0 0 auto; font-size:14px; transition:transform .15s ease; }
 .changelogEntry.is-open .changelogChevron{ transform:rotate(180deg); }
 .changelogDetails{ display:flex; flex-direction:column; gap:10px; margin-top:2px; padding-top:8px; border-top:1px solid var(--border); max-height:0; overflow:hidden; opacity:0; transition:max-height .2s ease, opacity .2s ease; }
-.changelogEntry.is-open .changelogDetails{ max-height:1200px; opacity:1; }
+.changelogEntry.is-open .changelogDetails{ max-height:1600px; opacity:1; }
 .changelogBody{ white-space:pre-line; overflow-wrap:anywhere; max-height:clamp(220px, 48vh, 460px); overflow-y:auto; -webkit-overflow-scrolling:touch; line-height:1.4; font-size:14px; }
-.changelogActions{ display:flex; gap:6px; flex-wrap:wrap; }
+.changelogActions{ display:flex; gap:6px; flex-wrap:wrap; justify-content:flex-end; }
 .changelogReactions{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-top:2px; }
 .changelogReactionBtn{
   display:inline-flex;


### PR DESCRIPTION
## Summary
- rely on CSS-driven changelog expansion with accessibility attributes instead of inline max-height
- adjust menu and changelog action layout to keep buttons visible on mobile
- raise changelog details max-height for reliable expansion space

## Testing
- npm test
- npm run check


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cf8db6db88333812f8cbd8e5605dd)