### PR TITLE
Add Phase 1 Memory & Lore system (DB, server APIs, Timeline UI)

### DIFF
--- a/database.js
+++ b/database.js
@@ -285,6 +285,35 @@ await run(`CREATE INDEX IF NOT EXISTS idx_appeal_messages_appeal ON appeal_messa
   `);
 
   await run(`
+    CREATE TABLE IF NOT EXISTS memories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      user_id INTEGER,
+      room_id TEXT,
+      type TEXT NOT NULL,
+      key TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT,
+      icon TEXT,
+      created_at INTEGER NOT NULL,
+      metadata TEXT,
+      visibility TEXT NOT NULL DEFAULT 'private',
+      pinned INTEGER NOT NULL DEFAULT 0,
+      seen INTEGER NOT NULL DEFAULT 0
+    )
+  `);
+  await run(`CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_user_key ON memories(user_id, key)`);
+  await run(`CREATE INDEX IF NOT EXISTS idx_memories_user_created ON memories(user_id, created_at DESC)`);
+  await run(`CREATE INDEX IF NOT EXISTS idx_memories_user_pinned ON memories(user_id, pinned)`);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS memory_settings (
+      user_id INTEGER PRIMARY KEY,
+      enabled INTEGER NOT NULL DEFAULT 0,
+      last_seen_at INTEGER
+    )
+  `);
+
+  await run(`
     CREATE TABLE IF NOT EXISTS changelog_entries (
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       seq INTEGER NOT NULL UNIQUE,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"No tests yet\" && exit 0",
+    "test:memory": "node scripts/memory-sanity.js",
     "check": "node --check server.js && node --check public/app.js && node --check public/theme-init.js && node --check database.js",
     "audit": "npm audit --audit-level=high",
     "fund": "npm fund",

--- a/public/app.js
+++ b/public/app.js
@@ -751,6 +751,12 @@ let profileLikeState = { count: 0, liked: false, isSelf: false };
 let modalFriendInfo = null;
 let currentRoom = "main";
 let featureFlags = {};
+let memoryFeatureAvailable = false;
+let memoryEnabled = false;
+let memorySettingsLoaded = false;
+let memoryFilter = "all";
+let memoryLoading = false;
+const memoryCacheByFilter = new Map();
 function displayRoomName(room){ return room==="diceroom" ? "Dice Room" : room; }
 
 let lastUsers = [];
@@ -2850,12 +2856,14 @@ const profileStatusValue = document.getElementById("profileStatus");
 
 // tabs/views
 const tabProfile = document.getElementById("tabProfile");
+const tabTimeline = document.getElementById("tabTimeline");
 const tabCustomize = document.getElementById("tabCustomize");
 const tabActions = document.getElementById("tabActions");
 const addFriendBtn = document.getElementById("addFriendBtn");
 const declineFriendBtn = document.getElementById("declineFriendBtn");
 
 const viewAccount = document.getElementById("viewProfile");
+const viewTimeline = document.getElementById("viewTimeline");
 const viewMore = document.getElementById("viewActions");
 const viewAbout = document.getElementById("viewAbout");
 const viewModeration = document.getElementById("viewModeration");
@@ -2876,6 +2884,14 @@ const levelToastText = document.getElementById("levelToastText");
 const profileSheetVibes = document.getElementById("profileSheetVibes");
 const profileSheetOverlay = document.getElementById("profileSheetOverlay");
 
+const memoryFilterBar = document.getElementById("memoryFilterBar");
+const memoryFilterChips = Array.from(document.querySelectorAll(".memoryFilterChip"));
+const memoryFeaturedSection = document.getElementById("memoryFeaturedSection");
+const memoryFeaturedRow = document.getElementById("memoryFeaturedRow");
+const memoryTimelineList = document.getElementById("memoryTimelineList");
+const memoryEmptyState = document.getElementById("memoryEmptyState");
+const memoryTimelineMsg = document.getElementById("memoryTimelineMsg");
+
 const directBadgeColor = document.getElementById("directBadgeColor");
 const groupBadgeColor = document.getElementById("groupBadgeColor");
 const directBadgeColorText = document.getElementById("directBadgeColorText");
@@ -2885,6 +2901,9 @@ const saveBadgePrefsBtn = document.getElementById("saveBadgePrefsBtn");
 
 // my profile edit
 const myProfileEdit = document.getElementById("myProfileEdit");
+const memorySettingsPanel = document.getElementById("memorySettingsPanel");
+const memoryEnabledToggle = document.getElementById("memoryEnabledToggle");
+const memorySettingsMsg = document.getElementById("memorySettingsMsg");
 const avatarFile = document.getElementById("avatarFile");
 const headerColorA = document.getElementById("headerColorA");
 const headerColorB = document.getElementById("headerColorB");
@@ -8271,6 +8290,7 @@ function setTab(tab){
     el.classList.toggle("active", el.dataset.tab===tab);
   }
   if (viewAccount) viewAccount.style.display = tab==="profile" ? "block" : "none";
+  if (viewTimeline) viewTimeline.style.display = tab==="timeline" ? "block" : "none";
   if (viewCustom) viewCustom.style.display = tab==="customize" ? "block" : "none";
   if (viewMore) viewMore.style.display = tab==="actions" ? "block" : "none";
   if (tab !== "profile") setProfileEditMode(false);
@@ -8281,12 +8301,19 @@ function setTab(tab){
       loadChatFxPrefs({ force: true }).catch(() => {});
     }
   }
+  if (tab === "timeline") {
+    void loadMemories();
+  }
   syncProfileEditUi();
   focusActiveTab();
   const scrollHost = modal?.querySelector(".modalBody");
   if (scrollHost) scrollHost.scrollTop = 0;
 }
 tabCustomize?.addEventListener("click", ()=>setTab("customize"));
+tabTimeline?.addEventListener("click", async () => {
+  setTab("timeline");
+  await loadMemories();
+});
 
 function applyCustomizeVisibility(){
   const showCustomize = currentProfileIsSelf;
@@ -8339,6 +8366,16 @@ customizeBackBtns.forEach((btn) => {
 customizeSearch?.addEventListener("input", () => {
   const value = customizeSearch.value;
   filterCustomize(value);
+});
+
+memoryFilterChips.forEach((chip) => {
+  chip.addEventListener("click", async () => {
+    const next = chip.dataset.filter || "all";
+    if (memoryFilter === next) return;
+    memoryFilter = next;
+    updateMemoryFilterChips();
+    await loadMemories({ force: true });
+  });
 });
 
 // New profile edit menu + avatar action wiring
@@ -11133,6 +11170,7 @@ function updateProfileActions({ isSelf = false, canModerate = false } = {}){
     profileSettingsBtn.style.display = "none";
   }
   syncProfileEditUi();
+  updateMemoryVisibility();
   setMsgline(profileActionMsg, "");
 }
 
@@ -11964,6 +12002,164 @@ function syncCustomizationUI(){
   if (customizeMsg) customizeMsg.textContent = "";
 }
 
+function updateMemoryFilterChips(){
+  memoryFilterChips.forEach((chip) => {
+    const active = chip.dataset.filter === memoryFilter;
+    chip.classList.toggle("active", active);
+  });
+}
+
+function updateMemoryVisibility(){
+  const showTimeline = currentProfileIsSelf && memoryEnabled;
+  if (tabTimeline) tabTimeline.style.display = showTimeline ? "" : "none";
+  if (viewTimeline) viewTimeline.style.display = activeProfileTab === "timeline" && showTimeline ? "block" : "none";
+  if (!showTimeline && activeProfileTab === "timeline") setTab("profile");
+
+  const isOwner = roleRank(me?.role || "User") >= roleRank("Owner");
+  const showSettings = currentProfileIsSelf && isOwner && memoryFeatureAvailable;
+  if (memorySettingsPanel) memorySettingsPanel.style.display = showSettings ? "block" : "none";
+  if (memoryEnabledToggle) memoryEnabledToggle.checked = !!memoryEnabled;
+}
+
+function renderMemoryTimeline(){
+  if (!memoryTimelineList || !memoryFeaturedRow || !memoryEmptyState) return;
+  const list = memoryCacheByFilter.get(memoryFilter) || [];
+  const pinned = list.filter((m) => m.pinned);
+
+  memoryTimelineList.innerHTML = "";
+  memoryFeaturedRow.innerHTML = "";
+
+  if (pinned.length) {
+    if (memoryFeaturedSection) memoryFeaturedSection.style.display = "";
+    pinned.forEach((memory) => {
+      memoryFeaturedRow.appendChild(buildMemoryCard(memory, { compact: true }));
+    });
+  } else if (memoryFeaturedSection) {
+    memoryFeaturedSection.style.display = "none";
+  }
+
+  list.forEach((memory) => {
+    memoryTimelineList.appendChild(buildMemoryCard(memory));
+  });
+
+  memoryEmptyState.style.display = list.length ? "none" : "block";
+}
+
+function buildMemoryCard(memory, { compact = false } = {}){
+  const card = document.createElement("div");
+  card.className = `panelBox memoryCard${compact ? " compact" : ""}`;
+
+  const icon = document.createElement("div");
+  icon.className = "memoryCardIcon";
+  icon.textContent = memory.icon || "✨";
+
+  const body = document.createElement("div");
+  const header = document.createElement("div");
+  header.className = "memoryCardHeader";
+
+  const title = document.createElement("div");
+  title.className = "memoryCardTitle";
+  title.textContent = memory.title || "Memory";
+
+  const pinBtn = document.createElement("button");
+  pinBtn.className = "iconBtn smallIcon memoryPinBtn";
+  pinBtn.type = "button";
+  pinBtn.textContent = "📌";
+  pinBtn.setAttribute("aria-label", memory.pinned ? "Unpin memory" : "Pin memory");
+  pinBtn.setAttribute("aria-pressed", memory.pinned ? "true" : "false");
+  pinBtn.classList.toggle("active", !!memory.pinned);
+  pinBtn.addEventListener("click", async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    await toggleMemoryPin(memory);
+  });
+
+  const meta = document.createElement("div");
+  meta.className = "memoryCardMeta";
+  meta.textContent = formatChangelogDate(memory.created_at || Date.now());
+
+  const desc = document.createElement("div");
+  desc.className = "memoryCardDesc";
+  desc.textContent = memory.description || "";
+
+  header.appendChild(title);
+  header.appendChild(pinBtn);
+  body.appendChild(header);
+  body.appendChild(meta);
+  if (!compact && desc.textContent) body.appendChild(desc);
+
+  card.appendChild(icon);
+  card.appendChild(body);
+  return card;
+}
+
+async function refreshMemorySettings({ force = false } = {}){
+  if (!currentProfileIsSelf) return;
+  if (memorySettingsLoaded && !force) {
+    updateMemoryVisibility();
+    return;
+  }
+  try {
+    const res = await fetch("/api/memory-settings");
+    if (!res.ok) throw new Error(await res.text());
+    const data = await res.json();
+    memoryFeatureAvailable = !!data.available;
+    memoryEnabled = !!data.enabled;
+    memorySettingsLoaded = true;
+    if (memorySettingsMsg) memorySettingsMsg.textContent = "";
+  } catch (e) {
+    memoryFeatureAvailable = false;
+    memoryEnabled = false;
+    if (memorySettingsMsg) memorySettingsMsg.textContent = "Memories are unavailable right now.";
+  }
+  updateMemoryVisibility();
+}
+
+async function loadMemories({ force = false } = {}){
+  if (!currentProfileIsSelf || !memoryEnabled) return;
+  if (!force && memoryCacheByFilter.has(memoryFilter)) {
+    renderMemoryTimeline();
+    return;
+  }
+  if (memoryLoading) return;
+  memoryLoading = true;
+  if (memoryTimelineMsg) memoryTimelineMsg.textContent = "Loading memories...";
+  try {
+    const res = await fetch(`/api/memories?filter=${encodeURIComponent(memoryFilter)}`);
+    if (res.status === 403) {
+      memoryEnabled = false;
+      updateMemoryVisibility();
+      return;
+    }
+    if (!res.ok) throw new Error(await res.text());
+    const data = await res.json();
+    memoryCacheByFilter.set(memoryFilter, Array.isArray(data.memories) ? data.memories : []);
+  } catch (e) {
+    if (memoryTimelineMsg) memoryTimelineMsg.textContent = e?.message || "Could not load memories.";
+  } finally {
+    memoryLoading = false;
+    if (memoryTimelineMsg && memoryTimelineMsg.textContent === "Loading memories...") memoryTimelineMsg.textContent = "";
+  }
+  renderMemoryTimeline();
+}
+
+async function toggleMemoryPin(memory){
+  if (!memory?.id) return;
+  try {
+    const res = await fetch(`/api/memories/${memory.id}/pin`, { method: "POST" });
+    if (!res.ok) throw new Error(await res.text());
+    const data = await res.json();
+    memory.pinned = !!data.pinned;
+    memoryCacheByFilter.set(
+      memoryFilter,
+      (memoryCacheByFilter.get(memoryFilter) || []).map((m) => (m.id === memory.id ? memory : m))
+    );
+    renderMemoryTimeline();
+  } catch (e) {
+    if (memoryTimelineMsg) memoryTimelineMsg.textContent = e?.message || "Could not update memory pin.";
+  }
+}
+
 async function openMyProfile(){
   closeDrawers();
   clearAvatarPreview();
@@ -11986,6 +12182,11 @@ async function openMyProfile(){
 
   fillProfileUI(p, true);
   syncCustomizationUI();
+  memoryFilter = "all";
+  memoryCacheByFilter.clear();
+  updateMemoryFilterChips();
+  await refreshMemorySettings({ force: true });
+  if (memoryEnabled) await loadMemories({ force: true });
 
   if (myProfileEdit) myProfileEdit.style.display="block";
   try { refreshCouplesUI(); } catch {}
@@ -12070,6 +12271,32 @@ changeUsernameBtn?.addEventListener("click", async () => {
 });
 refreshProfileBtn.addEventListener("click", openMyProfile);
 
+memoryEnabledToggle?.addEventListener("change", async () => {
+  if (!currentProfileIsSelf) return;
+  if (memorySettingsMsg) memorySettingsMsg.textContent = "Saving...";
+  memoryEnabledToggle.disabled = true;
+  try {
+    const res = await fetch("/api/memory-settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ enabled: !!memoryEnabledToggle.checked }),
+    });
+    if (!res.ok) throw new Error(await res.text());
+    const data = await res.json();
+    memoryFeatureAvailable = !!data.available;
+    memoryEnabled = !!data.enabled;
+    if (!memoryEnabled) memoryCacheByFilter.clear();
+    if (memorySettingsMsg) memorySettingsMsg.textContent = "Memory settings updated.";
+    updateMemoryVisibility();
+    if (memoryEnabled) await loadMemories({ force: true });
+  } catch (e) {
+    if (memorySettingsMsg) memorySettingsMsg.textContent = e?.message || "Could not update memory settings.";
+    memoryEnabledToggle.checked = memoryEnabled;
+  } finally {
+    memoryEnabledToggle.disabled = false;
+  }
+});
+
 async function openMemberProfile(username){
   modalTargetUsername = username;
   closeDrawers();
@@ -12087,6 +12314,18 @@ async function openMemberProfile(username){
   fillProfileUI(p, isSelf);
   modalFriendInfo = p.friend || null;
   syncCustomizationUI();
+  memoryFilter = "all";
+  memoryCacheByFilter.clear();
+  updateMemoryFilterChips();
+  if (isSelf) {
+    await refreshMemorySettings({ force: true });
+    if (memoryEnabled) await loadMemories({ force: true });
+  } else {
+    memoryFeatureAvailable = false;
+    memoryEnabled = false;
+    memorySettingsLoaded = false;
+    updateMemoryVisibility();
+  }
 
   if (myProfileEdit) myProfileEdit.style.display = isSelf ? "block" : "none";
 

--- a/public/index.html
+++ b/public/index.html
@@ -585,6 +585,7 @@
 <div class="profileActions">
 <div class="tabs profileActionTabs profileCompactTabs" id="profileTabs">
 <button class="tab active" data-tab="profile" id="tabProfile" type="button">Profile</button>
+<button class="tab" data-tab="timeline" id="tabTimeline" type="button">Timeline</button>
 <button class="tab" data-tab="customize" id="tabCustomize" type="button">Customize</button>
 <button class="tab" data-tab="actions" id="tabActions" style="display:none;" type="button">Actions</button>
 </div>
@@ -805,6 +806,18 @@
 <div class="small muted">Use BBCode for simple formatting. Links/images require full URLs.</div>
 </div>
 </div>
+<div class="panelBox" id="memorySettingsPanel" style="display:none;">
+<div class="sectionTitle">Memory &amp; Lore System</div>
+<div class="toggleRow">
+<label class="switch">
+<input id="memoryEnabledToggle" type="checkbox"/>
+<span class="slider"></span>
+</label>
+<div class="toggleLabel">Enable Memory Timeline</div>
+</div>
+<div class="small muted">Unlock memory cards and your profile timeline (Owner only during early rollout).</div>
+<div class="msgline" id="memorySettingsMsg"></div>
+</div>
 <div class="row">
 <button class="btn btnPrimary" id="saveProfileBtn" type="button">Save</button>
 <button class="btn btnSecondary" id="refreshProfileBtn" type="button">Cancel</button>
@@ -813,6 +826,32 @@
 <div class="msgline" id="profileMsg"></div>
 </div>
 </div>
+</div>
+</div>
+<div id="viewTimeline" style="display:none;">
+<div class="memoryTimeline">
+<div class="memoryFilters" id="memoryFilterBar">
+<div class="memoryFilterRow">
+<button class="memoryFilterChip active" data-filter="all" type="button">All</button>
+<button class="memoryFilterChip" data-filter="social" type="button">Social</button>
+<button class="memoryFilterChip" data-filter="progress" type="button">Progress</button>
+<button class="memoryFilterChip" data-filter="media" type="button">Media</button>
+<button class="memoryFilterChip" data-filter="rooms" type="button">Rooms</button>
+<button class="memoryFilterChip" data-filter="rare" type="button">Rare</button>
+</div>
+</div>
+<div class="memoryFeatured" id="memoryFeaturedSection" style="display:none;">
+<div class="sectionTitle">Featured Memories</div>
+<div class="memoryFeaturedRow" id="memoryFeaturedRow"></div>
+</div>
+<div class="memoryTimelineList" id="memoryTimelineList"></div>
+<div class="memoryEmptyState" id="memoryEmptyState" style="display:none;">
+<div class="panelBox">
+<div class="sectionTitle">No memories yet</div>
+<div class="small muted">Your timeline will capture milestones like your first voice note, image upload, and level ups.</div>
+</div>
+</div>
+<div class="msgline" id="memoryTimelineMsg"></div>
 </div>
 </div>
 <div id="viewCustomize" style="display:none;">

--- a/public/styles.css
+++ b/public/styles.css
@@ -6327,6 +6327,27 @@ body.polish-pack.polish-auras .presenceAura.isVip::after{
 .profileInfoRow .infoValue{ font-size: 12px; font-weight: 800; }
 .profileCustomEmpty .panelBox{ border-style: dashed; }
 
+/* Memory timeline */
+.memoryTimeline{ display:flex; flex-direction:column; gap:12px; }
+.memoryFilters{ position:sticky; top:0; z-index:3; background:var(--panel2); border:1px solid var(--border); border-radius:12px; padding:8px; }
+.memoryFilterRow{ display:flex; gap:8px; overflow-x:auto; padding-bottom:2px; }
+.memoryFilterRow::-webkit-scrollbar{ height:4px; }
+.memoryFilterChip{ border:1px solid var(--border); background:var(--panel); color:var(--text); border-radius:999px; padding:6px 12px; font-size:12px; white-space:nowrap; cursor:pointer; }
+.memoryFilterChip.active{ background:var(--accent); color:var(--btnPrimaryText); border-color:transparent; }
+.memoryFeatured{ display:flex; flex-direction:column; gap:8px; }
+.memoryFeaturedRow{ display:grid; grid-auto-flow:column; grid-auto-columns:minmax(220px, 1fr); gap:10px; overflow-x:auto; padding-bottom:4px; }
+.memoryTimelineList{ display:flex; flex-direction:column; gap:10px; }
+.memoryCard{ display:grid; grid-template-columns:40px 1fr; gap:10px; align-items:flex-start; }
+.memoryCardIcon{ width:36px; height:36px; border-radius:10px; display:grid; place-items:center; background:var(--panel); border:1px solid var(--border); font-size:18px; }
+.memoryCardHeader{ display:flex; align-items:center; justify-content:space-between; gap:8px; }
+.memoryCardTitle{ font-weight:600; }
+.memoryCardMeta{ font-size:12px; color:var(--muted); margin-top:2px; }
+.memoryCardDesc{ font-size:13px; color:var(--text); margin-top:6px; }
+.memoryPinBtn.active{ color:var(--accent); }
+.memoryCard.compact .memoryCardDesc{ display:none; }
+.memoryCard.compact .memoryCardMeta{ margin-top:0; }
+.memoryEmptyState .panelBox{ border-style:dashed; }
+
 .profileMenu{
   display: grid;
   gap: 10px;

--- a/scripts/memory-sanity.js
+++ b/scripts/memory-sanity.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const path = require("path");
+const os = require("os");
+const fs = require("fs");
+
+const tmpPath = path.join(os.tmpdir(), `chat-memory-sanity-${Date.now()}.db`);
+process.env.DB_FILE = tmpPath;
+
+const { db, migrationsReady } = require("../database");
+
+function dbRun(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function dbGet(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row || null);
+    });
+  });
+}
+
+function dbAll(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows || []);
+    });
+  });
+}
+
+async function main() {
+  await migrationsReady;
+
+  const tables = await dbAll("SELECT name FROM sqlite_master WHERE type='table'");
+  const names = new Set(tables.map((t) => t.name));
+  if (!names.has("memories")) throw new Error("Missing memories table");
+  if (!names.has("memory_settings")) throw new Error("Missing memory_settings table");
+
+  const now = Date.now();
+  await dbRun(
+    "INSERT INTO memories (user_id, type, key, title, created_at) VALUES (?, ?, ?, ?, ?)",
+    [1, "media", "first_image_upload", "First image", now]
+  );
+  await dbRun(
+    "INSERT OR IGNORE INTO memories (user_id, type, key, title, created_at) VALUES (?, ?, ?, ?, ?)",
+    [1, "media", "first_image_upload", "First image", now]
+  );
+  const countRow = await dbGet(
+    "SELECT COUNT(*) AS count FROM memories WHERE user_id = ? AND key = ?",
+    [1, "first_image_upload"]
+  );
+  if (Number(countRow?.count || 0) !== 1) throw new Error("Memory idempotency failed");
+
+  await dbRun(
+    "UPDATE memories SET pinned = CASE WHEN pinned = 1 THEN 0 ELSE 1 END WHERE user_id = ? AND key = ?",
+    [1, "first_image_upload"]
+  );
+  const pinRow = await dbGet(
+    "SELECT pinned FROM memories WHERE user_id = ? AND key = ?",
+    [1, "first_image_upload"]
+  );
+  if (!pinRow) throw new Error("Pinned memory not found");
+
+  console.log("Memory sanity checks passed.");
+}
+
+main()
+  .catch((err) => {
+    console.error(err);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    db.close();
+    try {
+      fs.unlinkSync(tmpPath);
+    } catch {}
+  });

--- a/server.js
+++ b/server.js
@@ -90,6 +90,14 @@ const { Server } = require("socket.io");
 const { db, migrationsReady } = require("./database");
 const { VIBE_TAGS, VIBE_TAG_LIMIT } = require("./vibe-tags");
 
+const MEMORY_SYSTEM_ENABLED = process.env.MEMORY_SYSTEM_ENABLED === "1";
+const MEMORY_SYSTEM_ALLOWLIST = new Set(
+  String(process.env.MEMORY_SYSTEM_ALLOWLIST || "")
+    .split(",")
+    .map((name) => name.trim().toLowerCase())
+    .filter(Boolean)
+);
+
 const PORT = Number(process.env.PORT || 3000);
 const PUBLIC_DIR = path.join(__dirname, "public");
 const UPLOADS_DIR = path.join(__dirname, "uploads");
@@ -300,6 +308,33 @@ const pgInitPromise = (async () => {
       );
       CREATE INDEX IF NOT EXISTS idx_profile_likes_target ON profile_likes(target_user_id);
       CREATE INDEX IF NOT EXISTS idx_profile_likes_user ON profile_likes(user_id);
+    `);
+
+    await pgPool.query(`
+      CREATE TABLE IF NOT EXISTS memories (
+        id BIGSERIAL PRIMARY KEY,
+        user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+        room_id TEXT,
+        type TEXT NOT NULL,
+        key TEXT NOT NULL,
+        title TEXT NOT NULL,
+        description TEXT,
+        icon TEXT,
+        created_at BIGINT NOT NULL,
+        metadata JSONB,
+        visibility TEXT NOT NULL DEFAULT 'private',
+        pinned BOOLEAN NOT NULL DEFAULT false,
+        seen BOOLEAN NOT NULL DEFAULT false
+      );
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_user_key ON memories(user_id, key);
+      CREATE INDEX IF NOT EXISTS idx_memories_user_created ON memories(user_id, created_at DESC);
+      CREATE INDEX IF NOT EXISTS idx_memories_user_pinned ON memories(user_id, pinned);
+
+      CREATE TABLE IF NOT EXISTS memory_settings (
+        user_id INTEGER PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+        enabled BOOLEAN NOT NULL DEFAULT false,
+        last_seen_at BIGINT
+      );
     `);
 
     // Centralized gold spending ledger so spend reasons can be audited later.
@@ -1758,6 +1793,215 @@ async function setConfigJson(key, obj) {
   return obj;
 }
 
+function isMemoryFeatureAvailableFor(user) {
+  if (MEMORY_SYSTEM_ENABLED) return true;
+  const username = String(user?.username || "").toLowerCase();
+  const role = user?.role || "User";
+  if (requireMinRole(role, "Owner")) return true;
+  return MEMORY_SYSTEM_ALLOWLIST.has(username);
+}
+
+function normalizeMemoryBool(value) {
+  return value === true || value === 1 || value === "1";
+}
+
+async function getMemorySettingsRow(userId) {
+  try {
+    if (await pgUserExists(userId)) {
+      const { rows } = await pgPool.query(
+        "SELECT enabled, last_seen_at FROM memory_settings WHERE user_id = $1 LIMIT 1",
+        [userId]
+      );
+      return rows[0] || null;
+    }
+  } catch (e) {
+    console.warn("[memory][pg settings]", e?.message || e);
+  }
+
+  try {
+    return await dbGetAsync("SELECT enabled, last_seen_at FROM memory_settings WHERE user_id = ?", [userId]);
+  } catch (e) {
+    console.warn("[memory][sqlite settings]", e?.message || e);
+    return null;
+  }
+}
+
+async function setMemorySettingsRow(userId, enabled) {
+  const isEnabled = !!enabled;
+  try {
+    if (await pgUserExists(userId)) {
+      await pgPool.query(
+        `
+        INSERT INTO memory_settings (user_id, enabled)
+        VALUES ($1, $2)
+        ON CONFLICT (user_id) DO UPDATE SET enabled = EXCLUDED.enabled
+        `,
+        [userId, isEnabled]
+      );
+      return;
+    }
+  } catch (e) {
+    console.warn("[memory][pg settings set]", e?.message || e);
+  }
+
+  await dbRunAsync(
+    `
+    INSERT INTO memory_settings (user_id, enabled)
+    VALUES (?, ?)
+    ON CONFLICT(user_id) DO UPDATE SET enabled = excluded.enabled
+    `,
+    [userId, isEnabled ? 1 : 0]
+  );
+}
+
+async function getMemorySettingsForUser(user) {
+  const available = isMemoryFeatureAvailableFor(user);
+  if (!available) return { available: false, enabled: false, lastSeenAt: null };
+
+  const row = await getMemorySettingsRow(user.id);
+  const enabled = row ? normalizeMemoryBool(row.enabled) : MEMORY_SYSTEM_ENABLED;
+  const lastSeenAt = row?.last_seen_at ?? row?.lastSeenAt ?? null;
+  return { available: true, enabled: !!enabled, lastSeenAt };
+}
+
+async function getUserIdentityForMemory(userId, hint) {
+  if (hint?.id && hint?.username) {
+    return { id: Number(hint.id), username: hint.username, role: hint.role || "User" };
+  }
+  try {
+    if (await pgUserExists(userId)) {
+      const row = await pgGetUserRowById(userId, ["id", "username", "role"]);
+      if (row) return { id: Number(row.id), username: row.username, role: row.role || "User" };
+    }
+  } catch (e) {
+    console.warn("[memory][pg user]", e?.message || e);
+  }
+  try {
+    const row = await dbGetAsync("SELECT id, username, role FROM users WHERE id = ?", [userId]);
+    if (row) return { id: Number(row.id), username: row.username, role: row.role || "User" };
+  } catch (e) {
+    console.warn("[memory][sqlite user]", e?.message || e);
+  }
+  return null;
+}
+
+function normalizeMemoryRow(row) {
+  if (!row) return null;
+  const metadata = row.metadata == null ? null : (typeof row.metadata === "object" ? row.metadata : safeJsonParse(row.metadata, null));
+  return {
+    id: Number(row.id),
+    user_id: row.user_id ?? row.userId ?? null,
+    room_id: row.room_id ?? row.roomId ?? null,
+    type: row.type,
+    key: row.key,
+    title: row.title,
+    description: row.description || "",
+    icon: row.icon || "",
+    created_at: Number(row.created_at ?? row.createdAt ?? Date.now()),
+    metadata,
+    visibility: row.visibility || "private",
+    pinned: normalizeMemoryBool(row.pinned),
+    seen: normalizeMemoryBool(row.seen),
+  };
+}
+
+async function ensureMemory(userId, key, payload, userHint) {
+  const identity = await getUserIdentityForMemory(userId, userHint);
+  if (!identity || !key) return null;
+
+  const settings = await getMemorySettingsForUser(identity);
+  if (!settings.available || !settings.enabled) return null;
+
+  const now = Date.now();
+  const memory = {
+    user_id: identity.id,
+    room_id: payload.room_id ?? payload.roomId ?? null,
+    type: payload.type || "event",
+    key: String(key),
+    title: String(payload.title || "Memory"),
+    description: payload.description ? String(payload.description) : "",
+    icon: payload.icon ? String(payload.icon) : "",
+    created_at: Number(payload.created_at || payload.createdAt || now),
+    metadata: payload.metadata ?? null,
+    visibility: payload.visibility || "private",
+  };
+
+  try {
+    if (await pgUserExists(identity.id)) {
+      const { rows } = await pgPool.query(
+        `
+        INSERT INTO memories (user_id, room_id, type, key, title, description, icon, created_at, metadata, visibility, pinned, seen)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,false,false)
+        ON CONFLICT (user_id, key) DO NOTHING
+        RETURNING *
+        `,
+        [
+          memory.user_id,
+          memory.room_id,
+          memory.type,
+          memory.key,
+          memory.title,
+          memory.description,
+          memory.icon,
+          memory.created_at,
+          memory.metadata,
+          memory.visibility,
+        ]
+      );
+      const created = normalizeMemoryRow(rows[0]);
+      if (created) {
+        const sid = socketIdByUserId.get(identity.id);
+        if (sid) io.to(sid).emit("memory:created", created);
+      }
+      return created;
+    }
+  } catch (e) {
+    console.warn("[memory][pg ensure]", e?.message || e);
+  }
+
+  const metadataJson = memory.metadata == null ? null : JSON.stringify(memory.metadata);
+  const result = await dbRunAsync(
+    `
+    INSERT OR IGNORE INTO memories (user_id, room_id, type, key, title, description, icon, created_at, metadata, visibility, pinned, seen)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, 0)
+    `,
+    [
+      memory.user_id,
+      memory.room_id,
+      memory.type,
+      memory.key,
+      memory.title,
+      memory.description,
+      memory.icon,
+      memory.created_at,
+      metadataJson,
+      memory.visibility,
+    ]
+  );
+  if (!result?.changes) return null;
+  const row = await dbGetAsync("SELECT * FROM memories WHERE id = ?", [result.lastID]);
+  const created = normalizeMemoryRow(row);
+  if (created) {
+    const sid = socketIdByUserId.get(identity.id);
+    if (sid) io.to(sid).emit("memory:created", created);
+  }
+  return created;
+}
+
+const MEMORY_FILTER_TYPES = {
+  all: null,
+  social: ["social"],
+  progress: ["progress", "milestone", "streak"],
+  media: ["media"],
+  rooms: ["room"],
+  rare: ["rare"],
+};
+
+function resolveMemoryTypes(filter) {
+  const key = String(filter || "all").toLowerCase();
+  return MEMORY_FILTER_TYPES[key] ?? null;
+}
+
 
 
 // Serialize XP updates per user to prevent race conditions between concurrent XP events.
@@ -2504,6 +2748,8 @@ function xpRatesForRole(role) {
   };
 }
 
+const MEMORY_LEVEL_MILESTONES = new Set([5, 10, 25]);
+
 function levelInfo(xpRaw) {
   let xp = Math.max(0, Math.floor(Number(xpRaw) || 0));
   let level = 1;
@@ -2646,6 +2892,21 @@ async function persistXpState(userId, data) {
   return await dbRunAsync(`UPDATE users SET ${sqliteSets.join(", ")} WHERE id = ?`, [...sqliteParams, userId]);
 }
 
+async function maybeCreateLevelMemories(userId, prevLevel, nextLevel) {
+  if (!Number.isFinite(prevLevel) || !Number.isFinite(nextLevel)) return;
+  for (const milestone of MEMORY_LEVEL_MILESTONES) {
+    if (milestone > prevLevel && milestone <= nextLevel) {
+      await ensureMemory(userId, `level_${milestone}`, {
+        type: "progress",
+        title: `Level ${milestone} reached`,
+        description: `You hit level ${milestone}.`,
+        icon: "⭐",
+        metadata: { level: milestone },
+      });
+    }
+  }
+}
+
 async function applyXpGain(userId, delta, opts = {}) {
   const amount = Math.max(0, Math.floor(Number(delta) || 0));
   if (!amount) return null;
@@ -2717,7 +2978,10 @@ async function applyXpGain(userId, delta, opts = {}) {
     }
 
     // Emit level-up only after the committed XP write to avoid racey toasts.
-    if (info && info.level > prevLevel) emitLevelUp(userId, info.level);
+    if (info && info.level > prevLevel) {
+      emitLevelUp(userId, info.level);
+      void maybeCreateLevelMemories(userId, prevLevel, info.level);
+    }
     emitProgressionUpdate(userId);
     emitLeaderboardUpdateThrottled();
     return info ? { xp: newXp, ...info } : null;
@@ -5773,6 +6037,110 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
   }
 });
 
+app.get("/api/memory-settings", requireLogin, async (req, res) => {
+  try {
+    const settings = await getMemorySettingsForUser(req.session.user);
+    return res.json({ ok: true, ...settings });
+  } catch (e) {
+    console.warn("[memory] settings fetch failed:", e?.message || e);
+    return res.status(500).json({ ok: false, error: "failed_to_load_settings" });
+  }
+});
+
+app.post("/api/memory-settings", requireLogin, express.json({ limit: "16kb" }), async (req, res) => {
+  try {
+    const user = req.session.user;
+    const settings = await getMemorySettingsForUser(user);
+    if (!settings.available) return res.status(403).json({ ok: false, error: "feature_disabled" });
+    const enabled = !!req.body?.enabled;
+    await setMemorySettingsRow(user.id, enabled);
+    return res.json({ ok: true, available: true, enabled });
+  } catch (e) {
+    console.warn("[memory] settings update failed:", e?.message || e);
+    return res.status(500).json({ ok: false, error: "failed_to_save_settings" });
+  }
+});
+
+app.get("/api/memories", requireLogin, async (req, res) => {
+  const user = req.session.user;
+  try {
+    const settings = await getMemorySettingsForUser(user);
+    if (!settings.available || !settings.enabled) return res.status(403).json({ ok: false, error: "disabled" });
+
+    const types = resolveMemoryTypes(req.query?.filter);
+    if (await pgUserExists(user.id)) {
+      const params = [user.id];
+      let whereSql = "user_id = $1";
+      if (types?.length) {
+        params.push(types);
+        whereSql += ` AND type = ANY($${params.length}::text[])`;
+      }
+      const { rows } = await pgPool.query(
+        `SELECT * FROM memories WHERE ${whereSql} ORDER BY created_at DESC`,
+        params
+      );
+      const memories = rows.map(normalizeMemoryRow);
+      return res.json({ ok: true, memories });
+    }
+  } catch (e) {
+    console.warn("[memory] pg list failed, falling back to sqlite:", e?.message || e);
+  }
+
+  try {
+    const params = [user.id];
+    let whereSql = "user_id = ?";
+    if (types?.length) {
+      whereSql += ` AND type IN (${types.map(() => "?").join(", ")})`;
+      params.push(...types);
+    }
+    const rows = await dbAllAsync(
+      `SELECT * FROM memories WHERE ${whereSql} ORDER BY created_at DESC`,
+      params
+    );
+    const memories = rows.map(normalizeMemoryRow);
+    return res.json({ ok: true, memories });
+  } catch (e) {
+    console.warn("[memory] sqlite list failed:", e?.message || e);
+    return res.status(500).json({ ok: false, error: "failed_to_load_memories" });
+  }
+});
+
+app.post("/api/memories/:id/pin", requireLogin, async (req, res) => {
+  const user = req.session.user;
+  const memoryId = Number(req.params.id) || 0;
+  if (!memoryId) return res.status(400).json({ ok: false, error: "bad_request" });
+
+  try {
+    const settings = await getMemorySettingsForUser(user);
+    if (!settings.available || !settings.enabled) return res.status(403).json({ ok: false, error: "disabled" });
+
+    if (await pgUserExists(user.id)) {
+      const { rows } = await pgPool.query(
+        `UPDATE memories SET pinned = NOT pinned WHERE id = $1 AND user_id = $2 RETURNING pinned`,
+        [memoryId, user.id]
+      );
+      const row = rows[0];
+      if (!row) return res.status(404).json({ ok: false, error: "not_found" });
+      return res.json({ ok: true, pinned: normalizeMemoryBool(row.pinned) });
+    }
+  } catch (e) {
+    console.warn("[memory] pg pin failed, falling back to sqlite:", e?.message || e);
+  }
+
+  try {
+    await dbRunAsync(
+      `UPDATE memories SET pinned = CASE WHEN pinned = 1 THEN 0 ELSE 1 END WHERE id = ? AND user_id = ?`,
+      [memoryId, user.id]
+    );
+    const row = await dbGetAsync(`SELECT pinned FROM memories WHERE id = ? AND user_id = ?`, [memoryId, user.id]);
+    if (!row) return res.status(404).json({ ok: false, error: "not_found" });
+    return res.json({ ok: true, pinned: normalizeMemoryBool(row.pinned) });
+  } catch (e) {
+    console.warn("[memory] sqlite pin failed:", e?.message || e);
+    return res.status(500).json({ ok: false, error: "failed_to_pin" });
+  }
+});
+
 
 // ---- Couples API (opt-in). Postgres only.
 app.get("/api/couples/me", requireLogin, async (req, res) => {
@@ -5873,6 +6241,32 @@ app.post("/api/couples/respond", requireLogin, async (req, res) => {
       `UPDATE couple_links SET status='active', activated_at=$2, updated_at=$2 WHERE id=$1`,
       [linkId, now]
     );
+
+    try {
+      const userIds = [Number(link.user1_id) || 0, Number(link.user2_id) || 0].filter(Boolean);
+      if (userIds.length === 2) {
+        const { rows: users } = await pgPool.query(
+          `SELECT id, username, role FROM users WHERE id = ANY($1::int[])`,
+          [userIds]
+        );
+        const map = new Map(users.map((u) => [Number(u.id), u]));
+        const u1 = map.get(userIds[0]);
+        const u2 = map.get(userIds[1]);
+        if (u1 && u2) {
+          const payloadFor = (self, partner) => ({
+            type: "social",
+            title: "Couple linked",
+            description: `Linked with ${partner.username}.`,
+            icon: "💜",
+            metadata: { partnerId: partner.id, partnerName: partner.username },
+          });
+          void ensureMemory(u1.id, `couple_linked_${u2.id}`, payloadFor(u1, u2), u1);
+          void ensureMemory(u2.id, `couple_linked_${u1.id}`, payloadFor(u2, u1), u2);
+        }
+      }
+    } catch (e) {
+      console.warn("[couples] memory create failed:", e?.message || e);
+    }
 
     const summary = await pgGetCoupleSummaryFor(meId);
     return res.json(summary);
@@ -6513,6 +6907,29 @@ app.post("/upload", requireLogin, (req, res) => {
 
     const url = `/uploads/${req.file.filename}`;
     const type = isImage ? "image" : (isAudio ? "audio" : "video");
+
+    if (req.session?.user?.id) {
+      const userHint = req.session.user;
+      if (isAudio && uploadKind === "audio-upload") {
+        void ensureMemory(req.session.user.id, "first_voice_note", {
+          type: "media",
+          title: "First voice note",
+          description: "Sent your first voice note.",
+          icon: "🎙️",
+          metadata: { kind: "voice_note" },
+        }, userHint);
+      }
+      if (isImage) {
+        void ensureMemory(req.session.user.id, "first_image_upload", {
+          type: "media",
+          title: "First image upload",
+          description: "Shared your first image.",
+          icon: "🖼️",
+          metadata: { kind: "image" },
+        }, userHint);
+      }
+    }
+
     return res.json({
       url,
       mime,
@@ -7772,6 +8189,16 @@ socket.on("join room", ({ room, status }) => {
           io.to(room).emit("system", msg);
 
           io.to(room).emit("dice:rolled", { userId: uid, username: socket.user.username, value, won });
+          if (won) {
+            void ensureMemory(uid, "dice_jackpot", {
+              type: "rare",
+              title: "Dice jackpot!",
+              description: "Landed the jackpot roll in Dice Room.",
+              icon: "🎲",
+              room_id: room,
+              metadata: { value, deltaGold },
+            }, socket.user);
+          }
           return;
         }
       } catch (e) {
@@ -7822,6 +8249,16 @@ socket.on("join room", ({ room, status }) => {
             io.to(room).emit("system", msg);
 
             io.to(room).emit("dice:rolled", { userId: uid, username: socket.user.username, value, won });
+            if (won) {
+              void ensureMemory(uid, "dice_jackpot", {
+                type: "rare",
+                title: "Dice jackpot!",
+                description: "Landed the jackpot roll in Dice Room.",
+                icon: "🎲",
+                room_id: room,
+                metadata: { value, deltaGold },
+              }, socket.user);
+            }
           }
         );
       });


### PR DESCRIPTION
### Motivation
- Implement Phase 1 of a gated Memory & Lore system to capture system-generated milestones (first voice/image, level milestones, dice jackpots, couple links) without regressing existing auth/ui flows.
- Provide a per-user toggle and server feature flag so rollout is safe and Owner/allowlist can enable the feature early.

### Description
- Database: added `memories` and `memory_settings` tables and supporting indexes for both SQLite (`database.js`) and Postgres (`server.js`) with safe migration patterns and idempotency (`user_id + key` unique index).
- Server: added `MEMORY_SYSTEM_ENABLED` env flag plus allowlist, helpers to read/save per-user memory settings, `ensureMemory` idempotent helper, normalization and PG/SQLite fallback logic, and a small set of generation hooks wired to existing events (uploads: `first_voice_note`/`first_image_upload`, XP level milestones, dice jackpot, couples link).
- API: implemented GET `/api/memory-settings`, POST `/api/memory-settings`, GET `/api/memories?filter=...`, and POST `/api/memories/:id/pin` with permission gating and PG/SQLite fallbacks.
- Client/UI: added Profile -> Timeline tab, filter chips (All/Social/Progress/Media/Rooms/Rare), featured pinned shelf, compact Memory Card component, styles, and an Owner-only toggle in profile settings; client fetch/caching and pin/unpin flows are implemented with graceful empty states.
- Tests & tooling: added a lightweight sanity script `scripts/memory-sanity.js` and an npm script `test:memory` that runs a temporary SQLite migration + idempotency/pin checks.

### Testing
- Ran `npm run check` (static syntax checking via `node --check`) — succeeded.
- Ran the memory sanity script `node scripts/memory-sanity.js` which bootstraps a temp SQLite DB, validates migrations, verifies idempotent insert and pin toggle — succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968df8bc8008333ad9c7b685d4135a6)