### PR TITLE
Harden DM quick-strip placeholder, prefs parsing, and socket robustness

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -7,6 +7,27 @@ const IS_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platfo
 const PREFERS_REDUCED_MOTION = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
 const DELETE_ANIM_MS = PREFERS_REDUCED_MOTION ? 1 : 200;
 
+function safeJsonParse(raw, fallback) {
+  try {
+    if (raw === null || raw === undefined || raw === "") return fallback;
+    if (typeof raw === "object") return raw;
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+function safeNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function safeString(value, fallback = "") {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return fallback;
+  return String(value);
+}
+
 // ---- Scroll pinning scheduler (hoisted)
 // This function is referenced early (e.g. visualViewport listeners inside initLayoutMetrics).
 // It must be hoisted to avoid TDZ/ReferenceError when app.js is evaluated.
@@ -1060,12 +1081,9 @@ const DM_LAST_READ_KEY = "dm:lastRead:v1";
 const AVATAR_CACHE_KEY = "dm:avatarCache:v1";
 
 function loadJson(key, fallback) {
-  try {
-    const raw = localStorage.getItem(key);
-    if (!raw) return fallback;
-    const val = JSON.parse(raw);
-    return val ?? fallback;
-  } catch { return fallback; }
+  const raw = localStorage.getItem(key);
+  const val = safeJsonParse(raw, fallback);
+  return val ?? fallback;
 }
 function saveJson(key, value) {
   try { localStorage.setItem(key, JSON.stringify(value)); } catch {}
@@ -1232,6 +1250,32 @@ function updateUserFxMap(username, fx){
   if (!username) return;
   const key = String(username);
   userFxMap[key] = normalizeChatFx(fx);
+}
+
+function escapeSelectorValue(value) {
+  if (window.CSS?.escape) return CSS.escape(String(value));
+  return String(value).replace(/["\\]/g, "\\$&");
+}
+
+function updateUserFxInDom(username, fx){
+  const name = String(username || "");
+  if (!name) return;
+  const normalized = normalizeChatFx(fx);
+  const selector = `.msgGroup[data-user="${escapeSelectorValue(name)}"]`;
+  document.querySelectorAll(selector).forEach((group) => {
+    const body = group.querySelector(".msgGroupBody");
+    group.querySelectorAll(".bubble").forEach((bubble) => {
+      applyChatFxToBubble(bubble, normalized, { groupBody: body });
+    });
+    group.querySelectorAll(".unameText").forEach((el) => applyNameFxToEl(el, normalized));
+  });
+
+  if (activeDmId && dmMessagesEl) {
+    const threadMessages = dmMessages.get(activeDmId) || dmMessages.get(String(activeDmId)) || [];
+    if (threadMessages.some((m) => String(m.user || "") === name)) {
+      renderDmMessages(activeDmId);
+    }
+  }
 }
 
 function hydrateUserFxMap(authorsFx){
@@ -2008,6 +2052,20 @@ const groupQuickStrip = document.getElementById("groupQuickStrip");
 const dmQuickEmpty = document.getElementById("dmQuickEmpty");
 const groupQuickEmpty = document.getElementById("groupQuickEmpty");
 const groupQuickStartBtn = document.getElementById("groupQuickStartBtn");
+
+const DM_THREAD_ENTRY_SELECTOR = ".dmAvatarBtn";
+function updateDmThreadPlaceholderVisibility(){
+  const applyVisibility = (stripEl, emptyEl) => {
+    if (!stripEl || !emptyEl) return;
+    const hasThreads = !!stripEl.querySelector(DM_THREAD_ENTRY_SELECTOR);
+    stripEl.hidden = false;
+    emptyEl.hidden = false;
+    stripEl.classList.toggle("hidden", !hasThreads);
+    emptyEl.classList.toggle("hidden", hasThreads);
+  };
+  applyVisibility(dmQuickStrip || dmStrip, dmQuickEmpty);
+  applyVisibility(groupQuickStrip, groupQuickEmpty);
+}
 
 const dmCloseBtn = document.getElementById("dmCloseBtn");
 const dmTabs = document.getElementById("dmTabs");
@@ -5221,12 +5279,9 @@ function renderDirectThreads(){
 
   stripEl.innerHTML = "";
   if (list.length === 0) {
-    stripEl.style.display = "none";
-    if (dmQuickEmpty) dmQuickEmpty.hidden = false;
+    updateDmThreadPlaceholderVisibility();
     return;
   }
-  if (dmQuickEmpty) dmQuickEmpty.hidden = true;
-  stripEl.style.display = "flex";
 
   list.sort((a,b)=>(Number(b.last_ts||0)-Number(a.last_ts||0)));
   for (const t of list) {
@@ -5261,6 +5316,7 @@ function renderDirectThreads(){
     });
     stripEl.appendChild(btn);
   }
+  updateDmThreadPlaceholderVisibility();
 }
 
 function vennPreview(thread){
@@ -5287,12 +5343,9 @@ function renderGroupThreads(){
 
   stripEl.innerHTML = "";
   if (list.length === 0) {
-    stripEl.style.display = "none";
-    if (groupQuickEmpty) groupQuickEmpty.hidden = false;
+    updateDmThreadPlaceholderVisibility();
     return;
   }
-  if (groupQuickEmpty) groupQuickEmpty.hidden = true;
-  stripEl.style.display = "flex";
   list.sort((a,b)=>(Number(b.last_ts||0)-Number(a.last_ts||0)));
 
   for (const t of list) {
@@ -5319,6 +5372,7 @@ function renderGroupThreads(){
     });
     stripEl.appendChild(btn);
   }
+  updateDmThreadPlaceholderVisibility();
 }
 
 function renderDmThreads(){
@@ -9384,6 +9438,10 @@ async function startApp(){
   updateChangelogControlsVisibility();
   updateRoomControlsVisibility();
 
+  if (socket) {
+    try { socket.removeAllListeners(); } catch {}
+    try { socket.disconnect(); } catch {}
+  }
   socket = io();
   socket.on("connect", () => {
     // Join initial room so history + realtime messages work reliably
@@ -9503,6 +9561,13 @@ socket.on("disconnect", (reason) => {
 
   socket.on("command response", handleCommandResponse);
   socket.on("user list", (users)=>renderMembers(users));
+  socket.on("user fx updated", (payload = {}) => {
+    const name = safeString(payload.username, "").trim();
+    if (!name) return;
+    updateUserFxMap(name, payload.chatFx || payload.fx || {});
+    updateUserFxInDom(name, payload.chatFx || payload.fx || {});
+    renderDmThreads();
+  });
   socket.on("typing update", (names)=>{
     typingUsers = new Set((names || []).map(normKey));
     const others=(names||[]).filter(n=>normKey(n)!==normKey(me.username));
@@ -9576,32 +9641,32 @@ socket.on("disconnect", (reason) => {
   socket.on("message deleted", onMainMessageDeleted);
   socket.on("messageDeleted", onMainMessageDeleted);
 
-    socket.on("dm message edited", ({ threadId, messageId, text, editedAt }) => {
-    const tid = String(threadId);
-    const mid = String(messageId);
+    socket.on("dm message edited", (payload = {}) => {
+    const tid = String(payload.threadId || "");
+    const mid = String(payload.messageId || "");
     const arr = dmMessages.get(tid) || [];
     const i = arr.findIndex(mm => String(mm.messageId || mm.id) === mid);
     if (i !== -1) {
-      arr[i].text = text;
-      arr[i].editedAt = editedAt || Date.now();
+      arr[i].text = safeString(payload.text, "");
+      arr[i].editedAt = payload.editedAt || Date.now();
     }
     if (String(activeDmId) === tid) renderDmMessages(tid);
   });
 
-  socket.on("message edited", ({ messageId, text, editedAt }) => {
-    const mid = String(messageId);
+  socket.on("message edited", (payload = {}) => {
+    const mid = String(payload.messageId || "");
     // update index cache if present
     const idx = msgIndex.findIndex((x) => String(x.id) === mid);
     if (idx !== -1) {
-      msgIndex[idx].text = text;
-      msgIndex[idx].editedAt = editedAt || Date.now();
+      msgIndex[idx].text = safeString(payload.text, "");
+      msgIndex[idx].editedAt = payload.editedAt || Date.now();
     }
 
     const item = document.querySelector(`.msgItem[data-mid="${mid}"]`);
     if (item) {
       const bubble = item.querySelector(".bubble");
       const textEl = bubble?.querySelector(".text");
-      if (textEl) textEl.innerHTML = linkify(escapeHtml(String(text||""))).replace(/\n/g, "<br/>");
+      if (textEl) textEl.innerHTML = linkify(escapeHtml(safeString(payload.text, ""))).replace(/\n/g, "<br/>");
       const timeEl = bubble?.querySelector(".time");
       if (timeEl && !timeEl.querySelector(".editedTag")) {
         const ed = document.createElement("span");
@@ -9612,7 +9677,7 @@ socket.on("disconnect", (reason) => {
     }
   });
 
-socket.on("dm history", (payload) => {
+socket.on("dm history", (payload = {}) => {
     const { threadId, messages = [], participants = [], title = "" } = payload || {};
     hydrateUserFxMap(payload?.authorsFx || payload?.authors_fx);
     if (Array.isArray(messages)) {
@@ -9663,7 +9728,8 @@ socket.on("dm history", (payload) => {
     }
   });
 
-  socket.on("dm history cleared", ({ threadId }) => {
+  socket.on("dm history cleared", (payload = {}) => {
+    const threadId = payload.threadId;
     if (!threadId) return;
     dmMessages.set(threadId, []);
     const meta = dmThreads.find((t) => String(t.id) === String(threadId));
@@ -9728,9 +9794,9 @@ socket.on("dm history", (payload) => {
   }
 });
 
-  socket.on("dm read", (payload) => {
+  socket.on("dm read", (payload = {}) => {
     try {
-      const tid = String(payload.threadId);
+      const tid = String(payload.threadId || "");
       if (!tid) return;
       dmReadCache[tid] = payload;
 
@@ -9742,18 +9808,19 @@ socket.on("dm history", (payload) => {
   });
 
 
-  socket.on("dm reaction update", ({ threadId, messageId, reactions }) => {
+  socket.on("dm reaction update", (payload = {}) => {
     // Keep cache even if the thread isn't open yet.
-    const midKey = String(messageId);
-    dmReactionsCache[midKey] = reactions || {};
+    const midKey = String(payload.messageId || "");
+    if (!midKey) return;
+    dmReactionsCache[midKey] = payload.reactions || {};
     // Only render if the message is currently in the DOM.
     renderDmReactions(midKey, dmReactionsCache[midKey]);
     if (Sound.shouldReaction()) Sound.cues.reaction();
   });
 
-  socket.on("dm message deleted", ({ threadId, messageId }) => {
-    handleDmMessageDeleted(threadId, messageId);
-    if (String(activeDmId) === String(threadId)) {
+  socket.on("dm message deleted", (payload = {}) => {
+    handleDmMessageDeleted(payload.threadId, payload.messageId);
+    if (String(activeDmId) === String(payload.threadId)) {
       closeReactionMenu();
     }
   });

--- a/public/styles.css
+++ b/public/styles.css
@@ -52,6 +52,10 @@
   --shadow: var(--shadowLg);
 }
 
+.hidden {
+  display: none !important;
+}
+
 :root[data-theme="Minimal Dark"],
 [data-theme="Minimal Dark"] {
   --bg: #1f1f24;

--- a/server.js
+++ b/server.js
@@ -3801,6 +3801,55 @@ function safeJsonParse(raw, fallback) {
     return fallback;
   }
 }
+function safeString(value, fallback = "") {
+  if (typeof value === "string") return value;
+  if (value === null || value === undefined) return fallback;
+  return String(value);
+}
+function safeNumber(value, fallback = 0) {
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+const PREFS_DEFAULTS = Object.freeze({
+  dmBadgePrefs: { direct: "#ed4245", group: "#5865f2" },
+  dmThemePrefs: { background: "#1e1f22" },
+  sound: {
+    enabled: false,
+    room: true,
+    dm: true,
+    mention: true,
+    sent: false,
+    receive: false,
+    reaction: false,
+  },
+});
+function normalizeSoundPrefs(raw) {
+  const base = { ...PREFS_DEFAULTS.sound };
+  if (!raw || typeof raw !== "object") return base;
+  for (const key of Object.keys(base)) {
+    if (typeof raw[key] === "boolean") base[key] = raw[key];
+  }
+  return base;
+}
+function normalizePrefs(raw) {
+  const prefs = raw && typeof raw === "object" ? raw : {};
+  const dmBadgePrefs = { ...PREFS_DEFAULTS.dmBadgePrefs };
+  if (prefs.dmBadgePrefs && typeof prefs.dmBadgePrefs === "object") {
+    if (typeof prefs.dmBadgePrefs.direct === "string") dmBadgePrefs.direct = prefs.dmBadgePrefs.direct;
+    if (typeof prefs.dmBadgePrefs.group === "string") dmBadgePrefs.group = prefs.dmBadgePrefs.group;
+  }
+  const dmThemePrefs = { ...PREFS_DEFAULTS.dmThemePrefs };
+  if (prefs.dmThemePrefs && typeof prefs.dmThemePrefs === "object") {
+    if (typeof prefs.dmThemePrefs.background === "string") dmThemePrefs.background = prefs.dmThemePrefs.background;
+  }
+  return {
+    ...prefs,
+    dmBadgePrefs,
+    dmThemePrefs,
+    sound: normalizeSoundPrefs(prefs.sound),
+    chatFx: sanitizeChatFx(prefs.chatFx),
+  };
+}
 function sanitizePrefsInput(p) {
   const out = {};
   if (p && typeof p === "object") {
@@ -3873,7 +3922,7 @@ app.get("/api/me/prefs", requireLogin, async (req, res) => {
     // Prefer Postgres if the user exists there
     if (await pgUserExists(userId)) {
       const { rows } = await pgPool.query("SELECT prefs_json FROM users WHERE id = $1 LIMIT 1", [userId]);
-      const prefs = safeJsonParse(rows?.[0]?.prefs_json, {});
+      const prefs = normalizePrefs(safeJsonParse(rows?.[0]?.prefs_json, {}));
       return res.json({ prefs });
     }
   } catch (e) {
@@ -3882,7 +3931,7 @@ app.get("/api/me/prefs", requireLogin, async (req, res) => {
 
   db.get("SELECT prefs_json FROM users WHERE id = ?", [userId], (err, row) => {
     if (err) return res.status(500).send("Failed");
-    const prefs = safeJsonParse(row?.prefs_json, {});
+    const prefs = normalizePrefs(safeJsonParse(row?.prefs_json, {}));
     return res.json({ prefs });
   });
 });
@@ -3896,7 +3945,7 @@ app.post("/api/me/prefs", requireLogin, async (req, res) => {
     if (await pgUserExists(userId)) {
       const { rows } = await pgPool.query("SELECT prefs_json FROM users WHERE id = $1 LIMIT 1", [userId]);
       const current = safeJsonParse(rows?.[0]?.prefs_json, {});
-      const merged = { ...(current || {}), ...(incoming || {}) };
+      const merged = normalizePrefs({ ...(current || {}), ...(incoming || {}) });
       // IMPORTANT: node-postgres does not reliably serialize plain JS objects to JSON/JSONB.
       // Always stringify and cast to jsonb to ensure prefs are actually persisted.
       await pgPool.query("UPDATE users SET prefs_json = $1::jsonb WHERE id = $2", [JSON.stringify(merged), userId]);
@@ -3916,7 +3965,7 @@ app.post("/api/me/prefs", requireLogin, async (req, res) => {
   // SQLite fallback
   db.get("SELECT prefs_json FROM users WHERE id = ?", [userId], (_e, row) => {
     const current = safeJsonParse(row?.prefs_json, {});
-    const merged = { ...(current || {}), ...(incoming || {}) };
+    const merged = normalizePrefs({ ...(current || {}), ...(incoming || {}) });
     db.run("UPDATE users SET prefs_json = ? WHERE id = ?", [JSON.stringify(merged), userId], (err2) => {
       if (err2) return res.status(500).send("Failed");
       if (shouldUpdateChatFx) {
@@ -5758,8 +5807,8 @@ if (!room) {
     }
   });
 
-  socket.on("dm join", ({ threadId }) => {
-    const tid = Number(threadId);
+  socket.on("dm join", (payload = {}) => {
+    const tid = Number(payload.threadId);
     if (!Number.isInteger(tid)) return;
 
     loadThreadForUser(tid, socket.user.id, (err, thread) => {
@@ -5834,10 +5883,10 @@ if (!room) {
   });
 
   
-  socket.on("dm mark read", ({ threadId, messageId, ts }) => {
-    const tid = Number(threadId);
-    const mid = Number(messageId);
-    const tms = Number(ts) || Date.now();
+  socket.on("dm mark read", (payload = {}) => {
+    const tid = Number(payload.threadId);
+    const mid = Number(payload.messageId);
+    const tms = safeNumber(payload.ts, Date.now());
     if (!socket.user) return;
     if (!Number.isInteger(tid) || !Number.isInteger(mid)) return;
 
@@ -5869,16 +5918,17 @@ if (!room) {
   });
 
 
-  socket.on("dm leave", ({ threadId }) => {
-    const tid = Number(threadId);
+  socket.on("dm leave", (payload = {}) => {
+    const tid = Number(payload.threadId);
     if (!Number.isInteger(tid)) return;
     try { socket.leave(`dm:${tid}`); } catch {}
     try { socket.dmThreads?.delete(tid); } catch {}
   });
 
-socket.on("dm message", ({ threadId, text, replyToId, attachment, tone }) => {
+  socket.on("dm message", (payload = {}) => {
+    const { threadId, text, replyToId, attachment, tone } = payload || {};
     const tid = Number(threadId);
-    const body = String(text || "").trim().slice(0, 800);
+    const body = safeString(text, "").trim().slice(0, 800);
     const att = attachment && typeof attachment === "object" ? attachment : null;
     const toneKey = sanitizeTone(tone);
 
@@ -5903,7 +5953,7 @@ socket.on("dm message", ({ threadId, text, replyToId, attachment, tone }) => {
       if (err) return;
       const ts = Date.now();
 
-      const replyId = Number(replyToId);
+      const replyId = safeNumber(replyToId, NaN);
       const doInsert = (replyMeta = {}) => {
         const replyUser = replyMeta.user || null;
         const replyText = replyMeta.text || null;
@@ -5954,7 +6004,7 @@ socket.on("dm message", ({ threadId, text, replyToId, attachment, tone }) => {
               io.to(`dm:${tid}`).emit("dm message", payload);
             }
           );
-        };
+      };
 
       if (Number.isInteger(replyId)) {
         db.get(
@@ -5971,10 +6021,10 @@ socket.on("dm message", ({ threadId, text, replyToId, attachment, tone }) => {
   });
 
     // ---- DM edit message (self-only, short window)
-  socket.on("dm edit message", ({ threadId, messageId, text }) => {
-    const tid = Number(threadId);
-    const mid = Number(messageId);
-    const body = String(text || "").trim().slice(0, 2000);
+  socket.on("dm edit message", (payload = {}) => {
+    const tid = Number(payload.threadId);
+    const mid = Number(payload.messageId);
+    const body = safeString(payload.text, "").trim().slice(0, 2000);
     if (!socket.user) return;
     if (!Number.isInteger(tid) || !Number.isInteger(mid) || !body) return;
 
@@ -6012,10 +6062,10 @@ socket.on("dm message", ({ threadId, text, replyToId, attachment, tone }) => {
   });
 
   // ---- DM reactions (1 reaction per user per DM message)
-  socket.on("dm reaction", ({ threadId, messageId, emoji }) => {
-    const tid = Number(threadId);
-    const mid = Number(messageId);
-    const em = String(emoji || "").slice(0, 8);
+  socket.on("dm reaction", (payload = {}) => {
+    const tid = Number(payload.threadId);
+    const mid = Number(payload.messageId);
+    const em = safeString(payload.emoji, "").slice(0, 8);
     if (!socket.user) return;
     if (!Number.isInteger(tid) || !Number.isInteger(mid) || !em) return;
 
@@ -6055,7 +6105,7 @@ socket.on("status change", ({ status }) => {
     if (socket.currentRoom) emitUserList(socket.currentRoom);
   });
 
-  socket.on("chat message", (payload) => {
+  socket.on("chat message", (payload = {}) => {
     // If a client sends before it has joined a room (mobile reconnect/race),
     // auto-join main so the message doesn't silently disappear.
     let room = socket.currentRoom;
@@ -6083,16 +6133,16 @@ socket.on("status change", ({ status }) => {
       isPunished(socket.user.id, "mute", (muted) => {
         if (muted) return;
 
-        const text = String(payload?.text || "").slice(0, 800);
+        const text = safeString(payload.text, "").slice(0, 800);
         if (text.trim().startsWith("/")) {
           executeCommand(socket, text, room);
           return;
         }
-        const attachmentUrl = String(payload?.attachmentUrl || "").slice(0, 400);
-        const attachmentType = String(payload?.attachmentType || "").slice(0, 20);
-        const attachmentMime = String(payload?.attachmentMime || "").slice(0, 60);
-        const attachmentSize = Number(payload?.attachmentSize || 0) || 0;
-        const tone = sanitizeTone(payload?.tone);
+        const attachmentUrl = safeString(payload.attachmentUrl, "").slice(0, 400);
+        const attachmentType = safeString(payload.attachmentType, "").slice(0, 20);
+        const attachmentMime = safeString(payload.attachmentMime, "").slice(0, 60);
+        const attachmentSize = safeNumber(payload.attachmentSize, 0);
+        const tone = sanitizeTone(payload.tone);
 
         awardPassiveGold(socket.user.id);
 
@@ -6122,7 +6172,7 @@ socket.on("status change", ({ status }) => {
               slowmodeTracker.set(key, Date.now());
             }
 
-            const replyId = Number(payload?.replyToId);
+            const replyId = safeNumber(payload.replyToId, NaN);
             const insertWithReply = (replyMeta = {}) => {
               const replyPk = Number.isInteger(replyMeta.id) ? replyMeta.id : null;
               const replyUser = replyMeta.username || replyMeta.user || null;
@@ -6191,9 +6241,9 @@ socket.on("status change", ({ status }) => {
   });
 
   // ---- Edit message (self-only, short window)
-  socket.on("edit message", ({ messageId, text }) => {
-    const mid = Number(messageId);
-    const body = String(text || "").trim().slice(0, 2000);
+  socket.on("edit message", (payload = {}) => {
+    const mid = Number(payload.messageId);
+    const body = safeString(payload.text, "").trim().slice(0, 2000);
     if (!socket.user) return;
     if (!Number.isInteger(mid) || !body) return;
 


### PR DESCRIPTION
### Motivation
- Fix a visual-state bug where the DM avatar strip could show the "No active DMs" placeholder while threads exist by relying on DOM truth instead of cached JS state.
- Improve robustness of client and server code to avoid uncaught exceptions from malformed socket payloads and localStorage JSON.
- Ensure user appearance (chatFx) updates apply to already-rendered messages and future messages consistently.
- Normalize and sanitize user prefs server-side so preferences always merge with safe defaults.

### Description
- Added `updateDmThreadPlaceholderVisibility()` and switched quick-strip visibility to class toggling using a new `.hidden` utility rule in `public/styles.css`, and called the helper from direct/group render code paths (`public/app.js`).
- Introduced defensive helpers `safeJsonParse`, `safeNumber`, and `safeString` in `public/app.js` and analogous `safeString`, `safeNumber`, `normalizePrefs`, and `normalizeSoundPrefs` on the server, and replaced fragile JSON/localStorage/payload access with these helpers (`server.js`, `public/app.js`).
- Hardened socket handling by normalizing incoming handlers to accept `payload = {}` and validating fields, and prevented duplicate listeners by removing previous listeners before creating a new socket instance in `public/app.js`.
- Added `updateUserFxInDom(username, fx)` and a `user fx updated` handler to update styling on existing rendered messages immediately when a user updates their `chatFx` (`public/app.js`).

### Testing
- Ran `npm ci` successfully (packages installed).
- Ran `npm run test`, `npm run check`, and `npm run verify` and they completed without failures.
- Attempted to start the server (`npm start`); the process started but Postgres connectivity failed with `ECONNREFUSED` in this environment while the app continued to run, so database-backed prefs/PG paths were not reachable here.
- UI automation screenshot attempt (Playwright) timed out locating login element in this environment, so manual smoke checks were not performed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696058ec8bc083338fc00254931cbbe5)