### PR TITLE
Restore avatar edit UX and make chat bubble preview sticky + live

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1176,6 +1176,10 @@ let chatFxPrefs = { ...CHAT_FX_DEFAULTS };
 let chatFxDraft = null;
 let chatFxPrefEls = null;
 let chatFxPreviewBubble = null;
+let chatFxPreviewAvatar = null;
+let chatFxPreviewName = null;
+let chatFxPreviewRoleIcon = null;
+let chatFxPreviewTime = null;
 let chatFxStatus = null;
 let chatFxPrefsLoaded = false;
 let chatFxPrefsLoading = false;
@@ -2741,6 +2745,7 @@ const headerColorA = document.getElementById("headerColorA");
 const headerColorB = document.getElementById("headerColorB");
 const headerColorAText = document.getElementById("headerColorAText");
 const headerColorBText = document.getElementById("headerColorBText");
+let avatarPreviewUrl = null;
 
 // couples (opt-in)
 const couplesPartnerInput = document.getElementById("couplesPartnerInput");
@@ -2782,6 +2787,14 @@ setMsgline(profileLikeMsg, "");
 setMsgline(mediaMsg, "");
 ensureVisibleOnFocus(editBio);
 ensureVisibleOnFocus(changelogBodyInput);
+if (avatarFile && !avatarFile._wired){
+  avatarFile._wired = true;
+  avatarFile.addEventListener("change", () => {
+    const file = avatarFile.files?.[0];
+    if (!file) return;
+    applyAvatarPreview(file);
+  });
+}
 const uiScaleRange = document.getElementById("uiScaleRange");
 const uiScaleValue = document.getElementById("uiScaleValue");
 const uiScaleResetBtn = document.getElementById("uiScaleResetBtn");
@@ -9667,6 +9680,7 @@ async function loadMyProfile(){
   meAvatar.appendChild(avatarNode(p.avatar, p.username, p.role));
   renderLevelProgress(progression, true);
   renderVibeOptions(me.vibe_tags || []);
+  updateChatFxPreviewIdentity(me);
   if (editUsername) editUsername.value = "";
   if (priorRole && priorRole !== p.role) {
     pushNotification({ type: "system", text: `Role updated to ${p.role}.` });
@@ -9694,6 +9708,22 @@ function ensureVisibleOnFocus(el){
       try { el.scrollIntoView({ block: "center", behavior: "smooth" }); } catch {}
     }, 60);
   });
+}
+
+function clearAvatarPreview(){
+  if (avatarPreviewUrl) {
+    try { URL.revokeObjectURL(avatarPreviewUrl); } catch {}
+    avatarPreviewUrl = null;
+  }
+}
+
+function applyAvatarPreview(file){
+  if (!file || !profileSheetAvatar) return;
+  clearAvatarPreview();
+  avatarPreviewUrl = URL.createObjectURL(file);
+  profileSheetAvatar.innerHTML = "";
+  profileSheetAvatar.appendChild(avatarNode(avatarPreviewUrl, me?.username || "", me?.role || ""));
+  if (profileMsg) profileMsg.textContent = "Avatar selected. Save to apply.";
 }
 
 function renderVibeChips(targetEl, tags){
@@ -10310,6 +10340,20 @@ function updateChatFxPreview(fx){
   chatFxPreviewBubble.closest(".chatFxPreview")?.classList.toggle("disabled", !normalizeChatFx(fx).enabled);
 }
 
+function updateChatFxPreviewIdentity(user = me){
+  if (!chatFxPreviewName || !chatFxPreviewRoleIcon || !chatFxPreviewAvatar) return;
+  const username = user?.username || "You";
+  const role = normalizeRole(user?.role || "User");
+  const roleToken = roleKey(role);
+  chatFxPreviewName.textContent = username;
+  chatFxPreviewName.dataset.role = roleToken;
+  chatFxPreviewName.closest(".name")?.setAttribute("data-role", roleToken);
+  chatFxPreviewRoleIcon.textContent = `${roleIcon(role)} `;
+  chatFxPreviewAvatar.innerHTML = "";
+  chatFxPreviewAvatar.appendChild(avatarNode(user?.avatar || user?.avatarUrl, username, role, username));
+  if (chatFxPreviewTime) chatFxPreviewTime.textContent = "Just now";
+}
+
 function handleChatFxInput(){
   if (!chatFxPrefEls) return;
   const normalized = normalizeChatFx(readChatFxFormRaw());
@@ -10439,7 +10483,12 @@ function wireChatFxPrefs(){
   };
   chatFxPrefEls.densityButtons = Array.from(chatFxPrefEls.densityRow?.querySelectorAll("button") || []);
   chatFxPreviewBubble = q("#chatFxPreviewBubble");
+  chatFxPreviewAvatar = q("#chatFxPreviewAvatar");
+  chatFxPreviewName = q("#chatFxPreviewName");
+  chatFxPreviewRoleIcon = q("#chatFxPreviewRoleIcon");
+  chatFxPreviewTime = q("#chatFxPreviewTime");
   chatFxStatus = chatFxPrefEls.status;
+  updateChatFxPreviewIdentity(me);
 
   chatFxPrefEls.enabled?.addEventListener("change", handleChatFxInput);
   chatFxPrefEls.glow?.addEventListener("change", handleChatFxInput);
@@ -10793,6 +10842,7 @@ function syncCustomizationUI(){
 
 async function openMyProfile(){
   closeDrawers();
+  clearAvatarPreview();
 
   // Try the self profile endpoint first (includes edit fields)
   let res = await fetch("/profile");

--- a/public/index.html
+++ b/public/index.html
@@ -566,11 +566,13 @@
                     <span class="ico" aria-hidden="true">
                       <svg viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
                     </span>
+                    <span class="iconLabel">Remove</span>
                   </button>
                   <button class="iconPill" id="profileAvatarChangeBtn" type="button" aria-label="Change avatar">
                     <span class="ico" aria-hidden="true">
                       <svg viewBox="0 0 24 24" fill="none"><path d="M4 7h4l2-2h4l2 2h4v14H4V7z" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/><path d="M12 17a4 4 0 1 0 0-8 4 4 0 0 0 0 8z" stroke="currentColor" stroke-width="2"/></svg>
                     </span>
+                    <span class="iconLabel">Change</span>
                   </button>
                 </div>
               </div>
@@ -925,117 +927,131 @@
                       <div class="small muted">Bubble style, density, and themes.</div>
                     </div>
                   </div>
-                  <div class="customizeSection">
-                    <div class="sectionTitle">Basic</div>
-                    <div class="panelBox" id="chatAppearanceBasic">
-                      <div class="field" data-customize-item data-search="bubble style glow">
-                        <label>Bubble style</label>
-                        <select id="chatFxGlow">
-                          <option value="off">Off</option>
-                          <option value="soft">Soft</option>
-                          <option value="neon">Neon</option>
-                          <option value="strong">Strong</option>
-                        </select>
-                      </div>
-                      <div class="field" data-customize-item data-search="bubble color">
-                        <label>Bubble color</label>
-                        <div class="chatFxColorRow">
-                          <input id="chatFxBubbleColorPick" type="color" value="#2b2d31" aria-label="Pick bubble color">
-                          <input id="chatFxBubbleColor" type="text" placeholder="#RRGGBB">
-                          <button class="pillBtn" id="chatFxBubbleColorClear" type="button">Clear</button>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="message spacing compact">
-                        <div class="toggleRow">
-                          <label class="switch">
-                            <input type="checkbox" id="chatSpacingCompact">
-                            <span class="slider"></span>
-                          </label>
-                          <div class="toggleLabel">Compact message spacing</div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                  <details class="customizeSection" data-section="chat-advanced">
-                    <summary>Advanced</summary>
-                    <div class="panelBox" id="chatAppearanceAdvanced">
-                      <div class="field" data-customize-item data-search="bubble radius">
-                        <label>Bubble radius</label>
-                        <div class="chatFxSliderRow">
-                          <input id="chatFxRadius" type="range" min="6" max="28" step="1">
-                          <span class="chatFxSliderValue" id="chatFxRadiusValue">14</span>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="border thickness">
-                        <label>Border thickness</label>
-                        <div class="chatFxSliderRow">
-                          <input id="chatFxBorder" type="range" min="0" max="3" step="1">
-                          <span class="chatFxSliderValue" id="chatFxBorderValue">0</span>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="shadow glow">
-                        <label>Bubble glow intensity</label>
-                        <div class="chatFxSliderRow">
-                          <input id="chatFxGlass" type="range" min="0" max="1" step="0.05">
-                          <span class="chatFxSliderValue" id="chatFxGlassValue">0</span>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="blur">
-                        <label>Bubble blur</label>
-                        <div class="chatFxSliderRow">
-                          <input id="chatFxBlur" type="range" min="0" max="16" step="1">
-                          <span class="chatFxSliderValue" id="chatFxBlurValue">0</span>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="density spacing">
-                        <label>Message spacing</label>
-                        <div class="chatFxDensityRow" id="chatFxDensity">
-                          <button class="pillBtn" type="button" data-value="compact">Compact</button>
-                          <button class="pillBtn" type="button" data-value="cozy">Cozy</button>
-                          <button class="pillBtn" type="button" data-value="spacious">Spacious</button>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="enable bubbles">
-                        <div class="toggleRow">
-                          <label class="switch">
-                            <input id="chatFxEnabled" type="checkbox">
-                            <span class="slider"></span>
-                          </label>
-                          <div class="toggleLabel">Enable custom bubbles</div>
-                        </div>
-                      </div>
-                      <div class="field" data-customize-item data-search="themes">
-                        <div class="sectionTitle">Themes</div>
-                        <div class="themeFilters">
-                          <button class="pillBtn active" data-theme-filter="all" type="button">All</button>
-                          <button class="pillBtn" data-theme-filter="dark" type="button">Dark</button>
-                          <button class="pillBtn" data-theme-filter="light" type="button">Light</button>
-                        </div>
-                        <div class="themeGrid" id="themeGrid"></div>
-                        <div class="msgline" id="themeMsg"></div>
-                      </div>
-                    </div>
-                  </details>
-                  <div class="chatFxPreviewWrap">
-                    <div class="small" style="margin-bottom:10px;">Preview your chat appearance before saving.</div>
-                    <div class="chatFxPreview" id="chatFxPreview">
-                      <div class="chatFxPreviewRow self">
-                        <div class="bubble chatFxPreviewBubble" id="chatFxPreviewBubble">
-                          <div class="meta">
-                            <div class="name"><span class="roleIco">👑 </span><span class="unameText">You</span></div>
-                            <div class="time">Just now</div>
+                  <div class="customizeChatLayout">
+                    <aside class="customizeChatPreview">
+                      <div class="chatFxPreviewWrap">
+                        <div class="small" style="margin-bottom:10px;">Preview your chat appearance before saving.</div>
+                        <div class="chatFxPreview" id="chatFxPreview">
+                          <div class="chatFxPreviewRow self">
+                            <div class="msgItem self chatFxPreviewItem">
+                              <div class="msgAvatar chatFxPreviewAvatar" id="chatFxPreviewAvatar"></div>
+                              <div class="msgMain">
+                                <div class="bubble chatFxPreviewBubble" id="chatFxPreviewBubble">
+                                  <div class="meta">
+                                    <div class="name">
+                                      <span class="roleIco" id="chatFxPreviewRoleIcon">👑 </span>
+                                      <span class="unameText" id="chatFxPreviewName">You</span>
+                                    </div>
+                                    <div class="time" id="chatFxPreviewTime">Just now</div>
+                                  </div>
+                                  <div class="text" id="chatFxPreviewText">Your message preview bubble.</div>
+                                </div>
+                              </div>
+                            </div>
                           </div>
-                          <div class="text">Your message preview bubble.</div>
+                        </div>
+                        <div class="chatFxActions">
+                          <div class="chatFxStatus" id="chatFxStatus"></div>
+                          <button class="btn" id="chatFxSaveBtn" type="button">Save appearance</button>
                         </div>
                       </div>
+                    </aside>
+                    <div class="customizeChatControls">
+                      <div class="customizeSection">
+                        <div class="sectionTitle">Basic</div>
+                        <div class="panelBox" id="chatAppearanceBasic">
+                          <div class="field" data-customize-item data-search="bubble style glow">
+                            <label>Bubble style</label>
+                            <select id="chatFxGlow">
+                              <option value="off">Off</option>
+                              <option value="soft">Soft</option>
+                              <option value="neon">Neon</option>
+                              <option value="strong">Strong</option>
+                            </select>
+                          </div>
+                          <div class="field" data-customize-item data-search="bubble color">
+                            <label>Bubble color</label>
+                            <div class="chatFxColorRow">
+                              <input id="chatFxBubbleColorPick" type="color" value="#2b2d31" aria-label="Pick bubble color">
+                              <input id="chatFxBubbleColor" type="text" placeholder="#RRGGBB">
+                              <button class="pillBtn" id="chatFxBubbleColorClear" type="button">Clear</button>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="message spacing compact">
+                            <div class="toggleRow">
+                              <label class="switch">
+                                <input type="checkbox" id="chatSpacingCompact">
+                                <span class="slider"></span>
+                              </label>
+                              <div class="toggleLabel">Compact message spacing</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <details class="customizeSection" data-section="chat-advanced">
+                        <summary>Advanced</summary>
+                        <div class="panelBox" id="chatAppearanceAdvanced">
+                          <div class="field" data-customize-item data-search="bubble radius">
+                            <label>Bubble radius</label>
+                            <div class="chatFxSliderRow">
+                              <input id="chatFxRadius" type="range" min="6" max="28" step="1">
+                              <span class="chatFxSliderValue" id="chatFxRadiusValue">14</span>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="border thickness">
+                            <label>Border thickness</label>
+                            <div class="chatFxSliderRow">
+                              <input id="chatFxBorder" type="range" min="0" max="3" step="1">
+                              <span class="chatFxSliderValue" id="chatFxBorderValue">0</span>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="shadow glow">
+                            <label>Bubble glow intensity</label>
+                            <div class="chatFxSliderRow">
+                              <input id="chatFxGlass" type="range" min="0" max="1" step="0.05">
+                              <span class="chatFxSliderValue" id="chatFxGlassValue">0</span>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="blur">
+                            <label>Bubble blur</label>
+                            <div class="chatFxSliderRow">
+                              <input id="chatFxBlur" type="range" min="0" max="16" step="1">
+                              <span class="chatFxSliderValue" id="chatFxBlurValue">0</span>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="density spacing">
+                            <label>Message spacing</label>
+                            <div class="chatFxDensityRow" id="chatFxDensity">
+                              <button class="pillBtn" type="button" data-value="compact">Compact</button>
+                              <button class="pillBtn" type="button" data-value="cozy">Cozy</button>
+                              <button class="pillBtn" type="button" data-value="spacious">Spacious</button>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="enable bubbles">
+                            <div class="toggleRow">
+                              <label class="switch">
+                                <input id="chatFxEnabled" type="checkbox">
+                                <span class="slider"></span>
+                              </label>
+                              <div class="toggleLabel">Enable custom bubbles</div>
+                            </div>
+                          </div>
+                          <div class="field" data-customize-item data-search="themes">
+                            <div class="sectionTitle">Themes</div>
+                            <div class="themeFilters">
+                              <button class="pillBtn active" data-theme-filter="all" type="button">All</button>
+                              <button class="pillBtn" data-theme-filter="dark" type="button">Dark</button>
+                              <button class="pillBtn" data-theme-filter="light" type="button">Light</button>
+                            </div>
+                            <div class="themeGrid" id="themeGrid"></div>
+                            <div class="msgline" id="themeMsg"></div>
+                          </div>
+                        </div>
+                      </details>
+                      <div class="customizeResetRow">
+                        <button class="btn secondary" id="resetChatAppearanceBtn" type="button">Reset this section</button>
+                      </div>
                     </div>
-                    <div class="chatFxActions">
-                      <div class="chatFxStatus" id="chatFxStatus"></div>
-                      <button class="btn" id="chatFxSaveBtn" type="button">Save appearance</button>
-                    </div>
-                  </div>
-                  <div class="customizeResetRow">
-                    <button class="btn secondary" id="resetChatAppearanceBtn" type="button">Reset this section</button>
                   </div>
                 </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -3364,6 +3364,17 @@ body:not(.polish-pack) .tonePicker{
 .chatFxPreview.disabled{ opacity:0.65; }
 .chatFxPreviewRow{ display:flex; justify-content:flex-end; }
 .chatFxPreviewRow .bubble{ max-width:100%; }
+.chatFxPreviewItem{
+  width: 100%;
+  align-items: flex-start;
+}
+.chatFxPreviewItem .msgMain{
+  min-width: 0;
+}
+.chatFxPreviewAvatar{
+  width: 32px;
+  height: 32px;
+}
 .chatFxSliderRow{ display:flex; align-items:center; gap:10px; }
 .chatFxSliderRow input[type="range"]{ flex:1; accent-color:var(--accent, #ff4f6d); }
 .chatFxSliderValue{
@@ -5650,6 +5661,11 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
 }
 .iconPill .ico{ width: 18px; height: 18px; display: inline-block; }
 .iconPill svg{ width: 18px; height: 18px; display:block; }
+.iconPill .iconLabel{
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
 .vibeRow{ display:flex; gap:6px; flex-wrap:wrap; margin-top:4px; }
 .vibeChip{ background: rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.08); padding:2px 8px; border-radius:999px; font-size:11px; line-height:1.2; color:var(--text,#fff); }
 .vibeChip.mini{ font-size:10px; opacity:0.85; }
@@ -5889,12 +5905,32 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   margin-top: 8px;
 }
 .chatFxPreviewWrap{
-  margin-top: 14px;
+  margin-top: 0;
 }
 .actionList{
   display: flex;
   gap: 10px;
   flex-wrap: wrap;
+}
+.customizeChatLayout{
+  display: flex;
+  gap: 16px;
+  align-items: flex-start;
+}
+.customizeChatControls{
+  flex: 1;
+  min-width: 0;
+}
+.customizeChatPreview{
+  width: 320px;
+  flex: 0 0 320px;
+  position: sticky;
+  top: 12px;
+  align-self: flex-start;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  padding: 12px;
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
 }
 
 @media (max-width: 760px){
@@ -5906,6 +5942,18 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   }
   .profileInfoCard.profileInfoWide{
     grid-column: span 1;
+  }
+}
+
+@media (max-width: 980px){
+  .customizeChatLayout{
+    flex-direction: column;
+  }
+  .customizeChatPreview{
+    width: 100%;
+    top: 0;
+    z-index: 3;
+    box-shadow: 0 6px 16px rgba(0,0,0,0.2);
   }
 }
 


### PR DESCRIPTION
### Motivation

- The profile/settings overhaul hid or broke avatar editing and made the chat bubble preview hard to see and non‑reactive; this change restores the missing affordances and live preview behavior. 
- Keep existing storage, API routes and role gating unchanged while restoring the previous UX (optimistic preview + save flow). 
- Ensure the bubble preview is always visible while editing and reflects draft settings in real time. 
- Avoid large framework changes and respect reduced‑motion preferences.

### Description

- Reworked the Chat Appearance subpage into a two‑column layout with a sticky preview pane and separate controls, making the preview always visible on desktop and pinned on mobile via CSS (`.customizeChatLayout`, `.customizeChatPreview`).
- Added richer preview DOM nodes and identity wiring (`#chatFxPreviewAvatar`, `#chatFxPreviewName`, `#chatFxPreviewRoleIcon`, `#chatFxPreviewTime`) and a new `updateChatFxPreviewIdentity` helper so the preview shows an avatar, username and sample message and updates immediately.
- Restored and improved avatar edit UX: added labeled avatar action buttons in the profile header (`Remove` / `Change` labels), optimistic local preview handling for `avatarFile` selection (`applyAvatarPreview` / `clearAvatarPreview`), and preserved the existing upload/save flow on save.
- Styling and wiring updates in three files: `public/index.html`, `public/app.js`, and `public/styles.css` (reorganized preview markup, added JS hooks for preview identity and avatar preview, and added CSS for sticky preview and avatar/action labels).

### Testing

- Ran `npm test` which completed successfully (project has no unit tests: output `No tests yet`).
- Started the server with `npm start`; the server process reached a running state but the environment produced a Postgres host lookup error during init (external DB host not reachable here) — the startup log shows the DB init error but then `Server running on http://localhost:3000` was printed.
- Attempted an automated Playwright screenshot to exercise the UI, but the headless browser crashed in this environment (segfault) so no browser screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962c5e209a083339c527138753d4e66)