### PR TITLE
Revamp login UI and gate chat boot

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1742,7 +1742,8 @@ let dmPinned = true;
 let unseenMainMessages = 0;
 
 // ---- DOM
-const authWrap = document.getElementById("authWrap");
+const loginView = document.getElementById("loginView");
+const chatView = document.getElementById("chatView");
 const app = document.getElementById("app");
 const addRoomBtn = document.getElementById("addRoomBtn");
 const menuToggleBtn = document.getElementById("menuToggleBtn");
@@ -1837,9 +1838,11 @@ const prefSoundReaction = document.getElementById("prefSoundReaction");
 const prefSoundStatus = document.getElementById("prefSoundStatus");
 
 
+const authForm = document.getElementById("authForm");
 const authUser = document.getElementById("authUser");
 const authPass = document.getElementById("authPass");
 const authMsg = document.getElementById("authMsg");
+const authValidation = document.getElementById("authValidation");
 const loginBtn = document.getElementById("loginBtn");
 const regBtn = document.getElementById("regBtn");
 const togglePassBtn = document.getElementById("togglePassBtn");
@@ -7949,9 +7952,52 @@ statusSelect.addEventListener("change", ()=>{
 });
 
 // ---- auth helpers
+let authUserState = null;
+let authHandlersBound = false;
+
+function getAuthUser(){
+  return authUserState;
+}
+
+function isAuthenticated(){
+  return !!authUserState;
+}
+
+function setAuthUser(user){
+  authUserState = user || null;
+}
+
+function setView(mode){
+  if(!loginView || !chatView) return;
+  document.body.classList.remove("auth-pending");
+  if(mode === "login"){
+    loginView.hidden = false;
+    chatView.hidden = true;
+  }else if(mode === "chat"){
+    loginView.hidden = true;
+    chatView.hidden = false;
+  }else{
+    loginView.hidden = true;
+    chatView.hidden = true;
+  }
+}
+
+function setAuthLoading(loading, message = ""){
+  if(authMsg) authMsg.textContent = message;
+  if(authValidation && !loading && message) authValidation.textContent = "";
+  if(loginBtn) loginBtn.disabled = loading;
+  if(regBtn) regBtn.disabled = loading;
+  if(authUser) authUser.disabled = loading;
+  if(authPass) authPass.disabled = loading;
+}
+
+function setAuthValidation(message = ""){
+  if(authValidation) authValidation.textContent = message;
+}
+
 async function api(path, options){
   try{
-  const res = await fetch(path, { credentials: "include", ...options });
+    const res = await fetch(path, { credentials: "include", ...options });
     const text=await res.text().catch(()=> "");
     return {res, text};
   }catch{
@@ -7959,38 +8005,114 @@ async function api(path, options){
   }
 }
 
+async function validateSession({ silent = false } = {}){
+  let meRes;
+  try{
+    // Explicit credentials prevents edge cases where the session cookie isn't sent.
+    meRes = await fetch("/me", { credentials: "include" });
+  }catch(err){
+    console.error("Failed to reach /me:", err);
+    if(!silent && authMsg) authMsg.textContent = "Unable to reach the server. Please try again.";
+    return null;
+  }
+
+  if(!meRes?.ok){
+    if(!silent && authMsg) authMsg.textContent = "Please login.";
+    return null;
+  }
+
+  try{
+    const payload = await meRes.json();
+    return payload || null;
+  }catch(err){
+    console.error("Invalid /me response:", err);
+    if(!silent && authMsg) authMsg.textContent = "Server response was invalid. Please refresh and try again.";
+    return null;
+  }
+}
+
+function initLoginUI(){
+  setView("login");
+  setAuthLoading(false, "");
+  setAuthValidation("");
+  if(!authHandlersBound){
+    authHandlersBound = true;
+    authForm?.addEventListener("submit", (e)=>{
+      e.preventDefault();
+      doLogin();
+    });
+    loginBtn?.addEventListener("click", (e)=>{ e?.preventDefault?.(); doLogin(); });
+    regBtn?.addEventListener("click", (e)=>{ e?.preventDefault?.(); doRegister(); });
+  }
+  if(authUser && !isAuthenticated()){
+    requestAnimationFrame(()=> authUser?.focus?.());
+  }
+}
+
 async function doLogin(){
-  authMsg.textContent="Logging in...";
+  const username = authUser?.value?.trim() || "";
+  const password = authPass?.value || "";
+  if(!username){
+    setAuthValidation("Please enter your username.");
+    authUser?.focus();
+    return;
+  }
+  if(!password){
+    setAuthValidation("Please enter your password.");
+    authPass?.focus();
+    return;
+  }
+  setAuthValidation("");
+  setAuthLoading(true, "Logging in...");
   const {res,text}=await api("/login",{
     method:"POST", headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({username:authUser.value, password:authPass.value})
+    body:JSON.stringify({username, password})
   });
-  if(!res.ok){ authMsg.textContent=text||"Login failed."; return; }
-  await startApp();
+  if(!res.ok){
+    setAuthLoading(false, text||"Login failed.");
+    return;
+  }
+  await initChatApp();
+  setAuthLoading(false, "");
 }
+
 async function doRegister(){
-  authMsg.textContent="Registering...";
+  const username = authUser?.value?.trim() || "";
+  const password = authPass?.value || "";
+  if(!username){
+    setAuthValidation("Please choose a username.");
+    authUser?.focus();
+    return;
+  }
+  if(!password){
+    setAuthValidation("Please choose a password.");
+    authPass?.focus();
+    return;
+  }
+  setAuthValidation("");
+  setAuthLoading(true, "Registering...");
   const {res,text}=await api("/register",{
     method:"POST", headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({username:authUser.value, password:authPass.value})
+    body:JSON.stringify({username, password})
   });
-  if(!res.ok){ authMsg.textContent=text||"Register failed."; return; }
-  authMsg.textContent="Registered! Now click Login.";
-}
-// Bind auth handlers defensively so a missing/renamed DOM id can't break boot.
-loginBtn?.addEventListener("click", (e)=>{ e?.preventDefault?.(); doLogin(); });
-regBtn?.addEventListener("click", (e)=>{ e?.preventDefault?.(); doRegister(); });
-authPass?.addEventListener("keydown", (e)=>{
-  if(e.key === "Enter"){
-    e.preventDefault();
-    doLogin();
+  if(!res.ok){
+    setAuthLoading(false, text||"Register failed.");
+    return;
   }
-});
+  setAuthLoading(false, "Registered! Now click Join chat.");
+}
 
 async function doLogout(){
   // Explicitly include credentials so the session cookie is always sent.
-  await fetch("/logout", {method:"POST", credentials:"include"});
-  location.reload();
+  await fetch("/logout", {method:"POST", credentials:"include"}).catch(()=>{});
+  setAuthUser(null);
+  me = null;
+  if(socket){
+    try { socket.removeAllListeners(); } catch {}
+    try { socket.disconnect(); } catch {}
+  }
+  setView("login");
+  initLoginUI();
 }
 logoutBtn?.addEventListener("click", doLogout);
 
@@ -9566,37 +9688,19 @@ async function refreshLogs(){
 refreshLogsBtn.addEventListener("click", refreshLogs);
 
 // start app
-async function startApp(){
-  let meRes;
-  try{
-    // Explicit credentials prevents edge cases where the session cookie isn't sent.
-    meRes = await fetch("/me", { credentials: "include" });
-  }catch(err){
-    console.error("Failed to reach /me:", err);
-    authMsg.textContent = "Unable to reach the server. Please try again.";
+async function initChatApp(){
+  const sessionUser = await validateSession();
+  if(!sessionUser){
+    initLoginUI();
     return;
   }
 
-  if(!meRes?.ok){
-    authMsg.textContent = "Please login.";
-    return;
-  }
-
-  try{
-    me = await meRes.json();
-  }catch(err){
-    console.error("Invalid /me response:", err);
-    authMsg.textContent = "Server response was invalid. Please refresh and try again.";
-    return;
-  }
-
-  if(!me){ authMsg.textContent="Please login."; return; }
+  me = sessionUser;
+  setAuthUser(sessionUser);
+  setView("chat");
 
   await loadVibeTags();
   await loadThemePreference();
-
-    authWrap.style.display="none";
-    app.style.display="flex";
 
   await loadMyProfile();
   await loadUserPrefs();
@@ -10016,22 +10120,20 @@ socket.on("dm history", (payload = {}) => {
   });
 }
 
-// boot: if already logged in, auto start
-(async function boot(){
-  try{
-    const res = await fetch("/me", { credentials: "include" });
-    if(!res.ok) return;
-
-    me = await res.json();
-    if(me){
-      authWrap.style.display="none";
-      app.style.display="flex";
-      await startApp();
-    }
-  }catch(err){
-    console.warn("Skipping auto-start due to /me failure", err);
+// boot: auth gate
+async function bootApp(){
+  setView("loading");
+  const sessionUser = await validateSession({ silent: true });
+  if(sessionUser){
+    me = sessionUser;
+    setAuthUser(sessionUser);
+    await initChatApp();
+    return;
   }
-})();
+  initLoginUI();
+}
+
+document.addEventListener("DOMContentLoaded", bootApp);
 
 // profile button also closes drawers
 profileBtn.addEventListener("click", () => { closeDrawers(); });

--- a/public/index.html
+++ b/public/index.html
@@ -9,54 +9,67 @@
   <link rel="stylesheet" href="/styles.css">
 </head>
 
-<body>
-  <!-- AUTH -->
-  <div id="authWrap">
-    <div class="authBackdrop" aria-hidden="true"></div>
+<body class="auth-pending">
+  <div id="authLoading" class="authLoading" aria-live="polite">
+    Checking your session...
+  </div>
 
-    <div class="authShell">
-      <div class="authBrand">
-        <div class="authLogo">Banter <span class="amp">&amp;</span> Brats</div>
-        <div class="authTag">18+ community chat • rooms • DMs • games</div>
+  <!-- AUTH -->
+  <div id="loginView">
+    <div class="loginBackdrop" aria-hidden="true"></div>
+
+    <div class="loginShell">
+      <div class="loginBrand">
+        <div class="loginBadge">Welcome to</div>
+        <h1 class="loginLogo">Banter <span class="amp">&amp;</span> Brats</h1>
+        <p class="loginTag">18+ community chat built for rooms, DMs, and a little chaos.</p>
+        <ul class="loginFeatures">
+          <li>Pick rooms, hop into DMs, and keep tabs on reactions.</li>
+          <li>Track XP, gold, and shout-outs in leaderboards.</li>
+          <li>Keep it cozy with themes, vibes, and profile flair.</li>
+        </ul>
       </div>
 
-      <div class="authCard" role="dialog" aria-label="Login or register">
-        <div class="authHeader">
-          <div class="authTitle">Welcome</div>
-          <div class="authSub">Log in or create an account to continue.</div>
+      <div class="loginCard" role="dialog" aria-label="Login or register">
+        <div class="loginHeader">
+          <h2>Sign in</h2>
+          <p>Use your username and password to continue.</p>
         </div>
 
-        <div class="authForm">
+        <form class="loginForm" id="authForm">
           <div class="field">
             <label for="authUser">Username</label>
-            <input id="authUser" autocomplete="username" placeholder="username">
+            <input id="authUser" autocomplete="username" placeholder="your username" required>
           </div>
 
           <div class="field">
             <label for="authPass">Password</label>
             <div class="passWrap">
-              <input id="authPass" type="password" autocomplete="current-password" placeholder="password">
+              <input id="authPass" type="password" autocomplete="current-password" placeholder="your password" required>
               <button class="passToggle" id="togglePassBtn" type="button" aria-label="Show password" title="Show password">👁</button>
             </div>
           </div>
 
-          <div class="row authActions">
-            <button class="btn" id="loginBtn" type="button">Login</button>
-            <button class="btn secondary" id="regBtn" type="button">Register</button>
+          <div class="loginValidation" id="authValidation" aria-live="polite"></div>
+
+          <div class="row loginActions">
+            <button class="btn" id="loginBtn" type="submit">Join chat</button>
+            <button class="btn secondary" id="regBtn" type="button">Create account</button>
           </div>
 
-          <div class="authHint small muted">Tip: you can register with any username — no email required (for now).</div>
-          <div class="msgline" id="authMsg"></div>
-        </div>
-      </div>
+          <div class="loginHint small muted">No email needed. Just claim a username.</div>
+          <div class="msgline" id="authMsg" aria-live="polite"></div>
+        </form>
 
-      <div class="authFoot small muted">
-        By continuing, you confirm you are 18+ and agree to follow the rules of the community.
+        <div class="loginFooter small muted">
+          By continuing, you confirm you are 18+ and agree to follow the community rules.
+        </div>
       </div>
     </div>
   </div>
 
   <!-- APP -->
+  <div id="chatView" hidden>
   <div id="app">
     <div class="layout">
       <aside class="channels" id="channelsPane">
@@ -1019,6 +1032,8 @@
     <button class="iconBtn largeClose" id="mediaLightboxClose" type="button" aria-label="Close media">✕</button>
     <img id="mediaLightboxImg" alt="Expanded media">
     <video id="mediaLightboxVideo" playsinline controls></video>
+  </div>
+
   </div>
 
   <script src="/socket.io/socket.io.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1529,6 +1529,10 @@ body[data-theme="420 Friendly (Light)"]{
 
 html, body { height: 100%; }
 
+[hidden]{
+  display:none !important;
+}
+
 body{
   margin:0;
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
@@ -1549,99 +1553,189 @@ a{ color:inherit; }
 button{ font-family:inherit; }
 
 /* AUTH */
-#authWrap{
-  height: var(--vvhPx);
+body.auth-pending #loginView,
+body.auth-pending #chatView{
+  display:none;
+}
+
+#authLoading{
+  display:none;
+  min-height: var(--vvhPx);
+  align-items:center;
+  justify-content:center;
+  text-align:center;
+  font-size:14px;
+  color:var(--muted);
+}
+
+body.auth-pending #authLoading{
+  display:flex;
+}
+
+#loginView{
+  min-height: var(--vvhPx);
   display:flex;
   align-items:center;
   justify-content:center;
-  padding:22px;
+  padding: clamp(20px, 4vw, 40px);
+  padding-top: calc(clamp(20px, 4vw, 40px) + env(safe-area-inset-top));
+  padding-bottom: calc(clamp(20px, 4vw, 40px) + env(safe-area-inset-bottom));
   position:relative;
   overflow:hidden;
+  background: radial-gradient(1200px 600px at 15% 5%, rgba(120,120,255,0.22), transparent 60%),
+              radial-gradient(900px 520px at 85% 10%, rgba(80,220,255,0.18), transparent 55%),
+              radial-gradient(1000px 720px at 50% 90%, rgba(255,120,190,0.16), transparent 65%),
+              linear-gradient(180deg, rgba(6,6,12,0.88), rgba(6,6,12,0.96));
 }
 
-#authWrap .authBackdrop{
+.loginBackdrop{
   position:absolute;
-  inset:-40px;
-  background:
-    radial-gradient(800px 500px at 20% 10%, rgba(160,110,255,0.25), transparent 60%),
-    radial-gradient(700px 500px at 80% 20%, rgba(80,200,255,0.18), transparent 55%),
-    radial-gradient(900px 700px at 50% 90%, rgba(255,120,190,0.12), transparent 65%),
-    linear-gradient(180deg, rgba(0,0,0,0.35), rgba(0,0,0,0.55));
-  filter: blur(0px);
+  inset:0;
+  background: linear-gradient(120deg, rgba(255,255,255,0.03), transparent 35%, rgba(255,255,255,0.02));
   pointer-events:none;
 }
 
-.authShell{
-  width:min(980px, 100%);
+.loginShell{
+  width:min(1040px, 100%);
   display:grid;
-  grid-template-columns: 1.1fr 1fr;
-  gap:22px;
+  grid-template-columns: 1.1fr minmax(0, 420px);
+  gap:24px;
   align-items:center;
   position:relative;
   z-index:1;
 }
 
-/* Nudge slightly left on wide desktop so the card never kisses the right edge */
-@media (min-width: 821px){
-  .authShell{ transform: translateX(-18px); }
+.loginBrand{
+  padding:12px 6px;
 }
 
-.authBrand{
-  padding:18px 10px;
+.loginBadge{
+  font-size:12px;
+  text-transform:uppercase;
+  letter-spacing:0.2em;
+  color: color-mix(in oklab, var(--muted) 75%, #fff);
 }
 
-.authLogo{
-  font-weight:1000;
-  letter-spacing:0.5px;
-  font-size: clamp(28px, 4vw, 44px);
+.loginLogo{
+  margin:8px 0 8px;
+  font-weight:800;
+  font-size: clamp(28px, 4.5vw, 46px);
   line-height:1.05;
-  text-shadow: 0 10px 30px rgba(0,0,0,0.35);
+  text-shadow: 0 12px 30px rgba(0,0,0,0.4);
 }
 
-.authLogo .amp{
-  opacity:0.95;
-  filter: drop-shadow(0 0 14px rgba(190,120,255,0.25));
+.loginLogo .amp{
+  opacity:0.9;
+  filter: drop-shadow(0 0 16px rgba(190,120,255,0.3));
 }
 
-.authTag{
-  margin-top:10px;
+.loginTag{
+  margin:0 0 14px;
+  color: var(--muted);
+  font-size:15px;
+}
+
+.loginFeatures{
+  list-style:none;
+  padding:0;
+  margin:0;
+  display:grid;
+  gap:10px;
+  color: color-mix(in oklab, var(--text) 80%, #fff);
   font-size:14px;
-  color:var(--muted);
 }
 
-.authCard{
+.loginFeatures li{
+  padding-left:22px;
+  position:relative;
+}
+
+.loginFeatures li::before{
+  content:"•";
+  position:absolute;
+  left:0;
+  color: rgba(170,200,255,0.9);
+}
+
+.loginCard{
   width:100%;
-  background: color-mix(in oklab, var(--panel) 92%, rgba(0,0,0,0.25));
-  border:1px solid color-mix(in oklab, var(--line) 85%, rgba(255,255,255,0.08));
-  border-radius:18px;
-  padding:18px;
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(10px);
+  background: color-mix(in oklab, var(--panel) 90%, rgba(0,0,0,0.35));
+  border:1px solid color-mix(in oklab, var(--line) 80%, rgba(255,255,255,0.1));
+  border-radius:20px;
+  padding:24px;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+  backdrop-filter: blur(12px);
 }
 
-.authHeader{
-  margin-bottom:12px;
+.loginHeader h2{
+  margin:0 0 6px;
+  font-size:22px;
 }
 
-.authTitle{ font-size:20px; font-weight:1000; margin:0; }
-.authSub{ margin-top:6px; font-size:13px; color:var(--muted); }
+.loginHeader p{
+  margin:0 0 12px;
+  color:var(--muted);
+  font-size:13px;
+}
 
-.authActions{ margin-top:12px; }
-.authActions .btn{ flex:1; min-width:140px; }
+.loginForm .field{
+  margin:12px 0;
+}
 
-.authHint{ margin-top:10px; }
+.loginForm input{
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
 
-.authFoot{
-  grid-column: 1 / -1;
-  padding-top:2px;
+.loginForm input:focus-visible{
+  border-color: rgba(140,180,255,0.8);
+  box-shadow: 0 0 0 3px rgba(120,160,255,0.25);
+}
+
+.loginValidation{
+  min-height:18px;
+  font-size:12px;
+  color: color-mix(in oklab, #ff8c9a 75%, var(--text));
+}
+
+.loginActions{
+  margin-top:12px;
+}
+
+.loginActions .btn{
+  flex:1;
+  min-width:140px;
+}
+
+.loginHint{
+  margin-top:12px;
+}
+
+.loginFooter{
+  margin-top:16px;
   text-align:center;
 }
 
-/* keep auth usable on mobile */
-@media (max-width: 820px){
-  .authShell{ grid-template-columns: 1fr; }
-  .authBrand{ text-align:center; padding:6px 0 0; }
-  .authTag{ max-width:520px; margin-left:auto; margin-right:auto; }
+@media (max-width: 860px){
+  .loginShell{
+    grid-template-columns: 1fr;
+  }
+  .loginBrand{
+    text-align:center;
+  }
+  .loginFeatures{
+    max-width:520px;
+    margin:0 auto;
+    text-align:left;
+  }
+}
+
+@media (max-width: 540px){
+  .loginCard{
+    padding:20px;
+  }
+  .loginActions{
+    flex-direction:column;
+  }
 }
 
 /* Shared form primitives */
@@ -1742,7 +1836,7 @@ textarea{ min-height:90px; resize:vertical; }
   min-height: 0;
   transform: translateY(var(--vvTop));
   overflow:hidden;
-  display:none;
+  display:flex;
   flex-direction: column;
 }
 .layout{ height:100%; display:flex; min-height:0; overflow:hidden; }


### PR DESCRIPTION
### Motivation

- Prevent the existing “flash of chat UI” when a visitor is not authenticated and provide a clean, modern login experience across mobile and desktop.
- Create a single client-side auth gate so the chat socket and all chat UI initialization only run after the session is validated.
- Keep all existing post-login features unchanged while isolating unauthenticated UI from chat elements.

### Description

- Added a dedicated `#loginView` and `#chatView` in `public/index.html` and an `#authLoading` placeholder, and kept chat hidden by default with `hidden`/CSS until auth is confirmed.
- Implemented client auth helpers in `public/app.js`: `getAuthUser()`, `isAuthenticated()`, `setAuthUser()`, `validateSession()`, `initLoginUI()`, `initChatApp()` and a `bootApp()` that runs on `DOMContentLoaded` to gate boot behavior.
- Ensured the socket is only created inside `initChatApp()` and session validation is performed via `GET /me` before showing chat, while login/register use the existing `/login` and `/register` endpoints.
- Reworked `public/styles.css` to provide a responsive, accessible login card (safe-area + `100dvh` handling) and CSS rules that prevent any chat DOM from displaying while the app is in the auth-pending state.

### Testing

- Ran `node -c server.js` to validate server syntax which completed successfully.
- Ran `node --check public/app.js` to ensure the frontend bundle has no syntax errors which completed successfully.
- Started the server and performed a headless smoke test (Playwright screenshot) to verify the login view renders and the chat UI remains hidden when not authenticated, which succeeded.
- Observed server start output (server reachable at `http://localhost:3000`) with non-blocking Postgres init warnings; chat UI gating and login flow were verified in the smoke test.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960800681988333ab30bccaa000614a)