### PR TITLE
Fix theme persistence & history ordering; restore Send split-button and add Personalisation categories

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1910,7 +1910,7 @@ const draftDebounce = (()=> {
 })();
 
 const TONE_MENU_OPTIONS = Object.freeze([
-  { key: "", emoji: "🚫", name: "Clear tone (None)", description: "No tone" },
+  { key: "", emoji: "🚫", name: "None (clear tone)", description: "No tone" },
   ...TONE_OPTIONS
 ]);
 let openToneMenu = null;
@@ -1930,10 +1930,11 @@ function updateToneMenu(container, activeKey){
   if (!container) return;
   const btn = container.querySelector(".toneMenuBtn");
   if (btn) {
-    btn.textContent = toneMenuButtonLabel(activeKey);
+    btn.textContent = "▴";
     btn.title = toneMenuTooltip(activeKey);
     btn.setAttribute("aria-label", toneMenuButtonLabel(activeKey));
   }
+  container.classList.toggle("has-tone", !!activeKey);
   container.querySelectorAll(".toneMenuItem").forEach((item) => {
     const on = (item.dataset.tone || "") === (activeKey || "");
     item.classList.toggle("is-active", on);
@@ -8647,6 +8648,32 @@ async function saveChatFxPrefs(){
   }
 }
 
+const PERSONALISATION_SECTIONS_KEY = "ui.personalisation.openSections";
+function initPersonalisationSections(container){
+  if (!container) return;
+  const sections = Array.from(container.querySelectorAll(".prefsSection"));
+  if (!sections.length) return;
+  let stored = [];
+  try {
+    const raw = localStorage.getItem(PERSONALISATION_SECTIONS_KEY);
+    stored = raw ? JSON.parse(raw) : [];
+  } catch {
+    stored = [];
+  }
+  const storedSet = new Set(Array.isArray(stored) ? stored : []);
+  sections.forEach((section, idx) => {
+    const key = section.dataset.section || String(idx);
+    if (storedSet.size) section.open = storedSet.has(key);
+    section.addEventListener("toggle", () => {
+      const openKeys = sections
+        .filter((item) => item.open)
+        .map((item) => item.dataset.section)
+        .filter(Boolean);
+      try { localStorage.setItem(PERSONALISATION_SECTIONS_KEY, JSON.stringify(openKeys)); } catch {}
+    });
+  });
+}
+
 function wireChatFxPrefs(){
   if (!editPreferencesPanel || editPreferencesPanel._chatFxWired) return;
   editPreferencesPanel._chatFxWired = true;
@@ -8670,159 +8697,190 @@ function wireChatFxPrefs(){
           </div>
         </div>
       </div>
-      <div class="field polishPackField">
-        <div class="polishPackHeader">
-          <label style="margin:0;">Enable Polish Pack</label>
-          <input id="chatFxPolishPack" type="checkbox">
-        </div>
-        <div class="polishPackOptions">
-          <label><input id="chatFxPolishAuras" type="checkbox"> Avatar auras</label>
-          <label><input id="chatFxPolishAnimations" type="checkbox"> Animations</label>
-        </div>
-      </div>
-      <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
-        <label style="margin:0;">Enabled</label>
-        <input id="chatFxEnabled" type="checkbox">
-      </div>
-      <div class="field">
-        <label>Glow</label>
-        <select id="chatFxGlow">
-          <option value="off">Off</option>
-          <option value="soft">Soft</option>
-          <option value="neon">Neon</option>
-          <option value="strong">Strong</option>
-        </select>
-      </div>
-      <div class="field">
-        <label>Font</label>
-        <select id="chatFxFont">
-          ${buildFontSelectOptionsHTML()}
-        </select>
-      </div>
-      <div class="field">
-        <label>Username font</label>
-        <select id="chatFxNameFont">
-          ${buildFontSelectOptionsHTML()}
-        </select>
-      </div>
-      <div class="field">
-        <label>Username color</label>
-        <div class="chatFxColorRow">
-          <input id="chatFxNameColorPick" type="color" value="#ffffff" aria-label="Pick username color">
-          <input id="chatFxNameColor" type="hidden" value="">
-          <button class="pillBtn" id="chatFxNameColorClear" type="button">Clear</button>
-        </div>
-        <div class="small">Leave blank to use the theme's default name colour.</div>
-      </div>
-      <div class="field">
-        <label>Bubble radius</label>
-        <div class="chatFxSliderRow">
-          <input id="chatFxRadius" type="range" min="6" max="28" step="1">
-          <span class="chatFxSliderValue" id="chatFxRadiusValue">14</span>
-        </div>
-      </div>
-      <div class="field">
-        <label>Border thickness</label>
-        <div class="chatFxSliderRow">
-          <input id="chatFxBorder" type="range" min="0" max="3" step="1">
-          <span class="chatFxSliderValue" id="chatFxBorderValue">0</span>
-        </div>
-      </div>
-      <div class="field">
-        <label>Glass opacity</label>
-        <div class="chatFxSliderRow">
-          <input id="chatFxGlass" type="range" min="0" max="1" step="0.05">
-          <span class="chatFxSliderValue" id="chatFxGlassValue">0</span>
-        </div>
-      </div>
-      <div class="field">
-        <label>Glass blur</label>
-        <div class="chatFxSliderRow">
-          <input id="chatFxBlur" type="range" min="0" max="16" step="1">
-          <span class="chatFxSliderValue" id="chatFxBlurValue">0</span>
-        </div>
-      </div>
-      <div class="field">
-        <label>Density</label>
-        <div class="chatFxDensityRow" id="chatFxDensity">
-          <button class="pillBtn" type="button" data-value="compact">Compact</button>
-          <button class="pillBtn" type="button" data-value="cozy">Cozy</button>
-          <button class="pillBtn" type="button" data-value="spacious">Spacious</button>
-        </div>
-      </div>
-      <div class="field">
-        <label>Accent color (optional)</label>
-        <input id="chatFxAccent" type="text" placeholder="#RRGGBB">
-        <div class="small">Leave blank to keep your theme accent.</div>
-      </div>
-      <div class="field">
-        <label>Bubble color (optional)</label>
-        <div class="chatFxColorRow">
-          <input id="chatFxBubbleColorPick" type="color" value="#2b2d31" aria-label="Pick bubble color">
-          <input id="chatFxBubbleColor" type="text" placeholder="#RRGGBB">
-          <button class="pillBtn" id="chatFxBubbleColorClear" type="button">Clear</button>
-        </div>
-        <div class="small">Leave blank to use the theme bubble colour.</div>
-      </div>
-      <div class="field">
-        <label>Text color (optional)</label>
-        <div class="chatFxColorRow">
-          <input id="chatFxTextColorPick" type="color" value="#ffffff" aria-label="Pick text color">
-          <input id="chatFxTextColor" type="text" placeholder="#RRGGBB">
-          <button class="pillBtn" id="chatFxTextColorClear" type="button">Clear</button>
-        </div>
-        <div class="small">Leave blank to use the theme's default message text.</div>
-      </div>
-      <div class="field">
-        <label>Message text style</label>
-        <div class="chatFxColorRow" style="justify-content:flex-start;">
-          <label style="display:flex; align-items:center; gap:6px;">
-            <input id="chatFxTextBold" type="checkbox"> Bold
-          </label>
-          <label style="display:flex; align-items:center; gap:6px;">
-            <input id="chatFxTextItalic" type="checkbox"> Italic
-          </label>
-        </div>
-      </div>
-      <div class="field">
-        <label>Text glow</label>
-        <select id="chatFxTextGlow">
-          <option value="off">Off</option>
-          <option value="soft">Soft</option>
-          <option value="neon">Neon</option>
-          <option value="strong">Strong</option>
-        </select>
-      </div>
-      <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
-        <label style="margin:0;">Text gradient</label>
-        <input id="chatFxTextGradientEnabled" type="checkbox">
-      </div>
-      <div class="field">
-        <label>Gradient color A</label>
-        <div class="chatFxColorRow">
-          <input id="chatFxTextGradientAPick" type="color" value="#7c4dff" aria-label="Pick gradient color A">
-          <input id="chatFxTextGradientA" type="text" placeholder="#RRGGBB">
-          <button class="pillBtn" id="chatFxTextGradientAClear" type="button">Clear</button>
-        </div>
-      </div>
-      <div class="field">
-        <label>Gradient color B</label>
-        <div class="chatFxColorRow">
-          <input id="chatFxTextGradientBPick" type="color" value="#00e5ff" aria-label="Pick gradient color B">
-          <input id="chatFxTextGradientB" type="text" placeholder="#RRGGBB">
-          <button class="pillBtn" id="chatFxTextGradientBClear" type="button">Clear</button>
-        </div>
-      </div>
-      <div class="field">
-        <label>Gradient angle</label>
-        <div class="chatFxSliderRow">
-          <input id="chatFxTextGradientAngle" type="range" min="0" max="360" step="1">
-          <span class="chatFxSliderValue" id="chatFxTextGradientAngleValue">135</span>
-        </div>
-      </div>
-      <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
-        <label style="margin:0;">Auto-contrast text</label>
-        <input id="chatFxAutoContrast" type="checkbox">
+      <div class="prefsSections">
+        <details class="prefsSection" data-section="text-fonts" open>
+          <summary>Text &amp; Fonts</summary>
+          <div class="prefsContent">
+            <div class="field">
+              <label>Font</label>
+              <select id="chatFxFont">
+                ${buildFontSelectOptionsHTML()}
+              </select>
+            </div>
+            <div class="field">
+              <label>Username font</label>
+              <select id="chatFxNameFont">
+                ${buildFontSelectOptionsHTML()}
+              </select>
+            </div>
+            <div class="field">
+              <label>Text color (optional)</label>
+              <div class="chatFxColorRow">
+                <input id="chatFxTextColorPick" type="color" value="#ffffff" aria-label="Pick text color">
+                <input id="chatFxTextColor" type="text" placeholder="#RRGGBB">
+                <button class="pillBtn" id="chatFxTextColorClear" type="button">Clear</button>
+              </div>
+              <div class="small">Leave blank to use the theme's default message text.</div>
+            </div>
+            <div class="field">
+              <label>Message text style</label>
+              <div class="chatFxColorRow" style="justify-content:flex-start;">
+                <label style="display:flex; align-items:center; gap:6px;">
+                  <input id="chatFxTextBold" type="checkbox"> Bold
+                </label>
+                <label style="display:flex; align-items:center; gap:6px;">
+                  <input id="chatFxTextItalic" type="checkbox"> Italic
+                </label>
+              </div>
+            </div>
+            <div class="field">
+              <label>Text glow</label>
+              <select id="chatFxTextGlow">
+                <option value="off">Off</option>
+                <option value="soft">Soft</option>
+                <option value="neon">Neon</option>
+                <option value="strong">Strong</option>
+              </select>
+            </div>
+            <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
+              <label style="margin:0;">Text gradient</label>
+              <input id="chatFxTextGradientEnabled" type="checkbox">
+            </div>
+            <div class="field">
+              <label>Gradient color A</label>
+              <div class="chatFxColorRow">
+                <input id="chatFxTextGradientAPick" type="color" value="#7c4dff" aria-label="Pick gradient color A">
+                <input id="chatFxTextGradientA" type="text" placeholder="#RRGGBB">
+                <button class="pillBtn" id="chatFxTextGradientAClear" type="button">Clear</button>
+              </div>
+            </div>
+            <div class="field">
+              <label>Gradient color B</label>
+              <div class="chatFxColorRow">
+                <input id="chatFxTextGradientBPick" type="color" value="#00e5ff" aria-label="Pick gradient color B">
+                <input id="chatFxTextGradientB" type="text" placeholder="#RRGGBB">
+                <button class="pillBtn" id="chatFxTextGradientBClear" type="button">Clear</button>
+              </div>
+            </div>
+            <div class="field">
+              <label>Gradient angle</label>
+              <div class="chatFxSliderRow">
+                <input id="chatFxTextGradientAngle" type="range" min="0" max="360" step="1">
+                <span class="chatFxSliderValue" id="chatFxTextGradientAngleValue">135</span>
+              </div>
+            </div>
+            <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
+              <label style="margin:0;">Auto-contrast text</label>
+              <input id="chatFxAutoContrast" type="checkbox">
+            </div>
+          </div>
+        </details>
+        <details class="prefsSection" data-section="bubbles" open>
+          <summary>Bubbles &amp; Chat Style</summary>
+          <div class="prefsContent">
+            <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
+              <label style="margin:0;">Enabled</label>
+              <input id="chatFxEnabled" type="checkbox">
+            </div>
+            <div class="field">
+              <label>Glow</label>
+              <select id="chatFxGlow">
+                <option value="off">Off</option>
+                <option value="soft">Soft</option>
+                <option value="neon">Neon</option>
+                <option value="strong">Strong</option>
+              </select>
+            </div>
+            <div class="field">
+              <label>Bubble radius</label>
+              <div class="chatFxSliderRow">
+                <input id="chatFxRadius" type="range" min="6" max="28" step="1">
+                <span class="chatFxSliderValue" id="chatFxRadiusValue">14</span>
+              </div>
+            </div>
+            <div class="field">
+              <label>Border thickness</label>
+              <div class="chatFxSliderRow">
+                <input id="chatFxBorder" type="range" min="0" max="3" step="1">
+                <span class="chatFxSliderValue" id="chatFxBorderValue">0</span>
+              </div>
+            </div>
+            <div class="field">
+              <label>Glass opacity</label>
+              <div class="chatFxSliderRow">
+                <input id="chatFxGlass" type="range" min="0" max="1" step="0.05">
+                <span class="chatFxSliderValue" id="chatFxGlassValue">0</span>
+              </div>
+            </div>
+            <div class="field">
+              <label>Glass blur</label>
+              <div class="chatFxSliderRow">
+                <input id="chatFxBlur" type="range" min="0" max="16" step="1">
+                <span class="chatFxSliderValue" id="chatFxBlurValue">0</span>
+              </div>
+            </div>
+            <div class="field">
+              <label>Density</label>
+              <div class="chatFxDensityRow" id="chatFxDensity">
+                <button class="pillBtn" type="button" data-value="compact">Compact</button>
+                <button class="pillBtn" type="button" data-value="cozy">Cozy</button>
+                <button class="pillBtn" type="button" data-value="spacious">Spacious</button>
+              </div>
+            </div>
+            <div class="field">
+              <label>Bubble color (optional)</label>
+              <div class="chatFxColorRow">
+                <input id="chatFxBubbleColorPick" type="color" value="#2b2d31" aria-label="Pick bubble color">
+                <input id="chatFxBubbleColor" type="text" placeholder="#RRGGBB">
+                <button class="pillBtn" id="chatFxBubbleColorClear" type="button">Clear</button>
+              </div>
+              <div class="small">Leave blank to use the theme bubble colour.</div>
+            </div>
+          </div>
+        </details>
+        <details class="prefsSection" data-section="theme-page">
+          <summary>Theme &amp; Page</summary>
+          <div class="prefsContent">
+            <div class="field">
+              <label>Accent color (optional)</label>
+              <input id="chatFxAccent" type="text" placeholder="#RRGGBB">
+              <div class="small">Leave blank to keep your theme accent.</div>
+            </div>
+          </div>
+        </details>
+        <details class="prefsSection" data-section="profile-identity">
+          <summary>Profile &amp; Identity</summary>
+          <div class="prefsContent">
+            <div class="field">
+              <label>Username color</label>
+              <div class="chatFxColorRow">
+                <input id="chatFxNameColorPick" type="color" value="#ffffff" aria-label="Pick username color">
+                <input id="chatFxNameColor" type="hidden" value="">
+                <button class="pillBtn" id="chatFxNameColorClear" type="button">Clear</button>
+              </div>
+              <div class="small">Leave blank to use the theme's default name colour.</div>
+            </div>
+            <div class="field" style="display:flex; align-items:center; justify-content:space-between; gap:10px;">
+              <label style="margin:0;">Avatar auras</label>
+              <input id="chatFxPolishAuras" type="checkbox">
+            </div>
+            <div class="small">Requires Polish Pack.</div>
+          </div>
+        </details>
+        <details class="prefsSection" data-section="advanced-accessibility">
+          <summary>Advanced / Accessibility</summary>
+          <div class="prefsContent">
+            <div class="field polishPackField">
+              <div class="polishPackHeader">
+                <label style="margin:0;">Enable Polish Pack</label>
+                <input id="chatFxPolishPack" type="checkbox">
+              </div>
+              <div class="polishPackOptions">
+                <label><input id="chatFxPolishAnimations" type="checkbox"> Animations</label>
+              </div>
+            </div>
+          </div>
+        </details>
       </div>
       <div class="chatFxActions">
         <div class="chatFxStatus" id="chatFxStatus"></div>
@@ -8832,6 +8890,7 @@ function wireChatFxPrefs(){
   `;
 
   editPreferencesPanel.appendChild(section);
+  initPersonalisationSections(section);
 
   const q = (sel) => section.querySelector(sel);
   chatFxPrefEls = {

--- a/public/styles.css
+++ b/public/styles.css
@@ -2671,6 +2671,17 @@ body.dice-room .sys .diceFace{
   color:var(--inputText);
   outline:none;
 }
+.inputBar #sendBtn,
+.dmInput #dmSendBtn{
+  order:4;
+  border-top-right-radius:0;
+  border-bottom-right-radius:0;
+}
+.inputBar .tonePicker,
+.dmInput .tonePicker{
+  order:5;
+  margin-left:-10px;
+}
 .tonePicker{
   position:relative;
   display:flex;
@@ -2678,22 +2689,28 @@ body.dice-room .sys .diceFace{
   flex-shrink:0;
 }
 .toneMenuBtn{
-  border:1px solid var(--border);
-  background:color-mix(in srgb, var(--panel) 85%, transparent);
-  color:var(--text);
+  border:0;
+  background:var(--btnPrimaryBg);
+  color:var(--btnPrimaryText);
   cursor:pointer;
-  font-size:13px;
+  font-size:14px;
   font-weight:800;
-  line-height:1.1;
-  padding:8px 12px;
-  border-radius:999px;
+  line-height:1;
+  padding:0 10px;
+  border-radius:0 var(--radiusMd) var(--radiusMd) 0;
   min-height:38px;
+  min-width:36px;
   display:inline-flex;
   align-items:center;
+  justify-content:center;
   gap:6px;
+  border-left:1px solid color-mix(in srgb, var(--btnPrimaryText) 25%, transparent);
 }
 .tonePicker.is-open .toneMenuBtn{
   box-shadow:0 0 0 2px color-mix(in srgb, var(--accent) 35%, transparent);
+}
+.tonePicker.has-tone .toneMenuBtn{
+  box-shadow:0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent);
 }
 .toneMenuPanel{
   position:absolute;
@@ -3043,6 +3060,42 @@ body:not(.polish-pack) .tonePicker{
 .panelBox{ background:var(--panel2); border:1px solid var(--border); border-radius:14px; padding:10px; }
 .panelBox .badge{ background:var(--accent); color:var(--btnPrimaryText); }
 .panelBox .small{ color:var(--muted); }
+.prefsSections{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  margin-top:6px;
+}
+.prefsSection{
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:color-mix(in srgb, var(--panel) 82%, transparent);
+  padding:0;
+}
+.prefsSection summary{
+  list-style:none;
+  cursor:pointer;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  min-height:40px;
+  padding:10px 12px;
+  font-weight:800;
+}
+.prefsSection summary::-webkit-details-marker{ display:none; }
+.prefsSection summary::after{
+  content:"▾";
+  font-size:14px;
+  color:var(--muted);
+  transition:transform .15s ease;
+}
+.prefsSection[open] summary::after{ transform:rotate(180deg); }
+.prefsContent{
+  padding:0 12px 12px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
 .chatFxPreview{
   margin-bottom:12px;
   padding:12px;

--- a/server.js
+++ b/server.js
@@ -1103,6 +1103,35 @@ const ALLOWED_THEMES = [
   "Pastel Light",
   "Paper / Parchment",
   "Sky Light",
+  "Cherry Blossom (Dark)",
+  "Cherry Blossom (Light)",
+  "420 Friendly (Light)",
+  "420 Friendly (Dark)",
+  "Aurora Night",
+  "Mint Soda",
+  "Lavender Fog",
+  "Crimson Noir",
+  "Ocean Mist",
+  "Deep Ocean",
+  "Sunlit Sand",
+  "Graphite",
+  "Forest Night",
+  "Retro Terminal",
+  "Desert Dusk",
+  "Arctic Light",
+  "Rose Quartz",
+  "Lemonade",
+  "Sunrise Sorbet",
+  "Cotton Candy Sky",
+  "Prismatic Pearl",
+  "Citrus Splash",
+  "Glacier Bloom",
+  "Aurora Pastel",
+  "Midnight Mirage",
+  "Neon Abyss",
+  "Velvet Galaxy",
+  "Obsidian Aurora",
+  "Iris & Lola Neon",
 ];
 
 // Passive gold accrues slowly over time. 5s ticks were far too fast.
@@ -5723,10 +5752,11 @@ function doJoin(room, status) {
             reply_to_id, reply_to_user, reply_to_text
      FROM messages
      WHERE (room=? OR room=?) AND deleted=0
-     ORDER BY ts ASC LIMIT 200`,
+     ORDER BY ts DESC LIMIT 200`,
     [room, legacyRoom],
     (_e, rows) => {
-      const baseHistory = (rows || []).map((r) => ({
+      // Query newest-first, then reverse so clients render oldest -> newest.
+      const baseHistory = (rows || []).reverse().map((r) => ({
         messageId: r.id,
         room: r.room,
         user: r.username,


### PR DESCRIPTION
### Motivation
- Themes selected in the client were being rejected by the server allowlist causing the UI to revert to default on refresh.  
- Room history ordering and trimming behaved incorrectly which could drop the newest messages instead of the oldest.  
- The composer lost a clear Send affordance and tone control needed a compact split-button UI that works on mobile.  
- The Personalisation panel was crowded and needed accessible, keyboard-friendly collapsible categories to declutter without changing behavior.

### Description
- Added every theme name from the client `THEME_LIST` into the server `ALLOWED_THEMES` so `sanitizeThemeNameServer()` accepts client selections while preserving private-theme gating.  
- Changed room history DB query to `ORDER BY ts DESC LIMIT 200` and reversed the returned rows before emitting so clients render oldest→newest and trimming removes oldest messages (comment included).  
- Updated the tone picker to a compact arrow split-button (`▴`) and kept the tone menu implementation, reworked `updateToneMenu()` text+state and added small CSS to position the Send button and tone arrow together without changing Enter-to-send.  
- Reorganized chat appearance/personalisation controls into accessible `<details>` collapsible sections (Text & Fonts, Bubbles & Chat Style, Theme & Page, Profile & Identity, Advanced / Accessibility) and added a tiny localStorage persist key `ui.personalisation.openSections` plus styling tweaks to preserve existing input IDs so wiring remains intact.

### Testing
- Ran `npm run check` which completed successfully.  
- Ran `npm run verify` which completed successfully (includes `check` + `audit`).  
- Ran `npm run test` which reports no tests (script exited 0).  
- Started the server for a smoke test (`SESSION_SECRET=devsecret npm start`) and exercised the web UI with a headless browser to capture a screenshot of the composer and tone split-button; the app started but the environment shows Postgres connection refused (expected in this environment) while the HTTP server was reachable for UI verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69606d449c148333bfa4c91f4c5a220f)