### PR TITLE
Fix changelog Edit toggle and remove orphaned avatar groups on message delete

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3976,10 +3976,22 @@ function removeFromMsgIndex(messageId){
   if (idx !== -1) msgIndex.splice(idx, 1);
 }
 
+function cleanupEmptyMessageGroup(group){
+  if(!group) return;
+  const body = group.querySelector(".msgGroupBody");
+  if(!body || !body.querySelector(".msgItem")) group.remove();
+}
+
 function handleMainMessageDeleted(messageId){
   removeFromMsgIndex(messageId);
   const row = document.querySelector(`[data-mid="${messageId}"]`);
-  if (row) removeMessageWithAnimation(row, () => closeReactionMenu());
+  const group = row?.closest(".msgGroup");
+  if (row) {
+    removeMessageWithAnimation(row, () => {
+      closeReactionMenu();
+      cleanupEmptyMessageGroup(group);
+    });
+  }
   else closeReactionMenu();
 }
 
@@ -5969,6 +5981,20 @@ function updateChangelogControlsVisibility(){
   if(!isOwner) closeChangelogEditor();
 }
 
+function scrollChangelogEditorIntoView(){
+  if(!changelogEditor) return;
+  const scroller = menuPanel?.querySelector(".menuContent") || document.querySelector(".menuContent");
+  if(scroller && scroller.contains(changelogEditor)){
+    const rect = changelogEditor.getBoundingClientRect();
+    const scrollerRect = scroller.getBoundingClientRect();
+    if(rect.top < scrollerRect.top || rect.bottom > scrollerRect.bottom){
+      try { changelogEditor.scrollIntoView({ behavior:"smooth", block:"nearest" }); } catch {}
+    }
+    return;
+  }
+  try { changelogEditor.scrollIntoView({ behavior:"smooth", block:"nearest" }); } catch {}
+}
+
 function openChangelogEditor(entry){
   if(!changelogEditor) return;
   editingChangelogId = entry?.id || null;
@@ -5976,7 +6002,10 @@ function openChangelogEditor(entry){
   if(changelogBodyInput) changelogBodyInput.value = entry?.body || "";
   if(changelogEditMsg) changelogEditMsg.textContent = "";
   changelogEditor.style.display = "block";
-  changelogTitleInput?.focus();
+  requestAnimationFrame(()=>{
+    scrollChangelogEditorIntoView();
+    changelogTitleInput?.focus();
+  });
 }
 
 function closeChangelogEditor(){
@@ -6249,12 +6278,14 @@ function renderChangelogList(){
     item.appendChild(panel);
 
     // Native <details> expansion is the most reliable option on iOS Safari.
-    // Keep only one open at a time for readability.
+    // Keep only one open at a time for readability (without re-rendering).
     item.addEventListener("toggle", ()=>{
       const nowOpen = item.open;
       openChangelogId = nowOpen ? entryId : (openChangelogId === entryId ? null : openChangelogId);
-      // Re-render to keep chevrons/state consistent and close other items.
-      renderChangelogList();
+      if(!nowOpen) return;
+      changelogList.querySelectorAll("details.clItem[open]").forEach((other)=>{
+        if(other !== item) other.open = false;
+      });
     }, { passive:true });
 
     changelogList.appendChild(item);


### PR DESCRIPTION
### Motivation
- The changelog editor sometimes failed to open because the `<details>` toggle handler re-rendered the entire list on every toggle, which could replace DOM mid-interaction and swallow clicks. 
- Deleting a single message could leave an empty `.msgGroup` wrapper (avatar/profile bubble) visible, creating orphaned avatars. 
- Changes must be robust on desktop and iOS Safari and must not rework layout/spacing systems. 
- Ensure the existing deletion animation (`.message--deleting`) is used and DOM is removed after the transition finishes.

### Description
- Stop re-rendering the changelog list on `toggle` inside `renderChangelogList` and instead close other entries by setting their `.open = false`, preserving native `<details>` behavior. 
- Add `scrollChangelogEditorIntoView` and update `openChangelogEditor` to `requestAnimationFrame` a smooth `scrollIntoView` and then focus the title input so `Edit` reliably reveals and focuses the editor. 
- Kept existing click wiring in `handleChangelogListClick` so `Edit` still calls `openChangelogEditor`, and prevented reaction buttons from toggling `<details>` via `preventDefault`/`stopPropagation`. 
- Add `cleanupEmptyMessageGroup` and invoke it from `handleMainMessageDeleted` after `removeMessageWithAnimation` finishes so empty `.msgGroup` containers (including avatars) are removed when the last message in a group is deleted, reusing the existing `.message--deleting` transition logic.

### Testing
- Automated tests: none were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e32c778908333be6177e28a52f219)