### PR TITLE
Fix chat media thumbnails, profile header layout, likes, and Iris & Lola theme access

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -699,6 +699,7 @@ let me = null;
 let progression = { gold: 0, xp: 0, level: 1, xpIntoLevel: 0, xpForNextLevel: 100 };
 let activeProfileTab = "account";
 let currentProfileIsSelf = false;
+let profileLikeState = { count: 0, liked: false, isSelf: false };
 let currentRoom = "main";
 function displayRoomName(room){ return room==="diceroom" ? "Dice Room" : room; }
 
@@ -1883,15 +1884,29 @@ const THEME_LIST = [
 
 const IRIS_LOLA_THEME = "Iris & Lola Neon";
 const IRIS_LOLA_ALLOWED_USERNAMES = ["Iri", "Lola Henderson"];
+const IRIS_LOLA_ALLOWED_USER_IDS = [];
 let onlineUsers = [];
 
+function normalizeUserKey(value) {
+  return String(value || "").trim().toLowerCase();
+}
+function getUserId(user) {
+  return user?.id ?? user?.user_id ?? user?.userId ?? null;
+}
+function isIrisLolaAllowedUser(user) {
+  const userId = getUserId(user);
+  if (userId != null && IRIS_LOLA_ALLOWED_USER_IDS.length) {
+    return IRIS_LOLA_ALLOWED_USER_IDS.map(String).includes(String(userId));
+  }
+  const uname = normalizeUserKey(user?.username || "");
+  return IRIS_LOLA_ALLOWED_USERNAMES.some((allowed) => normalizeUserKey(allowed) === uname);
+}
 function isIrisLolaAllowed() {
-  const u = String(me?.username || "");
-  return IRIS_LOLA_ALLOWED_USERNAMES.includes(u);
+  return isIrisLolaAllowedUser(me);
 }
 function bothIrisAndLolaOnline() {
-  const set = new Set((onlineUsers || []).map((n) => String(n)));
-  return IRIS_LOLA_ALLOWED_USERNAMES.every((n) => set.has(n));
+  const set = new Set((onlineUsers || []).map((n) => normalizeUserKey(n)));
+  return IRIS_LOLA_ALLOWED_USERNAMES.every((n) => set.has(normalizeUserKey(n)));
 }
 function updateIrisLolaTogetherClass() {
   const active = document.body?.getAttribute("data-theme") || "";
@@ -4654,6 +4669,67 @@ function closeMediaLightbox(){
 }
 mediaLightboxClose?.addEventListener("click", closeMediaLightbox);
 mediaLightbox?.addEventListener("click", (e) => { if (e.target === mediaLightbox) closeMediaLightbox(); });
+document.addEventListener("keydown", (e) => {
+  if (e.key === "Escape" && mediaLightbox?.classList.contains("show")) closeMediaLightbox();
+});
+
+const IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "bmp", "svg"]);
+const VIDEO_EXTS = new Set(["mp4", "webm", "mov", "m4v", "ogg"]);
+function inferAttachmentKind({ mime, type, url } = {}) {
+  const typeKey = normalizeUserKey(type);
+  if (typeKey === "image" || typeKey === "gif") return "image";
+  if (typeKey === "video") return "video";
+
+  const mimeKey = normalizeUserKey(mime);
+  if (mimeKey.startsWith("image/")) return "image";
+  if (mimeKey.startsWith("video/")) return "video";
+
+  const cleanUrl = String(url || "").split(/[?#]/)[0];
+  const ext = cleanUrl.includes(".") ? cleanUrl.split(".").pop().toLowerCase() : "";
+  if (IMAGE_EXTS.has(ext)) return "image";
+  if (VIDEO_EXTS.has(ext)) return "video";
+  return "file";
+}
+function renderAttachmentNode({ url, mime, type } = {}) {
+  const cleanUrl = String(url || "").trim();
+  if (!cleanUrl) return null;
+  const kind = inferAttachmentKind({ mime, type, url: cleanUrl });
+  const att = document.createElement("div");
+  att.className = "attachment";
+
+  if (kind === "image") {
+    const img = document.createElement("img");
+    img.className = "msg-media-thumb";
+    img.loading = "lazy";
+    img.src = cleanUrl;
+    img.alt = "attachment";
+    img.addEventListener("click", (e) => {
+      e.stopPropagation();
+      openMediaLightbox(cleanUrl, "image");
+    });
+    att.appendChild(img);
+    return att;
+  }
+
+  if (kind === "video") {
+    const video = document.createElement("video");
+    video.className = "msg-media-thumb";
+    video.src = cleanUrl;
+    video.controls = true;
+    video.playsInline = true;
+    video.preload = "metadata";
+    att.appendChild(video);
+    return att;
+  }
+
+  const a = document.createElement("a");
+  a.href = cleanUrl;
+  a.target = "_blank";
+  a.rel = "noopener";
+  a.textContent = "Download attachment";
+  att.appendChild(a);
+  return att;
+}
 
 function addMessage(m){
   // --- Main chat grouping: consecutive messages from same user are visually grouped ---
@@ -4862,39 +4938,12 @@ function buildMainMsgItem(m, opts){
     ytIds.forEach(id => bubble.appendChild(buildYouTubePreview(id)));
   }
 
-  // Legacy attachment fields (room chat)
-  if(m.attachmentUrl && m.attachmentType){
-    const att=document.createElement("div");
-    att.className="attachment";
-    if(m.attachmentType==="image"){
-      const img=document.createElement("img");
-      img.loading="lazy";
-      img.src=m.attachmentUrl;
-      img.alt="image";
-      img.addEventListener("click", ()=>openMediaLightbox(m.attachmentUrl, "image"));
-      att.appendChild(img);
-    }else{
-      const a=document.createElement("a");
-      a.href=m.attachmentUrl;
-      a.target="_blank";
-      a.rel="noopener";
-      a.textContent="Download attachment";
-      att.appendChild(a);
-    }
-    bubble.appendChild(att);
-  }
-
-  // New attachment object support (parity with DMs)
-  if(m.attachment && (m.attachment.url || m.attachmentUrl)){
-    try {
-      const url = m.attachment.url || m.attachmentUrl;
-      const type = m.attachment.type || m.attachmentType || "";
-      const mime = m.attachment.mime || m.attachmentMime || "";
-      const node = renderAnyAttachment({ url, type, mime }, { mode:"main" });
-      if(node) bubble.appendChild(node);
-    } catch (e) {
-      console.warn("Attachment render failed", e);
-    }
+  const attachmentPayload = m?.attachment?.url
+    ? { url: m.attachment.url, type: m.attachment.type, mime: m.attachment.mime }
+    : (m.attachmentUrl ? { url: m.attachmentUrl, type: m.attachmentType, mime: m.attachmentMime } : null);
+  if (attachmentPayload) {
+    const node = renderAttachmentNode(attachmentPayload);
+    if (node) bubble.appendChild(node);
   }
 
   // Reply preview (inline) if present
@@ -6174,31 +6223,12 @@ function renderDmMessages(threadId){
     text.innerHTML = applyMentions(m.text || "");
     bubble.appendChild(text);
 
-    if(m.attachmentUrl && m.attachmentType){
-      const att=document.createElement("div");
-      att.className="attachment";
-      if(m.attachmentType==="image"){
-        const img=document.createElement("img");
-        img.src=m.attachmentUrl;
-        img.alt="image";
-        img.addEventListener("click", ()=>openMediaLightbox(m.attachmentUrl, "image"));
-        att.appendChild(img);
-      }else if(m.attachmentType==="video"){
-        const v=document.createElement("video");
-        v.src=m.attachmentUrl;
-        v.controls=true;
-        v.playsInline=true;
-        v.addEventListener("click", ()=>openMediaLightbox(m.attachmentUrl, "video"));
-        att.appendChild(v);
-      }else{
-        const a=document.createElement("a");
-        a.href=m.attachmentUrl;
-        a.textContent="Download file";
-        a.target="_blank";
-        a.rel="noopener";
-        att.appendChild(a);
-      }
-      bubble.appendChild(att);
+    const attachmentPayload = m?.attachment?.url
+      ? { url: m.attachment.url, type: m.attachment.type, mime: m.attachment.mime }
+      : (m.attachmentUrl ? { url: m.attachmentUrl, type: m.attachmentType, mime: m.attachmentMime } : null);
+    if (attachmentPayload) {
+      const node = renderAttachmentNode(attachmentPayload);
+      if (node) bubble.appendChild(node);
     }
 
     const meta = document.createElement("div");
@@ -6869,7 +6899,13 @@ profileEditBtn?.addEventListener("click", () => {
   showEditPanel("about");
 });
 profileSettingsBtn?.addEventListener("click", async () => {
-  if (!currentProfileIsSelf) return;
+  if (!currentProfileIsSelf) {
+    if (modalTargetUsername) {
+      closeModal();
+      startDirectMessage(modalTargetUsername, modalTargetUserId);
+    }
+    return;
+  }
   setTab("custom");
   showEditPanel("preferences");
   try { syncSoundPrefsUI(true); } catch {}
@@ -9467,8 +9503,12 @@ function updateProfileActions({ isSelf = false, canModerate = false } = {}){
     profileEditBtn.style.display = isSelf ? "" : "none";
   }
   if (profileSettingsBtn) {
-    profileSettingsBtn.textContent = "⚙️";
-    profileSettingsBtn.style.display = isSelf ? "" : "none";
+    const showDm = !isSelf;
+    profileSettingsBtn.textContent = showDm ? "💬" : "⚙️";
+    profileSettingsBtn.title = showDm ? "Message" : "Preferences";
+    profileSettingsBtn.setAttribute("aria-label", showDm ? "Message user" : "Preferences");
+    profileSettingsBtn.dataset.mode = showDm ? "dm" : "prefs";
+    profileSettingsBtn.style.display = showDm ? "" : "none";
   }
   syncProfileEditUi();
   setMsgline(profileActionMsg, "");
@@ -10341,7 +10381,16 @@ function wireProfileAvatarActions(){
 
 function syncProfileLikes(p = {}, isSelf = false){
   const likesVal = Number(p.likes || 0);
-  if (likeCount) likeCount.textContent = likesVal.toLocaleString();
+  profileLikeState = { count: likesVal, liked: !!p.likedByMe, isSelf: !!isSelf };
+  if (likeCount) {
+    likeCount.textContent = `${p.likedByMe ? "❤️" : "♡"} ${likesVal.toLocaleString()}`;
+    likeCount.classList.toggle("active", !!p.likedByMe);
+    likeCount.setAttribute("aria-pressed", p.likedByMe ? "true" : "false");
+    likeCount.setAttribute("aria-label", isSelf ? "Likes" : (p.likedByMe ? "Unlike profile" : "Like profile"));
+    likeCount.setAttribute("role", "button");
+    likeCount.tabIndex = isSelf ? -1 : 0;
+    likeCount.dataset.disabled = isSelf ? "true" : "false";
+  }
   if (profileSheetLikes) profileSheetLikes.textContent = `${isSelf ? "❤️" : (p.likedByMe ? "❤️" : "♡")} ${likesVal.toLocaleString()}`;
   if (likeProfileBtn) {
     likeProfileBtn.disabled = !!isSelf;
@@ -10493,30 +10542,53 @@ async function openMemberProfile(username){
   openModal();
 }
 
-likeProfileBtn?.addEventListener("click", async () => {
-  if (!modalTargetUsername || likeProfileBtn.disabled) return;
+let likeToggleInFlight = false;
+async function toggleProfileLike() {
+  if (!modalTargetUsername || likeToggleInFlight || profileLikeState.isSelf) return;
   setMsgline(profileLikeMsg, "");
-  likeProfileBtn.disabled = true;
+  likeToggleInFlight = true;
+  const prev = { ...profileLikeState };
+  const nextLiked = !prev.liked;
+  const nextCount = Math.max(0, prev.count + (nextLiked ? 1 : -1));
+  syncProfileLikes({ likes: nextCount, likedByMe: nextLiked }, false);
+  if (likeProfileBtn) likeProfileBtn.disabled = true;
+
   try {
     const res = await fetch(`/profile/${encodeURIComponent(modalTargetUsername)}/like`, { method: "POST" });
     if (!res.ok) {
       const t = await res.text().catch(() => "");
-      setMsgline(profileLikeMsg, t || "Could not update like.");
-      return;
+      throw new Error(t || "Could not update like.");
     }
     const data = await res.json();
     syncProfileLikes({ likes: data.likes, likedByMe: data.liked }, false);
   } catch (err) {
-    setMsgline(profileLikeMsg, "Could not update like.");
+    syncProfileLikes({ likes: prev.count, likedByMe: prev.liked }, false);
+    setMsgline(profileLikeMsg, err?.message || "Could not update like.");
   } finally {
-    const isSelf = normKey(modalTargetUsername) === normKey(me?.username);
-    likeProfileBtn.disabled = isSelf;
+    likeToggleInFlight = false;
+    if (likeProfileBtn) likeProfileBtn.disabled = profileLikeState.isSelf;
   }
+}
+
+likeProfileBtn?.addEventListener("click", async () => {
+  await toggleProfileLike();
 });
 
 addFriendBtn?.addEventListener("click", () => {
   if (addFriendBtn.disabled) return;
   setMsgline(profileActionMsg, "Friend system coming soon.");
+});
+
+likeCount?.addEventListener("click", async () => {
+  if (profileLikeState.isSelf) return;
+  await toggleProfileLike();
+});
+likeCount?.addEventListener("keydown", async (e) => {
+  if (profileLikeState.isSelf) return;
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    await toggleProfileLike();
+  }
 });
 
 // media actions
@@ -11477,7 +11549,7 @@ function previewTheme(themeId, seconds = 10) {
 
 function isThemeVisible(themeName) {
   if (themeName === "Iris & Lola Neon") {
-    return ["Iri", "Lola Henderson"].includes(currentUser?.username);
+    return isIrisLolaAllowedUser(currentUser || me);
   }
   return true;
 }

--- a/public/styles.css
+++ b/public/styles.css
@@ -2697,14 +2697,23 @@ body.dice-room .sys .diceFace{
 
 
 .attachment{
-  margin-top:6px; border-radius:var(--radiusLg); overflow:hidden;
+  margin-top:6px;
+  border-radius:var(--radiusLg);
+  overflow:hidden;
   border:1px solid var(--border);
   max-width: min(520px, 80vw);
   background:var(--panel);
+  display: inline-block;
 }
-.attachment img, .attachment video{ display:block; width:100%; height:auto; }
+.attachment img, .attachment video{ display:block; max-width:100%; height:auto; }
 .attachment img, .attachment video{ user-select:none; }
 .attachment video{ background:var(--bg); }
+.msg-media-thumb{
+  max-width: clamp(180px, 60vw, 320px);
+  max-height: 240px;
+  border-radius: 12px;
+  object-fit: cover;
+}
 
 .actions{ display:flex; gap:8px; flex-wrap:wrap; align-items:center; margin-top:2px; }
 .reactBtn{
@@ -5391,7 +5400,7 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   color: var(--profileHeaderText, #fff);
   min-height: 120px;
   width: 100%;
-  max-width: 100%;
+  max-width: none;
   --profileHeaderTextShadow: 0 1px 4px rgba(0,0,0,.6);
   --profileHeaderText: #fff;
   --profileHeaderPillBg: rgba(0,0,0,.32);
@@ -5440,14 +5449,14 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
 .profileSheetContent{
   position: relative;
   z-index: 1;
-  display: flex;
+  display: grid;
+  grid-template-columns: auto 1fr;
   gap: 12px;
-  padding: 12px;
+  padding: 10px 12px;
   align-items: center;
-  flex-wrap: wrap;
 }
 .profileSheetContent.compact{
-  padding: 10px 12px;
+  padding: 8px 12px;
 }
 .profileAvatarWrap{ position: relative; display: grid; place-items: center; }
 .profileLevelRing{
@@ -5466,9 +5475,9 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   text-shadow: var(--profileHeaderTextShadow, 0 1px 4px rgba(0,0,0,.6));
 }
 .profileSheetAvatarCard{
-  width: 82px;
-  height: 82px;
-  border-radius: 16px;
+  width: 96px;
+  height: 96px;
+  border-radius: 18px;
   overflow: hidden;
   border: 2px solid rgba(255,255,255,.14);
   background: rgba(0,0,0,.40);
@@ -5531,8 +5540,25 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
 .vibeRow{ display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .vibeChip{ background: rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.08); padding:2px 8px; border-radius:999px; font-size:11px; line-height:1.2; color:var(--text,#fff); }
 .vibeChip.mini{ font-size:10px; opacity:0.85; }
-.profileSheetMeta{ color: var(--profileHeaderText, #fff); padding-bottom: 6px; text-shadow: var(--profileHeaderTextShadow, none); flex: 1; min-width: 0; }
-.profileSheetNameRow{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+.profileSheetMeta{
+  color: var(--profileHeaderText, #fff);
+  padding-bottom: 4px;
+  text-shadow: var(--profileHeaderTextShadow, none);
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  grid-column: 2;
+  grid-row: 1;
+  padding-right: 44px;
+  justify-content: center;
+  min-height: 96px;
+}
+.profileSheetNameRow{
+  display:flex;
+  gap:10px;
+  align-items:center;
+  flex-wrap:wrap;
+}
 .profileSheetName{ font-size: 18px; font-weight: 800; letter-spacing: .2px; text-shadow: var(--profileHeaderTextShadow, none); }
 .profileRoleChip{
   font-size: 11px;
@@ -5547,8 +5573,13 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   display:flex;
   gap:8px;
   flex-wrap:wrap;
-  margin-top:4px;
+  margin-top:auto;
+  order: 5;
 }
+.profileSheetSub{ order: 2; }
+#profileSheetVibes{ order: 3; }
+.profileSheetStats{ order: 4; }
+.profileSheetNameRow{ order: 1; }
 .profileDetail{
   padding:4px 8px;
   border-radius:12px;
@@ -5581,10 +5612,13 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   text-shadow: var(--profileHeaderTextShadow, none);
 }
 .profileHeaderActions{
-  margin-left: auto;
   display: flex;
   gap: 6px;
   align-self: flex-start;
+  position: absolute;
+  top: 8px;
+  right: 12px;
+  margin-left: 0;
 }
 .profileHeaderActions .iconBtn{
   height: 30px;
@@ -5593,8 +5627,8 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   font-size: 16px;
 }
 
-.profileActions{ display:flex; flex-direction:column; gap:8px; margin:6px 0 6px; }
-.profileActionTabs{ width:100%; flex-wrap:nowrap; display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap:6px; margin:6px 0 4px; }
+.profileActions{ display:flex; flex-direction:column; gap:4px; margin:4px 0; }
+.profileActionTabs{ width:100%; flex-wrap:nowrap; display:grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap:6px; margin:4px 0 2px; }
 .profileCompactTabs .tab{
   min-height: 34px;
   flex: 1 1 auto;
@@ -5605,13 +5639,41 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
 .profileQuickActions{ display:flex; gap:10px; align-items:center; justify-content:space-between; flex-wrap:wrap; }
 .quickActionGroup{ display:flex; gap:8px; align-items:center; flex-wrap:wrap; }
 .quickActionGroup .badge{ height:100%; display:flex; align-items:center; justify-content:center; }
+#dmUserBtn,
+#copyUsernameBtn,
+#likeProfileBtn,
+#addFriendBtn{
+  display: none !important;
+}
+#profileSheetStars{
+  display: none !important;
+}
+#likeCount{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  padding:6px 10px;
+  border-radius:999px;
+  border:1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 85%, transparent);
+  font-weight: 800;
+  cursor: pointer;
+  user-select:none;
+}
+#likeCount.active{
+  background: color-mix(in srgb, var(--accent) 25%, var(--panel));
+}
+#likeCount[data-disabled="true"]{
+  opacity: 0.6;
+  cursor: default;
+}
 
 .profileSticky{
   position: sticky;
   top: 0;
   z-index: 2;
   background: var(--panel);
-  padding-top: 6px;
+  padding-top: 4px;
   margin: 0 -12px;
   padding-left: 12px;
   padding-right: 12px;
@@ -5808,7 +5870,8 @@ body.polish-pack.polish-animations .msg-new .dmBubble{
 
   /* Keep the main room composer pinned on desktop layouts */
   .chatMain,
-  main.chatMain{
+  main.chatMain,
+  .chat{
     display: grid;
     grid-template-rows: auto 1fr auto;
     height: 100%;

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ async function setRoleEverywhere(targetId, username, role) {
 const PRIVATE_THEME_ALLOWLIST = {
   "Iris & Lola Neon": {
     users: ["Iri", "Lola Henderson"],
+    userIds: [],
     requireBothOnline: false
   }
 };
@@ -7560,14 +7561,25 @@ Promise.allSettled([migrationsReady, pgInitPromise]).then((results) => {
 });
 
 
+function normalizeUserKey(value) {
+  return String(value || "").trim().toLowerCase();
+}
 function areIrisAndLolaOnline() {
-  return ONLINE_USERS.has("Iri") && ONLINE_USERS.has("Lola Henderson");
+  const online = new Set(Array.from(ONLINE_USERS).map((name) => normalizeUserKey(name)));
+  return online.has(normalizeUserKey("Iri")) && online.has(normalizeUserKey("Lola Henderson"));
 }
 
 function canUseTheme(user, themeName) {
   const rule = PRIVATE_THEME_ALLOWLIST[themeName];
   if (rule) {
-    if (!rule.users.includes(user.username)) return false;
+    const userId = user?.id ?? user?.user_id ?? user?.userId;
+    if (userId != null && Array.isArray(rule.userIds) && rule.userIds.length) {
+      if (!rule.userIds.map(String).includes(String(userId))) return false;
+    } else {
+      const uname = normalizeUserKey(user?.username || "");
+      const allowed = (rule.users || []).some((name) => normalizeUserKey(name) === uname);
+      if (!allowed) return false;
+    }
     if (rule.requireBothOnline && !areIrisAndLolaOnline()) return false;
     return true;
   }


### PR DESCRIPTION
### Motivation
- Ensure image/GIF/video attachments render inline (with a lightbox) instead of showing only "Download attachment".  
- Make the profile modal header more compact and readable while removing redundant action UI and improving the likes UX.  
- Stabilize desktop chat column layout so top bar, messages and composer do not overlap.  
- Correct access gating for the private “Iris & Lola Neon” theme to be robust and support userId-based checks.

### Description
- Unified attachment rendering and inference in `public/app.js`: attachments are now classified (image/video/file) by MIME or extension and render inline thumbnails (`<img>` / `<video>`) with click-to-open lightbox and ESC-to-close support; non-previewable files remain download links.  
- Implemented a reusable `renderAttachmentNode` + `inferAttachmentKind` and replaced legacy per-place attachment handling for both room and DM messages.  
- Profile modal header and quick actions restyled in `public/styles.css` (header converted to 2-column grid, larger avatar, tighter padding), and redundant UI hidden (large Message/Copy username rows and star bubble removed visually).  
- Likes made interactive and optimistic in `public/app.js`: added `toggleProfileLike` with optimistic UI, rollback on error, and made the small likes bubble actionable (keyboard accessible).  
- `profileSettingsBtn` repurposed to act as a DM button when viewing other users (keeps a single edit/settings control for self).  
- Desktop chat layout fixed by ensuring the center chat column uses `display: grid` with `grid-template-rows: auto 1fr auto` on desktop breakpoints and `.msgs` has `min-height: 0` + `overflow-y: auto` in `public/styles.css`.  
- Hardened Iris & Lola Neon gating in both `public/app.js` and `server.js`: case-insensitive username matching, optional allowlist of userIds, and preserved "require both online" behavior.  
- Minor CSS tweaks for `.attachment`, `.msg-media-thumb`, profile spacing and padding to reduce empty space.

### Testing
- Started the app server with `npm start`; the server process reached "Server running on http://localhost:3000" (Postgres init printed a non-fatal connection error in the environment but the app stayed up).  
- Attempted a visual smoke test using Playwright to capture a screenshot, but the headless browser crashed (SIGSEGV) so no screenshot was produced.  
- No unit test suite was present or executed beyond the manual server start and browser attempt described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696195ad755083339cc628e1f59905dc)