### PR TITLE
Desktop chat grid, profile header level ring, auto-send media uploads, and upload size limits

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1901,11 +1901,18 @@ function updateIrisLolaTogetherClass() {
 const DEFAULT_THEME = "Minimal Dark";
 let currentTheme = document.body?.getAttribute("data-theme") || DEFAULT_THEME;
 let themeFilter = "all";
+const MAX_IMAGE_GIF_BYTES = 25 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024;
 
 let modalTargetUsername = null;
 let modalTargetUserId = null;
 let pendingFile = null;
+let roomPendingAttachment = null;
 let dmPendingAttachment = null;
+let roomUploadToken = null;
+let dmUploadToken = null;
+let roomUploading = false;
+let dmUploading = false;
 let uploadXhr = null;
 let memberMenuUser = null;
 let memberMenuUsername = "";
@@ -2443,28 +2450,35 @@ dmText?.addEventListener("input", ()=>draftDebounce(saveDmDraft));
 // Ensure DM quick bars start closed on load (safety net in case markup defaults are changed)
 hideAllDmQuickBars();
 
-// DM image upload (images only)
+// DM media upload
 dmPickFileBtn?.addEventListener("click", () => { dmFileInput?.click(); });
 dmFileInput?.addEventListener("change", async () => {
   const file = dmFileInput.files && dmFileInput.files[0] ? dmFileInput.files[0] : null;
   if(!file) return;
   // reset input so the same file can be re-selected
   try{ dmFileInput.value = ""; }catch{}
-  if(!/^image\//i.test(String(file.type||""))){
-    setDmNotice("Images only for DMs.");
+  dmPendingAttachment = null;
+  const validation = validateUploadFile(file);
+  if(!validation.ok){
+    setDmNotice(validation.message || "File not allowed.");
     return;
   }
-  if(file.size > (10*1024*1024)){
-    setDmNotice("Image too large (max 10MB).");
-    return;
-  }
+  dmUploadToken = `${Date.now()}-${Math.random()}`;
+  const token = dmUploadToken;
+  setDmUploadingState(true);
   try{
-    setDmNotice("Uploading image…");
+    setDmNotice("Uploading media…");
     const up = await uploadChatFileWithProgress(file);
+    if(token !== dmUploadToken) return;
     dmPendingAttachment = { url: up.url, mime: up.mime, type: up.type, size: up.size };
-    setDmNotice("Image ready. Press Send.");
+    dmUploadToken = null;
+    setDmUploadingState(false);
+    sendDmMessage();
   }catch(e){
+    if(token !== dmUploadToken) return;
+    dmUploadToken = null;
     dmPendingAttachment = null;
+    setDmUploadingState(false);
     setDmNotice(String(e?.message || "Upload failed."));
   }
 });
@@ -2547,6 +2561,7 @@ const profileSheetBg = document.getElementById("profileSheetBg");
 const profileSheetAvatar = document.getElementById("profileSheetAvatar");
 const profileSheetAvatarActions = document.getElementById("profileSheetAvatarActions");
 const profileSheetName = document.getElementById("profileSheetName");
+const profileSheetNameRow = document.querySelector(".profileSheetNameRow");
 const profileSheetRoleChip = document.getElementById("profileSheetRoleChip");
 const profileSheetStats = document.getElementById("profileSheetStats");
 const profileSheetStars = document.getElementById("profileSheetStars");
@@ -2588,6 +2603,7 @@ const copyUsernameBtn = document.getElementById("copyUsernameBtn");
 const mediaMsg = document.getElementById("mediaMsg");
 const profileActionMsg = document.getElementById("profileActionMsg");
 const customizeMsg = document.getElementById("customizeMsg");
+const levelPanel = document.getElementById("levelPanel");
 const levelBadge = document.getElementById("levelBadge");
 const xpText = document.getElementById("xpText");
 const xpProgress = document.getElementById("xpProgress");
@@ -3343,6 +3359,32 @@ function fmtCreated(ts){
   const d = new Date(ts);
   if(Number.isNaN(d.getTime())) return String(ts);
   return d.toLocaleString();
+}
+function formatMemberSince(value){
+  if(value == null || value === "") return "—";
+  let date = null;
+  if(typeof value === "number"){
+    const ms = value < 1e12 ? value * 1000 : value;
+    date = new Date(ms);
+  }else if(typeof value === "string"){
+    const trimmed = value.trim();
+    if(!trimmed) return "—";
+    const asNum = Number(trimmed);
+    if(Number.isFinite(asNum)){
+      const ms = asNum < 1e12 ? asNum * 1000 : asNum;
+      date = new Date(ms);
+    }else{
+      date = new Date(trimmed);
+    }
+  }else{
+    date = new Date(NaN);
+  }
+
+  if(!date || Number.isNaN(date.getTime())) return "—";
+  const dd = String(date.getDate()).padStart(2, "0");
+  const mm = String(date.getMonth() + 1).padStart(2, "0");
+  const yyyy = String(date.getFullYear());
+  return `${dd}/${mm}/${yyyy}`;
 }
 function bytesToNice(n){
   n = Number(n||0);
@@ -6428,6 +6470,7 @@ function sendDmMessage(){
   if (!activeDmId) return;
   const txt = (dmText?.value || "").trim();
   const att = dmPendingAttachment;
+  if (dmUploading && !att) return;
   if (!txt && !att) return;
 
   socket?.emit("dm message", {
@@ -6850,6 +6893,28 @@ pickFileBtn?.addEventListener("click", () => {
 });
 
 // upload preview
+function validateUploadFile(file){
+  const mime = String(file?.type || "");
+  const isImage = /^image\//i.test(mime);
+  const isVideo = /^video\//i.test(mime);
+  if(!isImage && !isVideo){
+    return { ok: false, message: "Only images, GIFs, or videos are allowed." };
+  }
+  const maxBytes = isVideo ? MAX_VIDEO_BYTES : MAX_IMAGE_GIF_BYTES;
+  if(file.size > maxBytes){
+    const label = isVideo ? "video" : "image/GIF";
+    return { ok: false, message: `Max ${label} size is ${bytesToNice(maxBytes)}.` };
+  }
+  return { ok: true, isImage, isVideo, maxBytes };
+}
+function setRoomUploadingState(isUploading){
+  roomUploading = isUploading;
+  if(sendBtn) sendBtn.disabled = isUploading;
+}
+function setDmUploadingState(isUploading){
+  dmUploading = isUploading;
+  if(dmSendBtn) dmSendBtn.disabled = isUploading;
+}
 function showUploadPreview(file){
   pendingFile = file;
   uploadPreview.style.display = "flex";
@@ -6886,16 +6951,36 @@ function clearUploadPreview(){
 fileInput.addEventListener("change", () => {
   const f=fileInput.files?.[0];
   if(!f) return clearUploadPreview();
-  if(f.size > 10*1024*1024){
-    addSystem("Max upload size is 10MB.");
+  roomPendingAttachment = null;
+  const validation = validateUploadFile(f);
+  if(!validation.ok){
+    addSystem(validation.message || "File not allowed.");
     fileInput.value="";
     return clearUploadPreview();
   }
   showUploadPreview(f);
+  roomUploadToken = `${Date.now()}-${Math.random()}`;
+  const token = roomUploadToken;
+  setRoomUploadingState(true);
+  uploadChatFileWithProgress(f).then((up) => {
+    if(token !== roomUploadToken) return;
+    roomPendingAttachment = { url: up.url, mime: up.mime, type: up.type, size: up.size };
+    roomUploadToken = null;
+    setRoomUploadingState(false);
+    sendMessage();
+  }).catch((e) => {
+    if(token !== roomUploadToken) return;
+    roomUploadToken = null;
+    setRoomUploadingState(false);
+    addSystem(`Upload failed: ${e?.message || "Upload failed."}`);
+  });
 });
 cancelUploadBtn.addEventListener("click", () => {
   if(uploadXhr){ uploadXhr.abort(); uploadXhr=null; addSystem("Upload canceled."); }
   fileInput.value="";
+  roomUploadToken = null;
+  roomPendingAttachment = null;
+  setRoomUploadingState(false);
   clearUploadPreview();
 });
 function uploadChatFileWithProgress(file){
@@ -8269,15 +8354,15 @@ async function sendMessage(){
   if(!socket) return;
   const text = msgInput.value || "";
   const file = pendingFile;
-  if(!text.trim() && !file) return;
+  const attachmentReady = roomPendingAttachment;
+  if(roomUploading && !attachmentReady) return;
+  if(!text.trim() && !file && !attachmentReady) return;
 
   try{
-    let attachment=null;
-    if(file){
+    let attachment = attachmentReady;
+    if(!attachment && file){
       addSystem(`Uploading ${file.name}...`);
       attachment = await uploadChatFileWithProgress(file);
-      fileInput.value="";
-      clearUploadPreview();
     }
 
     socket.emit("chat message", {
@@ -8293,6 +8378,11 @@ async function sendMessage(){
     if (Sound.shouldSent()) Sound.cues.sent();
 
     msgInput.value="";
+    fileInput.value="";
+    clearUploadPreview();
+    roomPendingAttachment = null;
+    roomUploadToken = null;
+    setRoomUploadingState(false);
     setReplyTarget(null);
     activeTone = "";
     updateToneMenu(tonePicker, activeTone);
@@ -9233,8 +9323,11 @@ function fillProfileUI(p, isSelf){
 
   infoAge.textContent = (p.age ?? "—");
   infoGender.textContent = (p.gender ?? "—");
-  if (infoLanguage) infoLanguage.textContent = (p.language ?? "—");
-  infoCreated.textContent = fmtCreated(p.created_at);
+  if (infoLanguage){
+    const langRow = infoLanguage.closest(".profileInfoRow");
+    if (langRow) langRow.style.display = "none";
+  }
+  infoCreated.textContent = formatMemberSince(p.created_at);
   infoLastSeen.textContent = formatLastSeen(p.last_seen);
   infoRoom.textContent = p.current_room ? `#${p.current_room}` : (p.last_room ? `#${p.last_room}` : "—");
   const statusLabel = normalizeStatusLabel(p.last_status, "");
@@ -9249,6 +9342,11 @@ function fillProfileUI(p, isSelf){
   renderVibeChips(profileVibes, p.vibe_tags);
   fillProfileSheetHeader(p, isSelf);
   syncProfileEditUi();
+  if (levelPanel){
+    levelPanel.style.display = "none";
+    const title = levelPanel.previousElementSibling;
+    if (title && title.classList.contains("sectionTitle")) title.style.display = "none";
+  }
 }
 
 
@@ -9269,6 +9367,25 @@ function fillProfileSheetHeader(p, isSelf){
   if (profileSheetRoleChip){
     profileSheetRoleChip.textContent = p.role ? `${roleIcon(p.role)} ${p.role}` : "User";
     profileSheetRoleChip.style.color = roleBadgeColor(p.role || "User");
+  }
+  if (profileSheetNameRow){
+    let ring = profileSheetNameRow.querySelector(".profileLevelRing");
+    if (!ring){
+      ring = document.createElement("span");
+      ring.className = "profileLevelRing";
+      ring.setAttribute("aria-label", "Account level");
+      profileSheetNameRow.insertBefore(ring, profileSheetNameRow.firstChild);
+    }
+    const levelVal = deriveProfileLevel(p);
+    ring.textContent = Number.isFinite(levelVal) ? levelVal.toLocaleString() : "—";
+    const xpInto = (typeof p?.xpIntoLevel === "number") ? p.xpIntoLevel : (isSelf ? progression?.xpIntoLevel : null);
+    const xpNext = (typeof p?.xpForNextLevel === "number") ? p.xpForNextLevel : (isSelf ? progression?.xpForNextLevel : null);
+    if (typeof xpInto === "number" && typeof xpNext === "number" && xpNext > 0) {
+      const pct = Math.max(0, Math.min(100, (xpInto / xpNext) * 100));
+      ring.style.setProperty("--levelProgress", `${pct}%`);
+    } else {
+      ring.style.removeProperty("--levelProgress");
+    }
   }
 
   // Age + gender

--- a/public/styles.css
+++ b/public/styles.css
@@ -3070,7 +3070,7 @@ body:not(.polish-pack) .tonePicker{
 }
 .profileModalTop{
   margin-bottom: 0;
-  padding: 12px 12px 0;
+  padding: 0;
 }
 .profileModalCard .modalBody{
   padding: 0 12px 12px;
@@ -5384,12 +5384,14 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
 .profileSheetHero{
   position: relative;
   margin: 0;
-  border-radius: 14px;
+  border-radius: 14px 14px 0 0;
   overflow: hidden;
   border: 1px solid rgba(255,255,255,.08);
   background: rgba(0,0,0,.25);
   color: var(--profileHeaderText, #fff);
   min-height: 120px;
+  width: 100%;
+  max-width: 100%;
   --profileHeaderTextShadow: 0 1px 4px rgba(0,0,0,.6);
   --profileHeaderText: #fff;
   --profileHeaderPillBg: rgba(0,0,0,.32);
@@ -5448,6 +5450,21 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   padding: 10px 12px;
 }
 .profileAvatarWrap{ position: relative; display: grid; place-items: center; }
+.profileLevelRing{
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-grid;
+  place-items: center;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--profileHeaderText, #fff);
+  background:
+    radial-gradient(circle at center, rgba(0,0,0,0.55) 55%, transparent 56%),
+    conic-gradient(var(--accent, #ff4f6d) var(--levelProgress, 0%), rgba(255,255,255,0.18) 0);
+  border: 1px solid rgba(255,255,255,0.35);
+  text-shadow: var(--profileHeaderTextShadow, 0 1px 4px rgba(0,0,0,.6));
+}
 .profileSheetAvatarCard{
   width: 82px;
   height: 82px;
@@ -5790,15 +5807,16 @@ body.polish-pack.polish-animations .msg-new .dmBubble{
   }
 
   /* Keep the main room composer pinned on desktop layouts */
-  .chat{
-    display:flex;
-    flex-direction:column;
-    min-height:0;
+  .chatMain,
+  main.chatMain{
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    height: 100%;
+    min-height: 0;
   }
   .msgs{
-    flex:1 1 auto;
     min-height:0;
-    overflow:auto;
+    overflow-y:auto;
   }
   .inputBar{
     position: relative;

--- a/server.js
+++ b/server.js
@@ -4989,7 +4989,9 @@ app.delete("/profile/avatar", requireLogin, async (req, res) => {
   });
 });
 
-// ---- Uploads (10MB max). VIP can upload mp4/mov, everyone can upload images.
+// ---- Uploads (25MB images/gifs, 100MB videos). VIP can upload videos, everyone can upload images.
+const MAX_IMAGE_GIF_BYTES = 25 * 1024 * 1024;
+const MAX_VIDEO_BYTES = 100 * 1024 * 1024;
 const chatUpload = multer({
   storage: multer.diskStorage({
     destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),
@@ -4998,30 +5000,56 @@ const chatUpload = multer({
       cb(null, `${Date.now()}-${Math.random().toString(16).slice(2)}${ext}`);
     },
   }),
-  limits: { fileSize: 25 * 1024 * 1024 },
+  limits: { fileSize: MAX_VIDEO_BYTES },
 });
 
-app.post("/upload", requireLogin, chatUpload.single("file"), (req, res) => {
-  if (!req.file) return res.status(400).send("No file");
+app.post("/upload", requireLogin, (req, res) => {
+  chatUpload.single("file")(req, res, (err) => {
+    if (err) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(413).json({ message: "File too large (max 100MB)." });
+      }
+      return res.status(400).json({ message: err.message || "Upload failed." });
+    }
+    if (!req.file) return res.status(400).send("No file");
 
-  const mime = String(req.file.mimetype || "");
-  const role = req.session.user.role;
+    const mime = String(req.file.mimetype || "");
+    const role = req.session.user.role;
 
-  const isImage = /^image\//i.test(mime);
-  const isVideo = /^(video\/mp4|video\/quicktime)$/i.test(mime);
+    const isImage = /^image\//i.test(mime);
+    const isVideo = /^video\//i.test(mime);
 
-  if (!isImage && !isVideo) return res.status(400).json({ message: "File type not allowed" });
+    const cleanupUpload = () => {
+      try { fs.unlinkSync(path.join(UPLOADS_DIR, req.file.filename)); } catch {}
+    };
 
-  if (isVideo && !requireMinRole(role, "VIP")) {
-    return res.status(403).json({ message: "VIP required for video uploads" });
-  }
+    if (!isImage && !isVideo) {
+      cleanupUpload();
+      return res.status(400).json({ message: "File type not allowed" });
+    }
 
-  const url = `/uploads/${req.file.filename}`;
-  return res.json({
-    url,
-    mime,
-    size: req.file.size,
-    type: isImage ? "image" : "video",
+    if (isImage && req.file.size > MAX_IMAGE_GIF_BYTES) {
+      cleanupUpload();
+      return res.status(413).json({ message: "Image/GIF too large (max 25MB)." });
+    }
+
+    if (isVideo && req.file.size > MAX_VIDEO_BYTES) {
+      cleanupUpload();
+      return res.status(413).json({ message: "Video too large (max 100MB)." });
+    }
+
+    if (isVideo && !requireMinRole(role, "VIP")) {
+      cleanupUpload();
+      return res.status(403).json({ message: "VIP required for video uploads" });
+    }
+
+    const url = `/uploads/${req.file.filename}`;
+    return res.json({
+      url,
+      mime,
+      size: req.file.size,
+      type: isImage ? "image" : "video",
+    });
   });
 });
 


### PR DESCRIPTION
### Motivation
- Make the desktop center chat column a proper 3-row layout so topbar, messages and composer stack and messages scroll correctly between them.
- Improve the profile modal header to span the modal width and surface account level as a compact circular ring near the avatar/name while removing duplicate bottom-level UI and the Language row.
- Auto-send media for room and DM composers once upload completes and keep client/server validation consistent to avoid oversized uploads.
- Raise server-side caps for images/GIFs and videos and return clear errors when limits are exceeded.

### Description
- Layout: changed desktop CSS to make the center chat column a grid with `grid-template-rows: auto 1fr auto` and ensured `.msgs` has `min-height:0` and `overflow-y:auto` so the messages scroll between topbar and composer (`public/styles.css`).
- Profile: made the profile header/background edge-to-edge, added a small `.profileLevelRing` CSS rule for the circular level indicator, inserted the level ring into the profile header DOM and hid the bottom "Account Level" panel and the Language row, and added `formatMemberSince` to render Member since as `DD/MM/YYYY` (`public/styles.css`, `public/app.js`).
- Media upload UX: added client-side constants for `MAX_IMAGE_GIF_BYTES` and `MAX_VIDEO_BYTES`, file validation on selection, per-composer pending/upload tokens and uploading state, automatic upload+auto-send flow for room and DM composers while preventing double-sends and clearing preview/state after send (`public/app.js`).
- Server: increased upload caps and added post-validate checks with clear JSON error responses; multer uses a 100MB hard cap and server-side logic enforces 25MB for images/GIFs and 100MB for videos (with cleanup and VIP checks preserved) (`server.js`).

### Testing
- Started the app with `npm start`; the server process launched and served on http://localhost:3000 but Postgres connection attempts failed with ECONNREFUSED during Postgres init (non-fatal in this environment), so the HTTP server was reachable.
- Ran a Playwright screenshot flow to capture the running UI at 1280x720 and it completed, producing a screenshot artifact (artifact path shown in the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69618e3e70088333b6e950141594a194)