### PR TITLE
Enhance UI: presence auras, message impact animations, and profile identity glow

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3825,10 +3825,12 @@ function presenceFlags(username, explicitStatus){
   const key = normKey(username);
   const u = (lastUsers || []).find((user) => normKey(user?.name) === key || normKey(user?.username) === key);
   const status = normalizeStatusLabel(explicitStatus || u?.status || "Online", "Online");
-  const isIdle = status === "Idle" || status === "Away";
+  const isIdle = status === "Idle" || status === "Away" || status === "Lurking";
+  const isDnd = status === "Busy" || status === "DnD";
   const isTyping = key && typingUsers.has(key);
   const isActiveDm = key && activeDmUsers.has(key);
-  return { status, isIdle, isTyping, isActiveDm };
+  const isOnline = !isIdle && !isDnd;
+  return { status, isIdle, isDnd, isTyping, isActiveDm, isOnline };
 }
 
 function resolvePresenceAuraTarget(el){
@@ -3845,17 +3847,38 @@ function applyPresenceAura(el, username, opts = {}){
   const key = normKey(username || opts.username || target.dataset.username || "");
   if (key) target.dataset.username = key;
   if (!isPolishAurasEnabled()) {
-    target.classList.remove("presenceAura", "isTyping", "isActiveDm", "isIdle", "isOnline");
+    target.classList.remove("presenceAura", "isTyping", "isActiveDm", "isIdle", "isOnline", "isDnd", "isVip");
     delete target.dataset.status;
     return;
   }
-  const { status, isIdle, isTyping, isActiveDm } = presenceFlags(key, opts.status);
+  const { status, isIdle, isTyping, isActiveDm, isDnd, isOnline } = presenceFlags(key, opts.status);
   target.classList.add("presenceAura");
   target.classList.toggle("isTyping", !!isTyping);
   target.classList.toggle("isActiveDm", !!isActiveDm);
   target.classList.toggle("isIdle", !!isIdle);
-  target.classList.toggle("isOnline", !isIdle);
+  target.classList.toggle("isDnd", !!isDnd);
+  target.classList.toggle("isOnline", !!isOnline);
   if (status) target.dataset.status = status;
+}
+
+function applyAvatarMeta(el, user = {}){
+  if (!el || !el.classList) return;
+  const username = typeof user === "string" ? user : (user?.username || user?.name || "");
+  const role = (typeof user === "object") ? (user?.role || user?.userRole || null) : null;
+  const target = resolvePresenceAuraTarget(el);
+  if (target && username) target.dataset.username = normKey(username);
+  if (target) {
+    const isVip = role && roleRank(role) >= roleRank("VIP");
+    target.classList.toggle("isVip", !!isVip);
+  }
+  applyPresenceAura(target || el, username, { status: user?.status });
+}
+
+function setPresenceClass(username, status){
+  const key = normKey(username || "");
+  if (!key) return;
+  const selector = `[data-username="${escapeSelectorValue(key)}"]`;
+  document.querySelectorAll(selector).forEach((node) => applyPresenceAura(node, key, { status }));
 }
 
 function updatePresenceAuras(){
@@ -3884,7 +3907,7 @@ function avatarNode(url, fallbackText, role, presenceName){
     const wrap=document.createElement("div");
     wrap.className = `avatarFallback role-${rKey}` + (rKey === "vip" ? " vipDiamond" : "");
     wrap.textContent=(fallbackText||"?").slice(0,1).toUpperCase();
-    applyPresenceAura(wrap, pName);
+    applyAvatarMeta(wrap, { username: pName, role });
     return wrap;
   };
 
@@ -3897,7 +3920,7 @@ function avatarNode(url, fallbackText, role, presenceName){
     img.onerror = () => {
       img.replaceWith(buildFallback());
     };
-    applyPresenceAura(img, pName);
+    applyAvatarMeta(img, { username: pName, role });
     return img;
   }
   return buildFallback();
@@ -3943,14 +3966,14 @@ function makeAvatarEl({ username, role, avatarUrl, size = 34 }) {
     };
 
     el.appendChild(img);
-    applyPresenceAura(el, username);
+    applyAvatarMeta(el, { username, role });
     return el;
   }
 
   // No avatar URL -> default gradient fallback
   el.classList.add("avatarFallback", `role-${roleKey(role)}`);
   el.textContent = (username || "?").slice(0, 1).toUpperCase();
-  applyPresenceAura(el, username);
+  applyAvatarMeta(el, { username, role });
   return el;
 }
 
@@ -3963,6 +3986,159 @@ function getUserMeta(username){
   }
   const u = (lastUsers || []).find(x => String((x.username||x.name||"")).toLowerCase() === name.toLowerCase());
   return { role: u?.role || "member", avatarUrl: u?.avatar || u?.avatarUrl || null, username: u?.username || u?.name || name, status: u?.status, vibe_tags: sanitizeVibeTagsClient(u?.vibe_tags) };
+}
+
+const IDENTITY_GLOW_PALETTE = [
+  "#6c7af7",
+  "#58a6ff",
+  "#a855f7",
+  "#ff7ad9",
+  "#ffb347",
+  "#5ee6c9"
+];
+const ROLE_GLOW_MAP = {
+  "Owner": "#f6c358",
+  "Co-owner": "#ff9f43",
+  "Admin": "#ff6b6b",
+  "Moderator": "#54a0ff",
+  "VIP": "#b96bff",
+  "Guest": "#8f9ca6",
+  "User": "#6c7af7",
+  "Member": "#6c7af7"
+};
+function clamp(num, min, max){ return Math.min(max, Math.max(min, num)); }
+function hashString(input){
+  const str = String(input || "");
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+}
+function hexToRgb(hex){
+  const raw = String(hex || "").replace("#", "");
+  const normalized = raw.length === 3 ? raw.split("").map((c)=>c + c).join("") : raw;
+  const int = Number.parseInt(normalized || "0", 16);
+  return {
+    r: (int >> 16) & 255,
+    g: (int >> 8) & 255,
+    b: int & 255
+  };
+}
+function rgbToHex({ r, g, b }){
+  const toHex = (v) => String(v.toString(16)).padStart(2, "0");
+  return `#${toHex(clamp(Math.round(r), 0, 255))}${toHex(clamp(Math.round(g), 0, 255))}${toHex(clamp(Math.round(b), 0, 255))}`;
+}
+function rgbToHsl({ r, g, b }){
+  const rn = r / 255;
+  const gn = g / 255;
+  const bn = b / 255;
+  const max = Math.max(rn, gn, bn);
+  const min = Math.min(rn, gn, bn);
+  let h = 0;
+  let s = 0;
+  const l = (max + min) / 2;
+  const d = max - min;
+  if (d !== 0) {
+    s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    switch (max) {
+      case rn: h = (gn - bn) / d + (gn < bn ? 6 : 0); break;
+      case gn: h = (bn - rn) / d + 2; break;
+      default: h = (rn - gn) / d + 4; break;
+    }
+    h /= 6;
+  }
+  return { h, s, l };
+}
+function hslToRgb({ h, s, l }){
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return { r: v, g: v, b: v };
+  }
+  const hue2rgb = (p, q, t) => {
+    let tt = t;
+    if (tt < 0) tt += 1;
+    if (tt > 1) tt -= 1;
+    if (tt < 1/6) return p + (q - p) * 6 * tt;
+    if (tt < 1/2) return q;
+    if (tt < 2/3) return p + (q - p) * (2/3 - tt) * 6;
+    return p;
+  };
+  const q = l < 0.5 ? l * (1 + s) : l + s - l * s;
+  const p = 2 * l - q;
+  const r = hue2rgb(p, q, h + 1/3);
+  const g = hue2rgb(p, q, h);
+  const b = hue2rgb(p, q, h - 1/3);
+  return { r: Math.round(r * 255), g: Math.round(g * 255), b: Math.round(b * 255) };
+}
+function mixRgb(a, b, ratio = 0.5){
+  const r = a.r + (b.r - a.r) * ratio;
+  const g = a.g + (b.g - a.g) * ratio;
+  const bch = a.b + (b.b - a.b) * ratio;
+  return { r, g, b: bch };
+}
+function getUserIdentityGlow(user){
+  const username = safeString(user?.username || user?.name || "");
+  const role = normalizeRole(user?.role || user?.userRole || "User");
+  const baseHex = ROLE_GLOW_MAP[role] || null;
+  const fallbackHex = IDENTITY_GLOW_PALETTE[hashString(username) % IDENTITY_GLOW_PALETTE.length] || "#6c7af7";
+  const seedHex = baseHex || fallbackHex;
+  let baseRgb = hexToRgb(seedHex);
+
+  const vibes = sanitizeVibeTagsClient(user?.vibe_tags);
+  if (vibes.length) {
+    const vibeHash = hashString(vibes.join("|"));
+    const hsl = rgbToHsl(baseRgb);
+    const hueShift = ((vibeHash % 18) - 9) / 360;
+    hsl.h = (hsl.h + hueShift + 1) % 1;
+    hsl.s = clamp(hsl.s + Math.min(0.12, vibes.length * 0.03), 0.2, 0.9);
+    hsl.l = clamp(hsl.l + 0.04, 0.24, 0.75);
+    baseRgb = hslToRgb(hsl);
+  }
+
+  const partner = safeString(user?.couple?.partner || "");
+  if (partner && partner.toLowerCase() !== username.toLowerCase()) {
+    const partnerHex = IDENTITY_GLOW_PALETTE[hashString(partner) % IDENTITY_GLOW_PALETTE.length] || "#6c7af7";
+    const partnerRgb = hexToRgb(partnerHex);
+    baseRgb = mixRgb(baseRgb, partnerRgb, 0.35);
+  }
+
+  const colorHex = rgbToHex(baseRgb);
+  return {
+    color: colorHex,
+    rgb: `${Math.round(baseRgb.r)} ${Math.round(baseRgb.g)} ${Math.round(baseRgb.b)}`
+  };
+}
+function applyIdentityGlow(el, user){
+  if (!el || !el.style) return;
+  const glow = getUserIdentityGlow(user || {});
+  if (!glow?.color) return;
+  el.style.setProperty("--userGlow", glow.color);
+  el.style.setProperty("--userGlowRgb", glow.rgb);
+}
+
+const MSG_IMPACT_LONG_THRESHOLD = 160;
+function detectMessageImpactVariant(targetEl, rawText){
+  if (!targetEl) return "";
+  const hasMedia = !!targetEl.querySelector(".attachment, .msg-media-thumb, .ytMiniCard, iframe, video");
+  if (hasMedia) return "media";
+  const len = String(rawText || "").trim().length;
+  if (len > MSG_IMPACT_LONG_THRESHOLD) return "long";
+  return "";
+}
+function applyMessageImpactAnimation(el, { variant, isVip } = {}){
+  if (!el || !el.classList || !isPolishAnimationsEnabled()) return;
+  const classes = ["msgEnter"];
+  if (variant) classes.push(`msgEnter--${variant}`);
+  if (isVip) classes.push("msgEnter--vip");
+  el.classList.remove("msgEnter", "msgEnter--long", "msgEnter--media", "msgEnter--vip");
+  el.classList.add(...classes);
+  const cleanup = () => {
+    el.classList.remove(...classes);
+  };
+  el.addEventListener("animationend", cleanup, { once:true });
+  setTimeout(cleanup, 800);
 }
 
 
@@ -4454,7 +4630,7 @@ function updatePolishPackClasses(fx = chatFxPrefs){
 
   if (!auras) {
     document.querySelectorAll(".presenceAura").forEach((el) => {
-      el.classList.remove("presenceAura", "isTyping", "isActiveDm", "isIdle", "isOnline");
+      el.classList.remove("presenceAura", "isTyping", "isActiveDm", "isIdle", "isOnline", "isDnd", "isVip");
       delete el.dataset.status;
     });
   } else {
@@ -5020,6 +5196,7 @@ try{
     const av = document.createElement("div");
     av.className = "msgAvatar";
     av.appendChild(avatarNode(m.avatar, senderName, senderRole));
+    applyAvatarMeta(av, { username: senderName, role: senderRole, status: m.status });
     av.title = `View ${senderName} profile`;
     av.tabIndex = 0;
     const openProfile = (e) => { e.stopPropagation(); openMemberProfile(senderName); };
@@ -5043,9 +5220,11 @@ try{
     showHeader: !canGroup, // show username/role only on first in group
     isSelf
   });
+  item.dataset.username = normKey(senderName || "");
 
   const bubbleEl = item.querySelector(".bubble");
   applyChatFxToBubble(bubbleEl, resolvedFx, { groupBody: body });
+  applyIdentityGlow(item, { username: senderName, role: senderRole, vibe_tags: m?.vibe_tags, couple: m?.couple });
   body.appendChild(item);
   queueContrastReinforcement(bubbleEl);
 
@@ -5064,6 +5243,9 @@ try{
       item.classList.add("msg-new");
       setTimeout(() => item.classList.remove("msg-new"), 220);
     }
+    const variant = detectMessageImpactVariant(item, rawText);
+    const isVip = roleRank(senderRole) >= roleRank("VIP");
+    applyMessageImpactAnimation(item, { variant, isVip });
     delete m.__fresh;
   }
 
@@ -5755,6 +5937,7 @@ function renderMembers(users){
 
       const av=document.createElement("div");
       av.className="mAvatar";
+      applyAvatarMeta(av, { username: u.name, role: u.role, status: u.status });
       const partnerPresent = !!(u?.couple?.partner && presentNames.has(u.couple.partner));
       if (u?.couple?.aura && partnerPresent) av.classList.add("coupleAura");
       av.appendChild(avatarNode(u.avatar, u.name, u.role));
@@ -5882,6 +6065,7 @@ function renderFriendsList(list){
       dot.className = 'dot';
       const statusLabel = f.online ? 'Online' : 'Offline';
       dot.style.background = statusDotColor(statusLabel);
+      applyAvatarMeta(av, { username: f.username, role: f.role || 'User', status: statusLabel });
 
       const meta = document.createElement('div');
       meta.className = 'mMeta';
@@ -6232,6 +6416,12 @@ function renderThreadItem(t){
   div.className = "dmItem" + (t.id === activeDmId ? " active" : "");
   const label = threadLabel(t);
   const preview = t.last_text ? String(t.last_text).slice(0, 80) : "No messages yet";
+  if (!t.is_group) {
+    const other = (t.participants || []).find((p) => p !== me?.username) || label;
+    const meta = getUserMeta(other);
+    div.dataset.username = normKey(meta.username || other);
+    applyIdentityGlow(div, meta);
+  }
 
   div.appendChild(threadAvatarNode(t));
 
@@ -6306,9 +6496,12 @@ function renderDirectThreads(){
       btn.className = "dmThreadBtn";
       btn.dataset.threadId = t.id;
       btn.dataset.flipKey = `dm-thread-${t.id}`;
+      if (String(t.id) === String(activeDmId)) btn.classList.add("active");
 
       const wrap = document.createElement("div");
       wrap.className = "dmThreadRow";
+      wrap.dataset.username = normKey(meta.username || other);
+      applyIdentityGlow(wrap, { username: meta.username || other, role: meta.role, vibe_tags: meta.vibe_tags, couple: meta.couple });
 
       const av = makeAvatarEl({
         username: meta.username || other,
@@ -6636,6 +6829,8 @@ function renderDmMessages(threadId){
     const row = document.createElement("div");
     row.className = "dmRow" + (isSelf ? " self" : "") + gClass;
     row.dataset.dmMid = m.messageId || m.id;
+    row.dataset.username = normKey(authorName || "");
+    applyIdentityGlow(row, { username: authorName, role: m.role || roleForUser(authorName), vibe_tags: m?.vibe_tags, couple: m?.couple });
 
 // Avatar column (non-self). Keep spacing consistent for grouped messages.
 const threadMeta = dmThreads.find(t => String(t.id) === String(threadId));
@@ -6877,6 +7072,9 @@ if (!isSelf) {
         row.classList.add("msg-new");
         setTimeout(() => row.classList.remove("msg-new"), 220);
       }
+      const variant = detectMessageImpactVariant(row, m.text || "");
+      const isVip = roleRank(m.role || roleForUser(authorName)) >= roleRank("VIP");
+      applyMessageImpactAnimation(row, { variant, isVip });
       delete m.__fresh;
     }
     dmMessagesEl.appendChild(row);
@@ -10142,6 +10340,7 @@ function fillProfileSheetHeader(p, isSelf){
 
   currentProfileHeaderRole = p?.role || "";
   applyProfileHeaderGradient(p?.header_grad_a, p?.header_grad_b, currentProfileHeaderRole);
+  applyIdentityGlow(profileSheetHero, p);
 
   // Avatar
   if (profileSheetAvatar){
@@ -11830,6 +12029,7 @@ socket.on("disconnect", (reason) => {
     }
     setTypingIndicator(text);
     stickToBottomIfWanted();
+    (names || []).forEach((name) => setPresenceClass(name, "typing"));
     updatePresenceAuras();
   });
   socket.on("level up", ({ level }) => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -37,6 +37,12 @@
   --shadowSm: 0 4px 12px rgba(0, 0, 0, 0.22);
   --shadowMd: 0 10px 30px rgba(0, 0, 0, 0.35);
   --shadowLg: 0 18px 60px rgba(0, 0, 0, 0.45);
+  --aura-online: 0 220 130;
+  --aura-typing: 105 157 255;
+  --aura-idle: 255 204 102;
+  --aura-dnd: 255 92 92;
+  --aura-strength: 0.28;
+  --aura-strength-vip: 0.45;
 
   /* legacy aliases so existing rules consume theme tokens */
   --soft: rgba(0, 0, 0, 0.13);
@@ -2503,6 +2509,14 @@ body.dice-room .sys .diceFace{
 .msg.self{ align-self:flex-end; flex-direction:row-reverse; }
 .msgAvatar{ width:38px; height:38px; border-radius:50%; background:var(--avatar-bg); overflow:hidden; flex:0 0 auto; border:1px solid var(--border); }
 .msgAvatar img{ width:100%; height:100%; object-fit:cover; display:block; }
+.msgItem,
+.dmRow,
+.dmThreadRow,
+.dmItem,
+.profileSheetHero{
+  --userGlow: transparent;
+  --userGlowRgb: 88 101 242;
+}
 .bubble{
   --fx-base: var(--fx-bubble-bg, var(--messageOtherBg));
   color:var(--fx-text, var(--messageOtherText));
@@ -2530,6 +2544,31 @@ body.dice-room .sys .diceFace{
     0 0 calc(var(--fx-glow, 0) * 6px) color-mix(in srgb, var(--fx-accent, var(--accent)) 45%, transparent),
     0 0 calc(var(--fx-glow, 0) * 14px) color-mix(in srgb, var(--fx-accent, var(--accent)) 28%, transparent);
 }
+.bubble,
+.dmBubble{
+  position:relative;
+}
+.bubble::after,
+.dmBubble::after{
+  content:"";
+  position:absolute;
+  inset:-1px;
+  border-radius:inherit;
+  pointer-events:none;
+  opacity:0.6;
+  box-shadow:
+    0 0 0 1px rgba(var(--userGlowRgb, 88 101 242) / 0.22),
+    0 0 12px rgba(var(--userGlowRgb, 88 101 242) / 0.12);
+  transition: opacity 180ms ease, box-shadow 180ms ease;
+}
+@supports (color: color-mix(in srgb, #000, #fff)){
+  .bubble::after,
+  .dmBubble::after{
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--userGlow) 28%, transparent),
+      0 0 12px color-mix(in srgb, var(--userGlow) 20%, transparent);
+  }
+}
 .self .bubble{
   --fx-base: var(--fx-bubble-bg, var(--messageSelfBg));
   color:var(--fx-text, var(--messageSelfText));
@@ -2540,6 +2579,34 @@ body.dice-room .sys .diceFace{
 .bubble,
 .dmBubble{
   transition: filter 180ms ease, box-shadow 180ms ease;
+}
+.msgEnter{
+  --msg-enter-anim: msgEnterBase;
+  --msg-vip-anim: none;
+  animation: var(--msg-enter-anim) 280ms ease-out both, var(--msg-vip-anim) 520ms ease-out both;
+}
+.msgEnter--long{ --msg-enter-anim: msgEnterLong; }
+.msgEnter--media{ --msg-enter-anim: msgEnterMedia; }
+.msgEnter--vip{ --msg-vip-anim: msgEnterVip; }
+@keyframes msgEnterBase{
+  0%{ opacity:0; transform: translateY(10px); }
+  100%{ opacity:1; transform: translateY(0); }
+}
+@keyframes msgEnterLong{
+  0%{ opacity:0; transform: translateY(12px) scaleY(0.98); }
+  100%{ opacity:1; transform: translateY(0) scaleY(1); }
+}
+@keyframes msgEnterMedia{
+  0%{ opacity:0; transform: translateY(8px) scale(0.96); }
+  100%{ opacity:1; transform: translateY(0) scale(1); }
+}
+@keyframes msgEnterVip{
+  0%{ box-shadow: 0 0 0 rgba(var(--userGlowRgb, 88 101 242) / 0); }
+  40%{ box-shadow: 0 0 18px rgba(var(--userGlowRgb, 88 101 242) / 0.45); }
+  100%{ box-shadow: 0 0 0 rgba(var(--userGlowRgb, 88 101 242) / 0); }
+}
+@media (prefers-reduced-motion: reduce){
+  .msgEnter{ animation:none; }
 }
 .msgItem:hover .bubble,
 .dmRow:hover .dmBubble,
@@ -3703,6 +3770,37 @@ body.lockScroll{ overflow:hidden; }
 .dmItem:hover{ background:var(--panel); }
 .dmItem.active{ background:var(--bubble); }
 .dmItem:last-child{ border-bottom:0; }
+.dmItem,
+.dmThreadRow{
+  position:relative;
+}
+.dmItem::after,
+.dmThreadRow::after{
+  content:"";
+  position:absolute;
+  inset:2px;
+  border-radius:12px;
+  pointer-events:none;
+  opacity:0;
+  transition: opacity 160ms ease, box-shadow 160ms ease;
+  box-shadow:
+    0 0 0 1px rgba(var(--userGlowRgb, 88 101 242) / 0.2),
+    0 0 14px rgba(var(--userGlowRgb, 88 101 242) / 0.12);
+}
+@supports (color: color-mix(in srgb, #000, #fff)){
+  .dmItem::after,
+  .dmThreadRow::after{
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--userGlow) 26%, transparent),
+      0 0 14px color-mix(in srgb, var(--userGlow) 18%, transparent);
+  }
+}
+.dmItem:hover::after,
+.dmItem.active::after,
+.dmThreadBtn:hover .dmThreadRow::after,
+.dmThreadBtn.active .dmThreadRow::after{
+  opacity:1;
+}
 .dmItem .name{ font-weight:900; font-size:13px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
 .dmItem .small{ color:var(--muted); font-size:11px; }
 .dmItem .preview{ display:block; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
@@ -5485,28 +5583,34 @@ body[data-theme="Iris & Lola Neon"].irisLolaTogether .topbar {
 body.polish-pack .presenceAura{
   position:relative;
   isolation:isolate;
+  --aura-color: var(--aura-online);
+  --aura-glow: var(--aura-strength);
 }
 body.polish-pack.polish-auras .presenceAura::after{
   content:"";
   position:absolute;
   inset:2px;
   border-radius:inherit;
-  box-shadow: 0 0 0 1px rgba(255,255,255,0.12);
   pointer-events:none;
-  transition: box-shadow 180ms ease, opacity 180ms ease;
+  opacity:0.9;
+  transition: box-shadow 180ms ease, opacity 180ms ease, filter 180ms ease;
+  box-shadow:
+    0 0 0 2px rgb(var(--aura-color) / calc(var(--aura-glow) + 0.08)),
+    0 0 10px rgb(var(--aura-color) / var(--aura-glow));
+  animation: var(--aura-anim, none);
 }
 body.polish-pack.polish-auras .presenceAura.isOnline::after{
-  box-shadow: 0 0 0 2px rgba(0, 220, 130, 0.28), 0 0 8px rgba(0, 220, 130, 0.18);
-  animation: auraPulse 7s ease-in-out infinite;
+  --aura-color: var(--aura-online);
+  --aura-anim: auraPulse 7s ease-in-out infinite;
 }
 body.polish-pack.polish-auras .presenceAura.isIdle::after{
-  box-shadow: 0 0 0 2px rgba(255, 200, 80, 0.22), 0 0 6px rgba(255, 200, 80, 0.14);
+  --aura-color: var(--aura-idle);
+  --aura-anim: auraPulse 7.5s ease-in-out infinite;
   opacity:0.75;
-  animation: auraPulse 7.5s ease-in-out infinite;
 }
 body.polish-pack.polish-auras .presenceAura.isActiveDm::after{
-  box-shadow: 0 0 0 2px rgba(120, 180, 255, 0.3), 0 0 7px rgba(120, 180, 255, 0.18);
-  animation: auraPulse 7s ease-in-out infinite;
+  --aura-color: var(--aura-typing);
+  --aura-anim: auraPulse 7s ease-in-out infinite;
 }
 @keyframes auraPulse{
   0%{ opacity:0.55; }
@@ -5514,13 +5618,31 @@ body.polish-pack.polish-auras .presenceAura.isActiveDm::after{
   100%{ opacity:0.55; }
 }
 body.polish-pack.polish-auras .presenceAura.isTyping::after{
-  animation: auraPulse 3.6s ease-in-out infinite;
+  --aura-color: var(--aura-typing);
+  --aura-anim: auraPulse 3.6s ease-in-out infinite;
+}
+body.polish-pack.polish-auras .presenceAura.isDnd::after{
+  --aura-color: var(--aura-dnd);
+  --aura-anim: auraPulse 6.2s ease-in-out infinite;
+}
+body.polish-pack.polish-auras .presenceAura.isVip{
+  --aura-glow: var(--aura-strength-vip);
+}
+body.polish-pack.polish-auras .presenceAura.isVip::after{
+  animation: var(--aura-anim, none), auraVipShimmer 12s ease-in-out infinite;
+}
+@keyframes auraVipShimmer{
+  0%{ filter: saturate(1); opacity:0.85; }
+  50%{ filter: saturate(1.25); opacity:1; }
+  100%{ filter: saturate(1); opacity:0.85; }
 }
 @media (prefers-reduced-motion: reduce){
   body.polish-pack.polish-auras .presenceAura.isTyping::after,
   body.polish-pack.polish-auras .presenceAura.isOnline::after,
   body.polish-pack.polish-auras .presenceAura.isIdle::after,
-  body.polish-pack.polish-auras .presenceAura.isActiveDm::after{
+  body.polish-pack.polish-auras .presenceAura.isActiveDm::after,
+  body.polish-pack.polish-auras .presenceAura.isDnd::after,
+  body.polish-pack.polish-auras .presenceAura.isVip::after{
     animation:none;
   }
 }
@@ -5542,6 +5664,24 @@ body.polish-pack.polish-auras .presenceAura.isTyping::after{
   --profileHeaderText: #fff;
   --profileHeaderPillBg: rgba(0,0,0,.32);
   --profileHeaderPillBorder: rgba(255,255,255,.18);
+}
+.profileSheetHero::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  pointer-events:none;
+  opacity:0.65;
+  box-shadow:
+    0 0 0 1px rgba(var(--userGlowRgb, 88 101 242) / 0.2),
+    0 0 24px rgba(var(--userGlowRgb, 88 101 242) / 0.16);
+}
+@supports (color: color-mix(in srgb, #000, #fff)){
+  .profileSheetHero::after{
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--userGlow) 24%, transparent),
+      0 0 24px color-mix(in srgb, var(--userGlow) 18%, transparent);
+  }
 }
 .profileSheetBg{
   position: absolute;


### PR DESCRIPTION
### Motivation
- Make presence more visible and expressive by adding animated aura rings around avatars for `online`, `typing`, `idle`, and `dnd` states. 
- Provide addictive micro-feedback when messages arrive via entry animations that vary by content type, length, and sender tier. 
- Surface a subtle, consistent per-user identity glow derived from role/vibes/couples without changing theme tokens or permissions.

### Description
- Added lightweight client helpers in `public/app.js`: `applyAvatarMeta`, `setPresenceClass`, `getUserIdentityGlow`, `applyIdentityGlow`, `detectMessageImpactVariant`, and `applyMessageImpactAnimation`, and wired presence/typing socket events to update DOM classes. 
- Updated message and DM rendering to tag elements with `data-username`, apply `applyAvatarMeta` to avatar wrappers, set `data-username` on message rows, compute and apply per-user `--userGlow`, and trigger impact animations for freshly received messages. 
- Extended `public/styles.css` with new CSS variables (`--aura-*`, `--aura-strength*`) and scoped rules for `.presenceAura` (state classes `.isOnline`, `.isTyping`, `.isIdle`, `.isDnd`, `.isVip`), new `.msgEnter` animation variants (`--long`, `--media`, `--vip`), and subtle uses of `--userGlow`/`--userGlowRgb` for bubble/DM/thread/profile glow effects while preserving existing variables and layout. 
- All changes are scoped (only `public/app.js` and `public/styles.css` modified) and are fail-safe: presence fallbacks use conservative defaults and avatar/meta helpers tolerate missing data.

### Testing
- Started the application with `node server.js`, which resulted in a non-fatal Postgres init warning but the server reported `Server running on http://localhost:3000`, indicating the web app process launched (succeeded, with a non-blocking DB init warning). 
- Opened the site headlessly using Playwright and captured a screenshot (`artifacts/chat-ui.png`) to validate UI rendering after the changes (page loaded and screenshot was saved successfully). 
- No automated unit tests existed for these UI changes; no JS runtime syntax crashes were observed during the server start and page load steps (observed run succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964385263788333912a66ccb956dbbd)