### PR TITLE
Centralize vibe tags with emojis and integrate client/server enforcement

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1635,6 +1635,7 @@ const editMood = document.getElementById("editMood");
 const editAge = document.getElementById("editAge");
 const editGender = document.getElementById("editGender");
 const vibeTagOptions = document.getElementById("vibeTagOptions");
+const vibeTagLimitLabel = document.getElementById("vibeTagLimit");
 const editBio = document.getElementById("editBio");
 const bioHelperToggle = document.getElementById("bioHelperToggle");
 const bioHelper = document.getElementById("bioHelper");
@@ -2349,7 +2350,10 @@ const STATUS_ALIASES = {
   "Looking to Chat": "Chatting",
   "Invisible": "Lurking",
 };
-const VIBE_TAG_OPTIONS = ["Chill", "Chaotic", "Night Owl", "Cozy", "Loud", "Quiet", "Curious", "Unhinged", "Friendly", "Competitive"];
+let VIBE_TAG_DEFS = [];
+let VIBE_TAG_OPTIONS = [];
+let VIBE_TAG_LIMIT = 3;
+const VIBE_TAG_LOOKUP = new Map();
 function normalizeStatusLabel(status, fallback=""){
   const raw = String(status || "").trim();
   if(!raw) return fallback;
@@ -2369,15 +2373,65 @@ function statusDotColor(status){
   }
 }
 
+function updateVibeTagLimitText(){
+  if(vibeTagLimitLabel) vibeTagLimitLabel.textContent = String(VIBE_TAG_LIMIT);
+}
+
+function setVibeTagDefs(payload){
+  const defs = Array.isArray(payload?.vibes) ? payload.vibes : [];
+  VIBE_TAG_DEFS = defs.filter((def) => def && def.label && def.emoji);
+  VIBE_TAG_OPTIONS = VIBE_TAG_DEFS.map((def) => def.label);
+  if (Number.isFinite(Number(payload?.limit))) {
+    VIBE_TAG_LIMIT = Number(payload.limit);
+  }
+  VIBE_TAG_LOOKUP.clear();
+  VIBE_TAG_DEFS.forEach((def) => {
+    const label = String(def.label || "").trim();
+    if (!label) return;
+    const normalized = label.toLowerCase();
+    VIBE_TAG_LOOKUP.set(normalized, { ...def, label });
+    if (def.id) VIBE_TAG_LOOKUP.set(String(def.id).toLowerCase(), { ...def, label });
+  });
+  updateVibeTagLimitText();
+}
+
+async function loadVibeTags(){
+  try{
+    const res = await fetch("/api/vibes");
+    if(!res.ok) return;
+    const data = await res.json();
+    setVibeTagDefs(data);
+  }catch(err){
+    console.warn("Failed to load vibe tags:", err);
+  }
+}
+
+function getVibeDef(tag){
+  const key = String(tag || "").trim().toLowerCase();
+  if(!key) return null;
+  return VIBE_TAG_LOOKUP.get(key) || null;
+}
+
+function formatVibeChipLabel(tag){
+  const def = getVibeDef(tag);
+  if(def?.emoji && def?.label) return `${def.emoji} ${def.label}`;
+  return String(tag || "").trim();
+}
+
 function sanitizeVibeTagsClient(raw){
   const arr = Array.isArray(raw) ? raw : [];
   const out = [];
+  const hasOptions = VIBE_TAG_OPTIONS.length > 0;
   arr.forEach((v) => {
-    if (out.length >= 3) return;
+    if (out.length >= VIBE_TAG_LIMIT) return;
     const val = String(v || "").trim();
     if (!val) return;
-    const hit = VIBE_TAG_OPTIONS.find((opt) => opt.toLowerCase() === val.toLowerCase());
-    if (hit && !out.includes(hit)) out.push(hit);
+    if(hasOptions){
+      const hit = VIBE_TAG_OPTIONS.find((opt) => opt.toLowerCase() === val.toLowerCase());
+      if (hit && !out.includes(hit)) out.push(hit);
+    } else if (!out.includes(val)) {
+      out.push(val);
+    }
   });
   return out;
 }
@@ -4048,7 +4102,7 @@ function renderMembers(users){
       vibes.forEach((v)=>{
         const chip = document.createElement("span");
         chip.className = "vibeChip mini";
-        chip.textContent = v;
+        chip.textContent = formatVibeChipLabel(v);
         vibeRow.appendChild(chip);
       });
       meta.appendChild(vibeRow);
@@ -7071,7 +7125,7 @@ function renderVibeChips(targetEl, tags){
   vibes.forEach((tag)=>{
     const chip = document.createElement("span");
     chip.className = "vibeChip";
-    chip.textContent = tag;
+    chip.textContent = formatVibeChipLabel(tag);
     targetEl.appendChild(chip);
   });
 }
@@ -7080,18 +7134,19 @@ function renderVibeOptions(selected = []){
   if(!vibeTagOptions) return;
   selectedVibeTags = sanitizeVibeTagsClient(selected);
   vibeTagOptions.innerHTML = "";
-  VIBE_TAG_OPTIONS.forEach((tag)=>{
+  VIBE_TAG_DEFS.forEach((def)=>{
+    const tag = def.label;
     const btn = document.createElement("button");
     btn.type = "button";
     const active = selectedVibeTags.includes(tag);
     btn.className = "pillBtn" + (active ? " active" : "");
-    btn.textContent = tag;
+    btn.textContent = formatVibeChipLabel(tag);
     btn.addEventListener("click", ()=>{
       const on = selectedVibeTags.includes(tag);
       if(on){
         selectedVibeTags = selectedVibeTags.filter((t)=>t!==tag);
       } else {
-        if(selectedVibeTags.length >= 3) return;
+        if(selectedVibeTags.length >= VIBE_TAG_LIMIT) return;
         selectedVibeTags = [...selectedVibeTags, tag];
       }
       renderVibeOptions(selectedVibeTags);
@@ -8256,6 +8311,7 @@ async function startApp(){
 
   if(!me){ authMsg.textContent="Please login."; return; }
 
+  await loadVibeTags();
   await loadThemePreference();
 
     authWrap.style.display="none";

--- a/public/index.html
+++ b/public/index.html
@@ -725,7 +725,7 @@
                         </div>
 
                         <div class="field">
-                          <label>Vibe tags (pick up to 3)</label>
+                          <label>Vibe tags (pick up to <span id="vibeTagLimit">3</span>)</label>
                           <div class="pillRow" id="vibeTagOptions"></div>
                           <div class="small">Adds a few personality badges to your profile.</div>
                         </div>

--- a/server.js
+++ b/server.js
@@ -53,6 +53,7 @@ process.on("uncaughtException", (err) => {
 });
 const { Server } = require("socket.io");
 const { db, migrationsReady } = require("./database");
+const { VIBE_TAGS, VIBE_TAG_LIMIT } = require("./vibe-tags");
 
 const PORT = Number(process.env.PORT || 3000);
 const PUBLIC_DIR = path.join(__dirname, "public");
@@ -469,9 +470,9 @@ function clamp(n, a, b) {
   return Math.max(a, Math.min(b, n));
 }
 
-const VIBE_TAG_OPTIONS = [
-  "Chill", "Chaotic", "Night Owl", "Cozy", "Loud", "Quiet", "Curious", "Unhinged", "Friendly", "Competitive"
-];
+const VIBE_TAG_LABELS = new Map(
+  VIBE_TAGS.map((tag) => [String(tag.label).toLowerCase(), tag.label])
+);
 
 const HEX_COLOR_RE = /^#([0-9a-f]{3}|[0-9a-f]{4}|[0-9a-f]{6}|[0-9a-f]{8})$/i;
 
@@ -484,10 +485,10 @@ function sanitizeVibeTags(raw) {
 
   const out = [];
   for (const v of arr) {
-    if (out.length >= 3) break;
+    if (out.length >= VIBE_TAG_LIMIT) break;
     const val = String(v || "").trim();
     if (!val) continue;
-    const hit = VIBE_TAG_OPTIONS.find((opt) => opt.toLowerCase() === val.toLowerCase());
+    const hit = VIBE_TAG_LABELS.get(val.toLowerCase());
     if (hit && !out.includes(hit)) out.push(hit);
   }
   return out;
@@ -3206,6 +3207,9 @@ app.get("/me", async (req, res) => {
 
 // Back-compat alias used by some clients
 app.get("/api/me", (req, res) => res.redirect(307, "/me"));
+app.get("/api/vibes", (_req, res) => {
+  res.json({ limit: VIBE_TAG_LIMIT, vibes: VIBE_TAGS });
+});
 
 app.get("/api/me/progression", requireLogin, async (req, res) => {
   const uid = req.session.user.id;

--- a/vibe-tags.js
+++ b/vibe-tags.js
@@ -1,0 +1,45 @@
+"use strict";
+
+const VIBE_TAG_LIMIT = 3;
+
+const VIBE_TAGS = Object.freeze([
+  { id: "chill", label: "Chill", emoji: "😌" },
+  { id: "chaotic", label: "Chaotic", emoji: "🌪️" },
+  { id: "night-owl", label: "Night Owl", emoji: "🦉" },
+  { id: "cozy", label: "Cozy", emoji: "🛋️" },
+  { id: "loud", label: "Loud", emoji: "📢" },
+  { id: "quiet", label: "Quiet", emoji: "🤫" },
+  { id: "curious", label: "Curious", emoji: "👀" },
+  { id: "unhinged", label: "Unhinged", emoji: "🧨" },
+  { id: "friendly", label: "Friendly", emoji: "😊" },
+  { id: "competitive", label: "Competitive", emoji: "🏆" },
+  { id: "high", label: "High", emoji: "🌿" },
+  { id: "horny", label: "Horny", emoji: "🔥" },
+  { id: "flirty", label: "Flirty", emoji: "💋" },
+  { id: "teasing", label: "Teasing", emoji: "🤭" },
+  { id: "bratty", label: "Bratty", emoji: "😈" },
+  { id: "submissive", label: "Submissive", emoji: "🧎" },
+  { id: "dominant", label: "Dominant", emoji: "🐺" },
+  { id: "switch", label: "Switch", emoji: "🔀" },
+  { id: "clingy", label: "Clingy", emoji: "🫶" },
+  { id: "thirsty", label: "Thirsty", emoji: "🥵" },
+  { id: "playful", label: "Playful", emoji: "🎲" },
+  { id: "seductive", label: "Seductive", emoji: "🕯️" },
+  { id: "provocative", label: "Provocative", emoji: "💄" },
+  { id: "spicy", label: "Spicy", emoji: "🌶️" },
+  { id: "filthy-minded", label: "Filthy Minded", emoji: "🧠" },
+  { id: "touch-starved", label: "Touch Starved", emoji: "✋" },
+  { id: "down-bad", label: "Down Bad", emoji: "🫠" },
+  { id: "hopeless-romantic", label: "Hopeless Romantic", emoji: "💞" },
+  { id: "confident", label: "Confident", emoji: "💪" },
+  { id: "shy", label: "Shy", emoji: "🙈" },
+  { id: "mysterious", label: "Mysterious", emoji: "🌒" },
+  { id: "bold", label: "Bold", emoji: "⚡" },
+  { id: "softcore", label: "Softcore", emoji: "🫦" },
+  { id: "after-dark", label: "After Dark", emoji: "🌙" }
+]);
+
+module.exports = {
+  VIBE_TAG_LIMIT,
+  VIBE_TAGS
+};


### PR DESCRIPTION
### Motivation
- Centralize all vibe tag definitions (id/label/emoji) so emoji assignment is stored with the definition and not scattered across UI code.
- Preserve existing vibe labels while attaching a unique emoji to each and add the requested adult/NSFW-adjacent tags with single unique emojis.
- Enforce a single source-of-truth for available vibes and the selectable limit both server-side and client-side to avoid mismatches.
- Ensure members list, profile headers, and compact views render vibe chips with emoji consistently without UI hardcoding.

### Description
- Added `vibe-tags.js` exporting `VIBE_TAGS` (array of `{ id, label, emoji }`) and `VIBE_TAG_LIMIT` and populated it with existing and new tags and unique emojis.
- Updated server (`server.js`) to import the centralized definitions, use them in `sanitizeVibeTags` validation, and expose them via `GET /api/vibes` (returns `{ limit, vibes }`).
- Updated client (`public/app.js`) to load `/api/vibes`, drive `VIBE_TAG_DEFS/OPTIONS/LIMIT`, enforce the limit client-side, and render labels with emojis in members list, profile headers, and vibe option buttons using `formatVibeChipLabel`.
- Touched `public/index.html` to display the dynamic vibe limit label and wired the UI to use the centralized definitions without hardcoding emoji logic.

### Testing
- Started the server with `node server.js`; the process ran and served HTTP, but Postgres initialization failed with `ECONNREFUSED` in this environment (startup logged the error and server continued running). (partial success)
- Attempted an automated Playwright end-to-end script to register/login and open the profile to exercise the vibe UI, but the Playwright run failed due to environment/browser timeouts and crashes. (failed)
- No unit tests were present or executed as part of this change. (none run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2619f7b083338daff4a36d50caa5)