### PR TITLE
Add expandable Tone menu button beside Send

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -680,10 +680,10 @@ const CHAT_FX_DEFAULTS = Object.freeze({
   polishAnimations: true
 });
 const TONE_OPTIONS = Object.freeze([
-  { key: "chill", emoji: "😌", label: "Chill" },
-  { key: "joke", emoji: "😂", label: "Joke" },
-  { key: "sarcastic", emoji: "🙃", label: "Sarcastic" },
-  { key: "serious", emoji: "⚠️", label: "Serious" }
+  { key: "chill", emoji: "😌", name: "Chill", description: "Relaxed / friendly" },
+  { key: "joke", emoji: "😂", name: "Joke", description: "Joking / playful" },
+  { key: "sarcastic", emoji: "🙃", name: "Sarcastic", description: "Sarcasm" },
+  { key: "serious", emoji: "⚠️", name: "Serious", description: "Serious / important" }
 ]);
 const CHAT_FX_FONT_STACKS = Object.freeze({
   system: "system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
@@ -1909,35 +1909,144 @@ const draftDebounce = (()=> {
   };
 })();
 
-function updateTonePicker(container, activeKey){
+const TONE_MENU_OPTIONS = Object.freeze([
+  { key: "", emoji: "🚫", name: "Clear tone (None)", description: "No tone" },
+  ...TONE_OPTIONS
+]);
+let openToneMenu = null;
+let toneMenuListenersBound = false;
+
+function toneMenuButtonLabel(toneKey){
+  const tone = toneMeta(toneKey);
+  return tone ? `Tone: ${tone.name} ${tone.emoji}` : "Tone: None";
+}
+
+function toneMenuTooltip(toneKey){
+  const tone = toneMeta(toneKey);
+  return tone ? `Tone: ${tone.name} — ${tone.description}` : "Tone: None";
+}
+
+function updateToneMenu(container, activeKey){
   if (!container) return;
-  container.querySelectorAll("button[data-tone]").forEach((btn) => {
-    const on = btn.dataset.tone === activeKey;
-    btn.classList.toggle("active", on);
-    btn.setAttribute("aria-pressed", on ? "true" : "false");
+  const btn = container.querySelector(".toneMenuBtn");
+  if (btn) {
+    btn.textContent = toneMenuButtonLabel(activeKey);
+    btn.title = toneMenuTooltip(activeKey);
+    btn.setAttribute("aria-label", toneMenuButtonLabel(activeKey));
+  }
+  container.querySelectorAll(".toneMenuItem").forEach((item) => {
+    const on = (item.dataset.tone || "") === (activeKey || "");
+    item.classList.toggle("is-active", on);
+    item.setAttribute("aria-checked", on ? "true" : "false");
   });
 }
 
-function initTonePicker(container, getTone, setTone){
+function closeToneMenu(menu){
+  if (!menu) return;
+  menu.container.classList.remove("is-open");
+  menu.button.setAttribute("aria-expanded", "false");
+  menu.panel.setAttribute("aria-hidden", "true");
+  if (openToneMenu === menu) openToneMenu = null;
+}
+
+function openToneMenuPanel(menu){
+  if (!menu) return;
+  if (openToneMenu && openToneMenu !== menu) closeToneMenu(openToneMenu);
+  menu.container.classList.add("is-open");
+  menu.button.setAttribute("aria-expanded", "true");
+  menu.panel.setAttribute("aria-hidden", "false");
+  openToneMenu = menu;
+}
+
+function toggleToneMenu(menu){
+  if (!menu) return;
+  const isOpen = menu.container.classList.contains("is-open");
+  if (isOpen) closeToneMenu(menu);
+  else openToneMenuPanel(menu);
+}
+
+function bindToneMenuListeners(){
+  if (toneMenuListenersBound) return;
+  toneMenuListenersBound = true;
+  document.addEventListener("pointerdown", (e) => {
+    if (!openToneMenu) return;
+    if (openToneMenu.container.contains(e.target)) return;
+    closeToneMenu(openToneMenu);
+  }, true);
+  document.addEventListener("keydown", (e) => {
+    if (e.key !== "Escape" || !openToneMenu) return;
+    closeToneMenu(openToneMenu);
+  });
+}
+
+function initToneMenu(container, getTone, setTone){
   if (!container) return;
   container.innerHTML = "";
-  TONE_OPTIONS.forEach((tone) => {
-    const btn = document.createElement("button");
-    btn.type = "button";
-    btn.className = "toneBtn";
-    btn.dataset.tone = tone.key;
-    btn.textContent = tone.emoji;
-    btn.title = tone.label;
-    btn.setAttribute("aria-label", tone.label);
-    btn.addEventListener("click", () => {
-      const current = getTone();
-      const next = current === tone.key ? "" : tone.key;
-      setTone(next);
-      updateTonePicker(container, next);
-    });
-    container.appendChild(btn);
+  container.classList.add("toneMenu");
+
+  const menuId = `${container.id || "tone"}Menu`;
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "toneMenuBtn";
+  button.setAttribute("aria-expanded", "false");
+  button.setAttribute("aria-controls", menuId);
+  button.setAttribute("aria-haspopup", "menu");
+
+  const panel = document.createElement("div");
+  panel.className = "toneMenuPanel";
+  panel.id = menuId;
+  panel.setAttribute("role", "menu");
+  panel.setAttribute("aria-hidden", "true");
+
+  TONE_MENU_OPTIONS.forEach((tone) => {
+    const item = document.createElement("button");
+    item.type = "button";
+    item.className = "toneMenuItem";
+    item.dataset.tone = tone.key;
+    item.setAttribute("role", "menuitemradio");
+    item.setAttribute("aria-checked", "false");
+
+    const emoji = document.createElement("span");
+    emoji.className = "toneMenuEmoji";
+    emoji.textContent = tone.emoji;
+
+    const textWrap = document.createElement("span");
+    textWrap.className = "toneMenuText";
+
+    const name = document.createElement("span");
+    name.className = "toneMenuName";
+    name.textContent = tone.name;
+
+    const desc = document.createElement("span");
+    desc.className = "toneMenuDesc";
+    desc.textContent = tone.description;
+
+    textWrap.appendChild(name);
+    textWrap.appendChild(desc);
+    item.appendChild(emoji);
+    item.appendChild(textWrap);
+    panel.appendChild(item);
   });
-  updateTonePicker(container, getTone());
+
+  const menuState = { container, button, panel };
+  button.addEventListener("click", (e) => {
+    e.preventDefault();
+    toggleToneMenu(menuState);
+  });
+
+  panel.addEventListener("click", (e) => {
+    const item = e.target.closest(".toneMenuItem");
+    if (!item) return;
+    const next = item.dataset.tone || "";
+    setTone(next);
+    updateToneMenu(container, next);
+    closeToneMenu(menuState);
+  });
+
+  container.appendChild(button);
+  container.appendChild(panel);
+  updateToneMenu(container, getTone());
+  bindToneMenuListeners();
 }
 
 const msgInput = document.getElementById("msgInput");
@@ -4311,8 +4420,9 @@ function buildMainMsgItem(m, opts){
     const toneEl = document.createElement("span");
     toneEl.className = "toneBadge";
     toneEl.textContent = tone.emoji;
-    toneEl.title = tone.label;
-    toneEl.setAttribute("aria-label", `${tone.label} tone`);
+    const toneLabel = `Tone: ${tone.name} — ${tone.description}`;
+    toneEl.title = toneLabel;
+    toneEl.setAttribute("aria-label", toneLabel);
     time.appendChild(toneEl);
   }
 
@@ -5687,8 +5797,9 @@ function renderDmMessages(threadId){
       const toneEl = document.createElement("span");
       toneEl.className = "toneBadge";
       toneEl.textContent = tone.emoji;
-      toneEl.title = tone.label;
-      toneEl.setAttribute("aria-label", `${tone.label} tone`);
+      const toneLabel = `Tone: ${tone.name} — ${tone.description}`;
+      toneEl.title = toneLabel;
+      toneEl.setAttribute("aria-label", toneLabel);
       t.appendChild(toneEl);
     }
 
@@ -5952,7 +6063,7 @@ function sendDmMessage(){
   dmPendingAttachment = null;
   setDmReplyTarget(null);
   activeDmTone = "";
-  updateTonePicker(dmTonePicker, activeDmTone);
+  updateToneMenu(dmTonePicker, activeDmTone);
   // Clear any "ready" notice
   setDmNotice("");
 }
@@ -7732,8 +7843,8 @@ function setDmReplyTarget(target){
   }
 }
 
-initTonePicker(tonePicker, () => activeTone, (next) => { activeTone = next; });
-initTonePicker(dmTonePicker, () => activeDmTone, (next) => { activeDmTone = next; });
+initToneMenu(tonePicker, () => activeTone, (next) => { activeTone = next; });
+initToneMenu(dmTonePicker, () => activeDmTone, (next) => { activeDmTone = next; });
 
 // typing/send
 let typingDebounce=null;
@@ -7793,7 +7904,7 @@ async function sendMessage(){
     msgInput.value="";
     setReplyTarget(null);
     activeTone = "";
-    updateTonePicker(tonePicker, activeTone);
+    updateToneMenu(tonePicker, activeTone);
     socket.emit("stop typing");
 
     // keep focus on mobile

--- a/public/styles.css
+++ b/public/styles.css
@@ -2672,26 +2672,95 @@ body.dice-room .sys .diceFace{
   outline:none;
 }
 .tonePicker{
+  position:relative;
   display:flex;
   align-items:center;
-  gap:6px;
-  padding:4px 6px;
-  border-radius:999px;
+  flex-shrink:0;
+}
+.toneMenuBtn{
   border:1px solid var(--border);
   background:color-mix(in srgb, var(--panel) 85%, transparent);
-}
-.toneBtn{
-  border:none;
-  background:transparent;
+  color:var(--text);
   cursor:pointer;
-  font-size:16px;
-  line-height:1;
-  padding:2px 4px;
-  border-radius:8px;
+  font-size:13px;
+  font-weight:800;
+  line-height:1.1;
+  padding:8px 12px;
+  border-radius:999px;
+  min-height:38px;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
 }
-.toneBtn.active{
-  background:color-mix(in srgb, var(--accent) 30%, transparent);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+.tonePicker.is-open .toneMenuBtn{
+  box-shadow:0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.toneMenuPanel{
+  position:absolute;
+  right:0;
+  bottom:calc(100% + 8px);
+  min-width:220px;
+  max-width:min(280px, 90vw);
+  padding:8px;
+  border-radius:14px;
+  border:1px solid var(--border);
+  background:var(--panel);
+  box-shadow:var(--shadowLg);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  opacity:0;
+  transform:translateY(6px);
+  pointer-events:none;
+  z-index:180;
+  transition:opacity .15s ease, transform .15s ease;
+}
+.tonePicker.is-open .toneMenuPanel{
+  opacity:1;
+  transform:translateY(0);
+  pointer-events:auto;
+}
+.toneMenuItem{
+  border:1px solid transparent;
+  background:transparent;
+  color:var(--text);
+  cursor:pointer;
+  border-radius:12px;
+  padding:8px 10px;
+  display:flex;
+  align-items:flex-start;
+  gap:8px;
+  text-align:left;
+  font-size:13px;
+}
+.toneMenuItem:hover{
+  background:color-mix(in srgb, var(--panel2) 90%, transparent);
+  border-color:var(--border);
+}
+.toneMenuItem.is-active{
+  background:color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color:color-mix(in srgb, var(--accent) 50%, transparent);
+}
+.toneMenuEmoji{
+  font-size:16px;
+  line-height:1.2;
+}
+.toneMenuText{
+  display:flex;
+  flex-direction:column;
+  gap:2px;
+}
+.toneMenuName{
+  font-weight:800;
+}
+.toneMenuDesc{
+  font-size:11px;
+  color:var(--muted);
+}
+@media (prefers-reduced-motion: reduce){
+  .toneMenuPanel{
+    transition:none;
+  }
 }
 body:not(.polish-pack) .tonePicker{
   display:none;


### PR DESCRIPTION
### Motivation
- Provide a single, clear Tone control attached to the Send button that reads `Tone: None` by default and `Tone: <Name> <Emoji>` after selection.
- Replace the small icon strip with a compact, accessible popover that lists options with emoji, name and a one-line description.
- Ensure the UX works on touch devices (sufficient hit target, no focus loss) and respects `prefers-reduced-motion`. 
- Keep existing behavior: tone selection remains per-message (it clears after sending) to match current flows.

### Description
- Added richer tone metadata and enum (`name`, `emoji`, `description`) in `public/app.js` and replaced the icon picker with a new `initToneMenu` / popover implementation. 
- Implemented menu open/close/toggle helpers (`openToneMenuPanel`, `closeToneMenu`, `toggleToneMenu`) with outside-tap and `Escape` handling and accessible attributes (`aria-expanded`, `aria-controls`, role/checked states). 
- Updated message rendering to show tone emoji near timestamps and improved tooltip/title to `Tone: <Name> — <description>`; integrated the new menu for both main composer and DMs. 
- Added touch-friendly styling and popover layout in `public/styles.css` (rounded panel, shadow, min touch height, reduced-motion handling) and limited changes to `public/app.js` + `public/styles.css` only.

### Testing
- Ran `npm run check` which completed successfully. 
- Ran `npm run verify` which completed successfully. 
- Ran `npm run test` (project contains no unit tests) which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960672b4840833398179283928435cb)