### PR TITLE
Fix message deletion reliability, enforce role rules, and add delete animation

### DIFF
--- a/database.js
+++ b/database.js
@@ -314,7 +314,8 @@ async function runSqliteMigrations() {
       user_id INTEGER NOT NULL,
       username TEXT NOT NULL,
       text TEXT,
-      ts INTEGER NOT NULL
+      ts INTEGER NOT NULL,
+      deleted INTEGER NOT NULL DEFAULT 0
     )
   `);
 
@@ -327,6 +328,7 @@ async function runSqliteMigrations() {
     ["attachment_mime", "attachment_mime TEXT"],
     ["attachment_type", "attachment_type TEXT"],
     ["attachment_size", "attachment_size INTEGER"],
+    ["deleted", "deleted INTEGER NOT NULL DEFAULT 0"],
 ]);
   // DM reactions (1 reaction per user per DM message)
   await run(`

--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,8 @@
 // Debug hook: enable tap hit-testing logs by setting `window.__TAP_DEBUG__ = true` in the console.
 window.__TAP_DEBUG__ = window.__TAP_DEBUG__ ?? false;
 const IS_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+const PREFERS_REDUCED_MOTION = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const DELETE_ANIM_MS = PREFERS_REDUCED_MOTION ? 1 : 200;
 
 // ---- Scroll pinning scheduler (hoisted)
 // This function is referenced early (e.g. visualViewport listeners inside initLayoutMetrics).
@@ -3754,7 +3756,7 @@ actions.appendChild(replyBtn);
     actions.appendChild(editBtn);
   }
 
-  if(roleRank((me && me.role) ? me.role : "member") >= roleRank("Moderator")){
+  if (canDeleteMessage(isSelf)) {
     const del = document.createElement("button");
     del.type="button";
     del.className="delBtn";
@@ -3762,7 +3764,16 @@ actions.appendChild(replyBtn);
     del.title="Delete";
     del.onclick=(e)=>{
       e.stopPropagation();
-      if(confirm("Delete this message?")) socket?.emit("delete message", { messageId: mid });
+      if(!confirm("Delete this message?")) return;
+      markMessageDeleting(item);
+      socket?.emit("delete message", { messageId: mid }, (res = {}) => {
+        if (!res.ok) {
+          clearMessageDeleting(item);
+          addSystem(res.message || "Failed to delete message.");
+          return;
+        }
+        handleMainMessageDeleted(mid);
+      });
     };
     actions.appendChild(del);
   }
@@ -3918,6 +3929,74 @@ function renderDmReactions(messageId, reactionsMap){
 
   const host = container.closest(".dmRow");
   if(host) host.classList.toggle("hasReacts", Object.keys(counts).length > 0);
+}
+
+function canDeleteMessage(isSelf){
+  const myRole = me?.role || "User";
+  const isModerator = roleRank(myRole) >= roleRank("Moderator");
+  if (isModerator) return true;
+  return isSelf && roleRank(myRole) >= roleRank("VIP");
+}
+
+function markMessageDeleting(row){
+  if (!row) return;
+  row.classList.add("message--deleting");
+  row.dataset.deletePending = "1";
+}
+
+function clearMessageDeleting(row){
+  if (!row) return;
+  row.classList.remove("message--deleting");
+  delete row.dataset.deletePending;
+  delete row.dataset.deleteRemoving;
+}
+
+function removeMessageWithAnimation(row, onDone){
+  if (!row || row.dataset.deleteRemoving === "1") return;
+  row.dataset.deleteRemoving = "1";
+  row.classList.add("message--deleting");
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    row.removeEventListener("transitionend", onEnd);
+    if (row.isConnected) row.remove();
+    if (onDone) onDone();
+  };
+  const onEnd = (e) => {
+    if (e.target !== row) return;
+    finish();
+  };
+  row.addEventListener("transitionend", onEnd);
+  setTimeout(finish, DELETE_ANIM_MS + 80);
+}
+
+function removeFromMsgIndex(messageId){
+  const idx = msgIndex.findIndex((x) => String(x.id) === String(messageId));
+  if (idx !== -1) msgIndex.splice(idx, 1);
+}
+
+function handleMainMessageDeleted(messageId){
+  removeFromMsgIndex(messageId);
+  const row = document.querySelector(`[data-mid="${messageId}"]`);
+  if (row) removeMessageWithAnimation(row, () => closeReactionMenu());
+  else closeReactionMenu();
+}
+
+function handleDmMessageDeleted(threadId, messageId){
+  const midKey = String(messageId);
+  delete dmReactionsCache[midKey];
+
+  const tidKey = dmMessages.has(threadId) ? threadId : String(threadId);
+  const arr = dmMessages.get(tidKey) || [];
+  const idx = arr.findIndex((x) => String(x.messageId || x.id) === midKey);
+  if (idx !== -1) {
+    arr.splice(idx, 1);
+    dmMessages.set(tidKey, arr);
+  }
+
+  const row = document.querySelector(`[data-dm-mid="${midKey}"]`);
+  if (row) removeMessageWithAnimation(row);
 }
 
 function closeMemberMenu(){
@@ -4757,18 +4836,6 @@ function renderDmMessages(threadId){
       focusDmComposer();
     };
 
-    const delBtn = document.createElement("button");
-    delBtn.type = "button";
-    delBtn.className = "iconBtn smallIcon";
-    delBtn.title = "Delete";
-    delBtn.textContent = "🗑️";
-    delBtn.onclick = (e) => {
-      e.stopPropagation();
-      const ok = confirm("Delete this message?");
-      if (!ok) return;
-      socket?.emit("dm delete message", { threadId, messageId: (m.messageId || m.id) });
-    };
-
     actions.appendChild(reactBtn);
     actions.appendChild(replyBtn);
     // Edit (self, within 5 minutes)
@@ -4785,7 +4852,29 @@ function renderDmMessages(threadId){
       };
       actions.appendChild(editBtn);
     }
-    actions.appendChild(delBtn);
+    if (canDeleteMessage(isSelf)) {
+      const delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "iconBtn smallIcon";
+      delBtn.title = "Delete";
+      delBtn.textContent = "🗑️";
+      delBtn.onclick = (e) => {
+        e.stopPropagation();
+        const ok = confirm("Delete this message?");
+        if (!ok) return;
+        markMessageDeleting(row);
+        const msgId = (m.messageId || m.id);
+        socket?.emit("dm delete message", { threadId, messageId: msgId }, (res = {}) => {
+          if (!res.ok) {
+            clearMessageDeleting(row);
+            addSystem(res.message || "Failed to delete message.");
+            return;
+          }
+          handleDmMessageDeleted(threadId, msgId);
+        });
+      };
+      actions.appendChild(delBtn);
+    }
 
     // Bubble + meta
     const bubbleWrap = document.createElement("div");
@@ -8544,15 +8633,12 @@ socket.on("disconnect", (reason) => {
     if (Sound.shouldReaction()) Sound.cues.reaction();
   });
 
-  socket.on("message deleted", ({ messageId }) => {
-    const row = document.querySelector(`[data-mid="${messageId}"]`);
-    if (row) row.remove();
-
-    const idx = msgIndex.findIndex((x) => String(x.id) === String(messageId));
-    if (idx !== -1) msgIndex.splice(idx, 1);
-
-    closeReactionMenu();
-  });
+  const onMainMessageDeleted = ({ messageId }) => {
+    if (!messageId) return;
+    handleMainMessageDeleted(messageId);
+  };
+  socket.on("message deleted", onMainMessageDeleted);
+  socket.on("messageDeleted", onMainMessageDeleted);
 
     socket.on("dm message edited", ({ threadId, messageId, text, editedAt }) => {
     const tid = String(threadId);
@@ -8730,22 +8816,8 @@ socket.on("dm history", (payload) => {
   });
 
   socket.on("dm message deleted", ({ threadId, messageId }) => {
-    const midKey = String(messageId);
-    const row = document.querySelector(`[data-dm-mid="${midKey}"]`);
-    if (row) row.remove();
-    delete dmReactionsCache[midKey];
-
-    // Remove from cached messages
-    const tidKey = threadId;
-    const arr = dmMessages.get(tidKey) || [];
-    const idx = arr.findIndex((x) => String(x.messageId || x.id) === midKey);
-    if (idx !== -1) {
-      arr.splice(idx, 1);
-      dmMessages.set(tidKey, arr);
-    }
-
+    handleDmMessageDeleted(threadId, messageId);
     if (String(activeDmId) === String(threadId)) {
-      // Close any open action menus
       closeReactionMenu();
     }
   });

--- a/public/styles.css
+++ b/public/styles.css
@@ -2262,6 +2262,20 @@ body.dice-room .sys .diceFace{
 .msgGroupBody{ display:flex; flex-direction:column; gap:var(--fx-group-gap, 1px); min-width:0; }
 .msgItem{ position:relative; display:flex; flex-direction:row; align-items:flex-start; gap:8px; min-width:0; }
 .msgItem.self{ flex-direction:row-reverse; }
+.msgItem.message--deleting,
+.dmRow.message--deleting{
+  opacity:0;
+  transform: translateY(-4px) scale(0.98);
+  transition: opacity 200ms ease, transform 200ms ease;
+  pointer-events:none;
+}
+@media (prefers-reduced-motion: reduce){
+  .msgItem.message--deleting,
+  .dmRow.message--deleting{
+    transition-duration: 1ms;
+    transform: none;
+  }
+}
 
 /* ---- Main chat actions: no reserved space + horizontal bar below message ----
    Actions live inside .msgMain (after bubble + reactions) and are collapsed

--- a/server.js
+++ b/server.js
@@ -1336,6 +1336,8 @@ const commandRegistry = {
       const rows = await dbAllAsync(`SELECT id FROM messages WHERE room=? AND deleted=0 ORDER BY ts DESC LIMIT ?`, [room, amt]);
       for (const r of rows) {
         await dbRunAsync(`UPDATE messages SET deleted=1 WHERE id=?`, [r.id]);
+        await dbRunAsync(`DELETE FROM reactions WHERE message_id=?`, [r.id]);
+        io.to(room).emit("messageDeleted", { messageId: r.id, roomId: room });
         io.to(room).emit("message deleted", { messageId: r.id });
       }
       return { ok: true, message: `Cleared ${rows.length} messages in #${room}` };
@@ -4839,11 +4841,19 @@ function handleListDmThreads(req, res) {
 
   db.all(
     `SELECT t.id, t.title, t.is_group, t.created_at,
-            COALESCE(t.last_message_id, (SELECT id FROM dm_messages WHERE thread_id=t.id ORDER BY ts DESC LIMIT 1)) AS last_message_id,
-            (SELECT text FROM dm_messages WHERE thread_id=t.id ORDER BY ts DESC LIMIT 1) AS last_text,
-            COALESCE(t.last_message_at, (SELECT ts FROM dm_messages WHERE thread_id=t.id ORDER BY ts DESC LIMIT 1)) AS last_ts,
+            COALESCE(
+              (SELECT id FROM dm_messages WHERE id=t.last_message_id AND deleted=0),
+              (SELECT id FROM dm_messages WHERE thread_id=t.id AND deleted=0 ORDER BY ts DESC LIMIT 1)
+            ) AS last_message_id,
+            (SELECT text FROM dm_messages WHERE thread_id=t.id AND deleted=0 ORDER BY ts DESC LIMIT 1) AS last_text,
+            COALESCE(
+              (SELECT ts FROM dm_messages WHERE id=t.last_message_id AND deleted=0),
+              t.last_message_at,
+              (SELECT ts FROM dm_messages WHERE thread_id=t.id AND deleted=0 ORDER BY ts DESC LIMIT 1)
+            ) AS last_ts,
             (SELECT COUNT(*) FROM dm_messages m
               WHERE m.thread_id = t.id
+                AND m.deleted = 0
                 AND m.user_id != ?
                 AND m.ts > COALESCE(pself.last_read_at, 0)
             ) AS unreadCount
@@ -5688,7 +5698,7 @@ if (!room) {
       socket.join(`dm:${tid}`);
 
       db.all(
-        `SELECT id, thread_id, user_id, username, text, ts, edited_at, reply_to_id, reply_to_user, reply_to_text, attachment_url, attachment_mime, attachment_type, attachment_size FROM dm_messages WHERE thread_id=? ORDER BY ts DESC LIMIT 50`,
+        `SELECT id, thread_id, user_id, username, text, ts, edited_at, reply_to_id, reply_to_user, reply_to_text, attachment_url, attachment_mime, attachment_type, attachment_size FROM dm_messages WHERE thread_id=? AND deleted=0 ORDER BY ts DESC LIMIT 50`,
         [tid],
         (_e, rows) => {
           const msgs = (rows || []).reverse().map((r) => ({
@@ -5861,7 +5871,7 @@ replyToId: replyPk,
 
       if (Number.isInteger(replyId)) {
         db.get(
-          `SELECT id, username, text FROM dm_messages WHERE id = ? AND thread_id = ?`,
+          `SELECT id, username, text FROM dm_messages WHERE id = ? AND thread_id = ? AND deleted=0`,
           [replyId, tid],
           (_e, row) => {
             doInsert(row || {});
@@ -5885,7 +5895,7 @@ replyToId: replyPk,
       if (err || !thread) return;
 
       db.get(
-        `SELECT id, thread_id, user_id, ts FROM dm_messages WHERE id = ? AND thread_id = ?`,
+        `SELECT id, thread_id, user_id, ts FROM dm_messages WHERE id = ? AND thread_id = ? AND deleted=0`,
         [mid, tid],
         (e2, row) => {
           if (e2 || !row) return;
@@ -6149,38 +6159,173 @@ socket.on("status change", ({ status }) => {
     );
   });
 
-  // ---- Moderation: delete message
-  socket.on("mod delete message", ({ messageId }) => {
-    const room = socket.currentRoom;
-    if (!room) return;
+  const logDeleteFailure = ({ scope, messageId, actorId, actorRole, reason, roomId, threadId }) => {
+    console.warn(`[delete:${scope}]`, { messageId, actorId, actorRole, roomId, threadId, reason });
+  };
 
-    const actorRole = socket.request.session.user.role;
-    if (!requireMinRole(actorRole, "Moderator")) return;
+  const respondDelete = (ack, payload) => {
+    if (typeof ack === "function") ack(payload);
+  };
 
-    const mid = String(messageId || "").trim();
-    if (!mid) return;
+  const emitMainMessageDeleted = (messageId, roomId) => {
+    const rawRoom = String(roomId || "").trim();
+    if (!rawRoom) return;
+    const emitRoom = rawRoom.startsWith("#") ? rawRoom.slice(1) : rawRoom;
+    io.to(emitRoom).emit("messageDeleted", { messageId, roomId: emitRoom });
+    io.to(emitRoom).emit("message deleted", { messageId });
+  };
+
+  const handleMainDeleteMessage = ({ messageId } = {}, ack) => {
+    const actor = socket.user;
+    if (!actor) {
+      respondDelete(ack, { ok: false, message: "Not authenticated." });
+      return;
+    }
+
+    const actorRole = actor.role || socket.request?.session?.user?.role || "User";
+    const mid = Number(messageId);
+    if (!Number.isInteger(mid)) {
+      respondDelete(ack, { ok: false, message: "Invalid message id." });
+      logDeleteFailure({ scope: "main", messageId, actorId: actor.id, actorRole, reason: "invalid_id" });
+      return;
+    }
 
     db.get(
-      "SELECT * FROM messages WHERE id=? AND room=?",
-      [mid, room],
-      (_e, msg) => {
-        if (!msg) return;
-        // cannot delete higher/equal role messages unless it's your own
-        if (!canModerate(actorRole, msg.role) && msg.user_id !== socket.user.id) return;
+      "SELECT id, room, user_id, username, role, deleted FROM messages WHERE id=?",
+      [mid],
+      (err, msg) => {
+        if (err) {
+          respondDelete(ack, { ok: false, message: "Failed to load message." });
+          logDeleteFailure({ scope: "main", messageId: mid, actorId: actor.id, actorRole, reason: "load_failed" });
+          return;
+        }
+        if (!msg) {
+          respondDelete(ack, { ok: false, message: "Message not found." });
+          logDeleteFailure({ scope: "main", messageId: mid, actorId: actor.id, actorRole, reason: "not_found" });
+          return;
+        }
 
-        db.run("UPDATE messages SET deleted=1 WHERE id=?", [mid], () => {
-          io.to(room).emit("message deleted", { messageId: mid });
-          logModAction({
-            actor: socket.user,
-            action: "DELETE_MESSAGE",
-            targetUserId: msg.user_id,
-            targetUsername: msg.username,
-            room,
-            details: `messageId=${mid}`,
+        const isModerator = requireMinRole(actorRole, "Moderator");
+        const isVip = requireMinRole(actorRole, "VIP");
+        const isOwner = Number(msg.user_id) === Number(actor.id);
+        if (!isModerator && !(isVip && isOwner)) {
+          respondDelete(ack, { ok: false, message: "Not allowed to delete this message." });
+          logDeleteFailure({ scope: "main", messageId: mid, actorId: actor.id, actorRole, roomId: msg.room, reason: "forbidden" });
+          return;
+        }
+
+        const wasDeleted = Number(msg.deleted || 0) === 1;
+        if (wasDeleted) {
+          respondDelete(ack, { ok: true, alreadyDeleted: true });
+          emitMainMessageDeleted(mid, msg.room);
+          return;
+        }
+
+        db.run("UPDATE messages SET deleted=1 WHERE id=?", [mid], (updateErr) => {
+          if (updateErr) {
+            respondDelete(ack, { ok: false, message: "Failed to delete message." });
+            logDeleteFailure({ scope: "main", messageId: mid, actorId: actor.id, actorRole, roomId: msg.room, reason: "update_failed" });
+            return;
+          }
+
+          db.run("DELETE FROM reactions WHERE message_id=?", [mid], (reactErr) => {
+            if (reactErr) {
+              console.warn("[delete:main] reaction cleanup failed", { messageId: mid, error: reactErr?.message || reactErr });
+            }
+            if (requireMinRole(actorRole, "Moderator")) {
+              logModAction({
+                actor,
+                action: "DELETE_MESSAGE",
+                targetUserId: msg.user_id,
+                targetUsername: msg.username,
+                room: msg.room,
+                details: `messageId=${mid}`,
+              });
+            }
+            respondDelete(ack, { ok: true });
+            emitMainMessageDeleted(mid, msg.room);
           });
         });
       }
     );
+  };
+
+  socket.on("delete message", handleMainDeleteMessage);
+  // Backward compatibility for older clients
+  socket.on("mod delete message", handleMainDeleteMessage);
+
+  socket.on("dm delete message", ({ threadId, messageId } = {}, ack) => {
+    const actor = socket.user;
+    if (!actor) {
+      respondDelete(ack, { ok: false, message: "Not authenticated." });
+      return;
+    }
+
+    const tid = Number(threadId);
+    const mid = Number(messageId);
+    if (!Number.isInteger(tid) || !Number.isInteger(mid)) {
+      respondDelete(ack, { ok: false, message: "Invalid message id." });
+      logDeleteFailure({ scope: "dm", messageId, actorId: actor.id, actorRole: actor.role, threadId, reason: "invalid_id" });
+      return;
+    }
+
+    loadThreadForUser(tid, actor.id, (err, thread) => {
+      if (err || !thread) {
+        respondDelete(ack, { ok: false, message: "Not allowed in this thread." });
+        logDeleteFailure({ scope: "dm", messageId: mid, actorId: actor.id, actorRole: actor.role, threadId: tid, reason: "thread_access" });
+        return;
+      }
+
+      const actorRole = actor.role || socket.request?.session?.user?.role || "User";
+      db.get(
+        "SELECT id, thread_id, user_id, deleted FROM dm_messages WHERE id=? AND thread_id=?",
+        [mid, tid],
+        (msgErr, msg) => {
+          if (msgErr) {
+            respondDelete(ack, { ok: false, message: "Failed to load message." });
+            logDeleteFailure({ scope: "dm", messageId: mid, actorId: actor.id, actorRole, threadId: tid, reason: "load_failed" });
+            return;
+          }
+          if (!msg) {
+            respondDelete(ack, { ok: false, message: "Message not found." });
+            logDeleteFailure({ scope: "dm", messageId: mid, actorId: actor.id, actorRole, threadId: tid, reason: "not_found" });
+            return;
+          }
+
+          const isModerator = requireMinRole(actorRole, "Moderator");
+          const isVip = requireMinRole(actorRole, "VIP");
+          const isOwner = Number(msg.user_id) === Number(actor.id);
+          if (!isModerator && !(isVip && isOwner)) {
+            respondDelete(ack, { ok: false, message: "Not allowed to delete this message." });
+            logDeleteFailure({ scope: "dm", messageId: mid, actorId: actor.id, actorRole, threadId: tid, reason: "forbidden" });
+            return;
+          }
+
+          const wasDeleted = Number(msg.deleted || 0) === 1;
+          if (wasDeleted) {
+            respondDelete(ack, { ok: true, alreadyDeleted: true });
+            io.to(`dm:${tid}`).emit("dm message deleted", { threadId: tid, messageId: mid });
+            return;
+          }
+
+          db.run("UPDATE dm_messages SET deleted=1 WHERE id=? AND thread_id=?", [mid, tid], (delErr) => {
+            if (delErr) {
+              respondDelete(ack, { ok: false, message: "Failed to delete message." });
+              logDeleteFailure({ scope: "dm", messageId: mid, actorId: actor.id, actorRole, threadId: tid, reason: "update_failed" });
+              return;
+            }
+
+            db.run("DELETE FROM dm_reactions WHERE thread_id=? AND message_id=?", [tid, mid], (reactErr) => {
+              if (reactErr) {
+                console.warn("[delete:dm] reaction cleanup failed", { messageId: mid, threadId: tid, error: reactErr?.message || reactErr });
+              }
+              respondDelete(ack, { ok: true });
+              io.to(`dm:${tid}`).emit("dm message deleted", { threadId: tid, messageId: mid });
+            });
+          });
+        }
+      );
+    });
   });
 
   // ---- Kick / Mute / Ban + Unmute/Unban/Warn + Set role


### PR DESCRIPTION
### Motivation
- Fix unreliable message deletions across main chat and DMs so deletes always reach the server or surface an explicit error.  
- Enforce server-side role rules so Guests/Users cannot delete, VIPs can delete only their own, and Moderation roles can delete any message.  
- Prevent deleted messages from reappearing by making deletes durable in the DB and cleaning up dependent rows (reactions).  
- Provide a smooth, accessible frontend delete animation and make client controls consistent with server-side rules.

### Description
- Server: added unified handlers for `delete message` and `dm delete message` that determine the caller role from the authenticated session, validate permissions (Moderator/Admin/Co-owner/Owner can delete any message; VIP can delete own messages; Guests/Users denied), mark messages as deleted (`deleted=1`), remove related reactions, emit both a new `messageDeleted` event and the legacy `message deleted` event for realtime sync, return explicit ack payloads, and log failures for debugging.  
- Database/API: added a `deleted` column to `dm_messages` and updated DM listing / history SQL to filter `deleted=0` so deleted DMs are excluded from history and unread counts.  
- Client: added role-aware UI checks (`canDeleteMessage`) to hide/enable delete buttons, send deletes with acknowledgement callbacks, optimistically mark elements with `.message--deleting`, and remove DOM nodes after a CSS transition completes; realtime handlers now apply the same animation for remote deletes.  
- CSS: added `.message--deleting` (and `.dmRow.message--deleting`) styles that fade/translate/scale with a 200ms transition and respect `prefers-reduced-motion` by reducing duration to near-zero.

### Testing
- Started the app with `npm start` and observed the server run on `http://localhost:3000` (Postgres connection was refused in the environment but the server continued using the SQLite path).  
- Ran a headless Playwright script that loaded `http://localhost:3000` and captured a screenshot demonstrating the UI state/artifact at `artifacts/delete-animation.png`.  
- No unit tests were present or executed beyond the manual/automated runtime checks above.  
- `npm run check` / further CI was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e28e30a80833385a3d204d1e62f7d)