### PR TITLE
Fix couples permissions; add COUPLES_V2 feature-flagged card, memories, badge & nudge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,9 @@
         "pg": "^8.16.3",
         "socket.io": "^4.8.3",
         "sqlite3": "^5.1.7"
+      },
+      "devDependencies": {
+        "supertest": "^7.2.2"
       }
     },
     "node_modules/@gar/promisify": {
@@ -28,6 +31,19 @@
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@npmcli/fs": {
       "version": "1.1.1",
@@ -53,6 +69,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -186,6 +212,20 @@
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -430,6 +470,29 @@
         "color-support": "bin.js"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -511,6 +574,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -565,6 +635,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
@@ -588,6 +668,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -789,6 +880,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -923,6 +1030,13 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -948,6 +1062,64 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -1112,6 +1284,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1428,6 +1616,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -2658,6 +2869,42 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/tar": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"No tests yet\" && exit 0",
+    "test:couples": "node scripts/couples-regression.js",
     "test:memory": "node scripts/memory-sanity.js",
     "check": "node --check server.js && node --check public/app.js && node --check public/theme-init.js && node --check database.js",
     "audit": "npm audit --audit-level=high",
@@ -28,6 +29,9 @@
     "pg": "^8.16.3",
     "socket.io": "^4.8.3",
     "sqlite3": "^5.1.7"
+  },
+  "devDependencies": {
+    "supertest": "^7.2.2"
   },
   "overrides": {
     "qs": "^6.14.1"

--- a/public/app.js
+++ b/public/app.js
@@ -2833,6 +2833,12 @@ const profileSheetLikes = document.getElementById("profileSheetLikes");
 const profileSheetSub = document.getElementById("profileSheetSub");
 const profileCoupleChip = document.getElementById("profileCoupleChip");
 const profileCoupleCard = document.getElementById("profileCoupleCard");
+const profileCoupleBody = document.getElementById("profileCoupleBody");
+const profileCoupleAvatars = document.getElementById("profileCoupleAvatars");
+const profileCoupleName = document.getElementById("profileCoupleName");
+const profileCoupleBadge = document.getElementById("profileCoupleBadge");
+const profileCoupleMeta = document.getElementById("profileCoupleMeta");
+const profileCoupleBio = document.getElementById("profileCoupleBio");
 const profileSheetAge = document.getElementById("profileSheetAge");
 const profileSheetGender = document.getElementById("profileSheetGender");
 const profileSheetDetails = document.getElementById("profileSheetDetails");
@@ -2924,6 +2930,16 @@ const couplesBadgeToggle = document.getElementById("couplesBadgeToggle");
 const couplesAuraToggle = document.getElementById("couplesAuraToggle");
 const couplesShowMembersToggle = document.getElementById("couplesShowMembersToggle");
 const couplesGroupToggle = document.getElementById("couplesGroupToggle");
+const couplesAllowPingToggle = document.getElementById("couplesAllowPingToggle");
+const couplesV2Box = document.getElementById("couplesV2Box");
+const couplesPrivacySelect = document.getElementById("couplesPrivacySelect");
+const couplesNameInput = document.getElementById("couplesNameInput");
+const couplesBioInput = document.getElementById("couplesBioInput");
+const couplesShowBadgeToggle = document.getElementById("couplesShowBadgeToggle");
+const couplesBonusesToggle = document.getElementById("couplesBonusesToggle");
+const couplesSettingsSaveBtn = document.getElementById("couplesSettingsSaveBtn");
+const couplesNudgeBtn = document.getElementById("couplesNudgeBtn");
+const couplesV2Status = document.getElementById("couplesV2Status");
 const couplesUnlinkBtn = document.getElementById("couplesUnlinkBtn");
 const couplesMsg = document.getElementById("couplesMsg");
 
@@ -3756,6 +3772,29 @@ function getFeatureFlag(key, fallback=false){
   if (typeof v === "number") return !!v;
   if (typeof v === "string") return v === "true" || v === "1" || v === "on";
   return fallback;
+}
+
+function parseFeatureAllowlist(value){
+  if(!value) return new Set();
+  if(Array.isArray(value)){
+    return new Set(value.map((item)=>String(item).trim().toLowerCase()).filter(Boolean));
+  }
+  if(typeof value === "string"){
+    return new Set(value.split(",").map((item)=>String(item).trim().toLowerCase()).filter(Boolean));
+  }
+  return new Set();
+}
+
+function isCouplesV2EnabledFor(user){
+  if(!getFeatureFlag("COUPLES_V2_ENABLED", false)) return false;
+  if(roleRank(user?.role || "User") >= roleRank("Owner")) return true;
+  const allowlist = parseFeatureAllowlist(featureFlags?.COUPLES_V2_ALLOWLIST);
+  if(!allowlist.size) return false;
+  const username = String(user?.username || "").trim().toLowerCase();
+  const userId = user?.id ?? user?.user_id ?? user?.userId;
+  if(username && allowlist.has(username)) return true;
+  if(userId != null && allowlist.has(String(userId).toLowerCase())) return true;
+  return false;
 }
 
 function applyAmbientClasses(){
@@ -6135,8 +6174,11 @@ function reorderCouplesInMembers(list){
     seen.add(name);
     const c = u?.couple;
     if (c && c.group && c.partner && byName.has(c.partner) && !seen.has(c.partner)) {
-      out.push(byName.get(c.partner));
-      seen.add(c.partner);
+      const partnerUser = byName.get(c.partner);
+      if (partnerUser && roleRank(partnerUser.role) === roleRank(u.role)) {
+        out.push(partnerUser);
+        seen.add(c.partner);
+      }
     }
   }
   return (out.length === users.length) ? out : users;
@@ -10984,6 +11026,49 @@ function fillProfileUI(p, isSelf){
     }
   } catch {}
 
+  try {
+    const card = p?.coupleCard;
+    const members = Array.isArray(card?.members) ? card.members.filter(Boolean) : [];
+    const hasCard = members.length >= 2;
+    if (profileCoupleBody) profileCoupleBody.style.display = hasCard ? "" : "none";
+    if (profileCoupleChip) {
+      const hasChip = !!(p?.couple?.partner);
+      profileCoupleChip.style.display = (!hasCard && hasChip) ? "" : "none";
+    }
+    if (hasCard) {
+      if (profileCoupleAvatars) {
+        profileCoupleAvatars.innerHTML = "";
+        members.slice(0, 2).forEach((m) => {
+          profileCoupleAvatars.appendChild(avatarNode(m.avatar, m.username, m.role));
+        });
+      }
+      if (profileCoupleName) {
+        const defaultName = members.length >= 2 ? `${members[0].username} + ${members[1].username}` : "Couple";
+        profileCoupleName.textContent = card?.coupleName ? card.coupleName : defaultName;
+      }
+      if (profileCoupleBadge) {
+        if (card?.showBadge && card?.statusEmoji) {
+          profileCoupleBadge.style.display = "";
+          profileCoupleBadge.textContent = card.statusEmoji;
+          profileCoupleBadge.title = `${card.statusEmoji} ${card.statusLabel || "Linked"}`;
+        } else {
+          profileCoupleBadge.style.display = "none";
+          profileCoupleBadge.textContent = "";
+          profileCoupleBadge.title = "";
+        }
+      }
+      if (profileCoupleMeta) {
+        const sinceTxt = card?.since ? `Together ${fmtDaysSince(card.since)}` : "Together";
+        const privacyLabel = card?.privacy ? card.privacy.charAt(0).toUpperCase() + card.privacy.slice(1) : "Private";
+        profileCoupleMeta.textContent = `${sinceTxt} • ${privacyLabel}`;
+      }
+      if (profileCoupleBio) {
+        const bio = String(card?.coupleBio || "").trim();
+        profileCoupleBio.textContent = bio ? bio : "No couple bio yet.";
+      }
+    }
+  } catch {}
+
   if (infoAge) infoAge.textContent = (p.age ?? "—");
   if (infoGender) infoGender.textContent = (p.gender ?? "—");
   if (infoLanguage){
@@ -11004,8 +11089,9 @@ function fillProfileUI(p, isSelf){
   setMsgline(profileLikeMsg, "");
   setMsgline(profileActionMsg, "");
   setMsgline(mediaMsg, "");
-  if (profileCoupleChip && profileCoupleCard){
-    const showCouple = profileCoupleChip.style.display !== "none";
+  if (profileCoupleCard){
+    const showCouple = (profileCoupleBody && profileCoupleBody.style.display !== "none")
+      || (profileCoupleChip && profileCoupleChip.style.display !== "none");
     profileCoupleCard.style.display = showCouple ? "" : "none";
   }
   fillProfileSheetHeader(p, isSelf);
@@ -12867,6 +12953,16 @@ initAppealsDurationSelect();
     try{ renderFeatureFlagsGrid(); }catch(_){}
   });
 
+  socket.on("couples:update", () => {
+    try { refreshCouplesUI(); } catch {}
+    try { emitLocalMembersRefresh(); } catch {}
+  });
+
+  socket.on("couples:nudge", (payload={}) => {
+    const fromName = payload?.fromName || "Your partner";
+    showToast(`${fromName} nudged you 💜`, { durationMs: 3200 });
+  });
+
   socket.on("room:event", (payload={})=>{
     if(payload && payload.room && String(payload.room) !== String(currentRoom)) return;
     const ev = payload.active || null;
@@ -13637,13 +13733,36 @@ async function refreshCouplesUI(){
     if (couplesAuraToggle) couplesAuraToggle.checked = !!p.aura;
     if (couplesShowMembersToggle) couplesShowMembersToggle.checked = !!p.showMembers;
     if (couplesGroupToggle) couplesGroupToggle.checked = !!p.groupMembers;
+    if (couplesAllowPingToggle) couplesAllowPingToggle.checked = !!p.allowPing;
   }
 
   // disable toggles if no active link
-  const toggles = [couplesEnabledToggle,couplesShowProfileToggle,couplesBadgeToggle,couplesAuraToggle,couplesShowMembersToggle,couplesGroupToggle];
+  const toggles = [couplesEnabledToggle,couplesShowProfileToggle,couplesBadgeToggle,couplesAuraToggle,couplesShowMembersToggle,couplesGroupToggle,couplesAllowPingToggle];
   toggles.forEach(t => { if (t) t.disabled = !active; });
 
   if (couplesUnlinkBtn) couplesUnlinkBtn.disabled = !active;
+
+  const canEditSettings = isCoupleMember(me?.id ?? me?.user_id ?? me?.userId, couplesState?.couple);
+  const v2Enabled = !!(couplesState?.v2Enabled && active && canEditSettings);
+  if (couplesV2Box) couplesV2Box.style.display = v2Enabled ? "" : "none";
+  if (v2Enabled && couplesState?.couple) {
+    const c = couplesState.couple;
+    if (couplesPrivacySelect) couplesPrivacySelect.value = c.privacy || "private";
+    if (couplesNameInput) couplesNameInput.value = c.couple_name || "";
+    if (couplesBioInput) couplesBioInput.value = c.couple_bio || "";
+    if (couplesShowBadgeToggle) couplesShowBadgeToggle.checked = c.show_badge !== false;
+    if (couplesBonusesToggle) couplesBonusesToggle.checked = !!c.bonuses_enabled;
+    if (couplesSettingsSaveBtn) couplesSettingsSaveBtn.disabled = false;
+    if (couplesNudgeBtn) couplesNudgeBtn.disabled = false;
+    if (couplesV2Status) {
+      const sinceTxt = active?.since ? `Together ${fmtDaysSince(active.since)}` : "Couple card settings";
+      couplesV2Status.textContent = sinceTxt;
+    }
+  } else {
+    if (couplesSettingsSaveBtn) couplesSettingsSaveBtn.disabled = true;
+    if (couplesNudgeBtn) couplesNudgeBtn.disabled = true;
+    if (couplesV2Status) couplesV2Status.textContent = "";
+  }
 }
 
 function emitLocalMembersRefresh(){
@@ -13657,6 +13776,14 @@ function emitUserListNow(){
   // The server pushes user list on join/updates; we can also request by toggling a no-op room refresh if such exists.
   // If socket exists, ask it to refresh:
   try { if (socket) socket.emit("refresh user list"); } catch {}
+}
+
+function isCoupleMember(currentUserId, couple){
+  const uid = Number(currentUserId) || 0;
+  if (!uid || !couple) return false;
+  const a = Number(couple.user_a_id ?? couple.user1_id ?? couple.userAId ?? couple.user1Id ?? 0) || 0;
+  const b = Number(couple.user_b_id ?? couple.user2_id ?? couple.userBId ?? couple.user2Id ?? 0) || 0;
+  return uid === a || uid === b;
 }
 
 async function setCouplePrefs(patch){
@@ -13675,6 +13802,37 @@ async function setCouplePrefs(patch){
     emitLocalMembersRefresh();
   } catch (e) {
     setMsgline(couplesMsg, e?.message || "Could not save");
+  }
+}
+
+async function setCoupleSettings(patch){
+  const active = couplesState?.active;
+  if (!active?.linkId) return;
+  if (couplesV2Status) couplesV2Status.textContent = "Saving…";
+  try {
+    const r = await fetch("/api/couples/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch || {})
+    });
+    if (!r.ok) throw new Error(await r.text().catch(()=> "Could not save"));
+    couplesState = await r.json();
+    await refreshCouplesUI();
+    emitLocalMembersRefresh();
+    if (couplesV2Status) couplesV2Status.textContent = "Saved.";
+  } catch (e) {
+    if (couplesV2Status) couplesV2Status.textContent = e?.message || "Could not save";
+  }
+}
+
+async function sendCoupleNudge(){
+  if (couplesV2Status) couplesV2Status.textContent = "";
+  try {
+    const r = await fetch("/api/couples/nudge", { method: "POST" });
+    if (!r.ok) throw new Error(await r.text().catch(()=> "Could not nudge"));
+    if (couplesV2Status) couplesV2Status.textContent = "Nudge sent.";
+  } catch (e) {
+    if (couplesV2Status) couplesV2Status.textContent = e?.message || "Could not nudge";
   }
 }
 
@@ -13705,6 +13863,18 @@ if (couplesBadgeToggle) couplesBadgeToggle.onchange = () => setCouplePrefs({ bad
 if (couplesAuraToggle) couplesAuraToggle.onchange = () => setCouplePrefs({ aura: !!couplesAuraToggle.checked });
 if (couplesShowMembersToggle) couplesShowMembersToggle.onchange = () => setCouplePrefs({ showMembers: !!couplesShowMembersToggle.checked });
 if (couplesGroupToggle) couplesGroupToggle.onchange = () => setCouplePrefs({ groupMembers: !!couplesGroupToggle.checked });
+if (couplesAllowPingToggle) couplesAllowPingToggle.onchange = () => setCouplePrefs({ allowPing: !!couplesAllowPingToggle.checked });
+
+if (couplesSettingsSaveBtn) {
+  couplesSettingsSaveBtn.onclick = () => setCoupleSettings({
+    privacy: couplesPrivacySelect?.value || "private",
+    couple_name: couplesNameInput?.value || "",
+    couple_bio: couplesBioInput?.value || "",
+    show_badge: !!couplesShowBadgeToggle?.checked,
+    bonuses_enabled: !!couplesBonusesToggle?.checked
+  });
+}
+if (couplesNudgeBtn) couplesNudgeBtn.onclick = () => sendCoupleNudge();
 
 if (couplesUnlinkBtn) {
   couplesUnlinkBtn.onclick = async () => {

--- a/public/index.html
+++ b/public/index.html
@@ -636,6 +636,19 @@
 </div>
 <div class="profileInfoCard profileInfoWide" id="profileCoupleCard" style="display:none;">
 <div class="infoLabel">Couple</div>
+<div class="coupleCardBody" id="profileCoupleBody" style="display:none;">
+<div class="coupleCardHeader">
+<div class="coupleCardAvatars" id="profileCoupleAvatars"></div>
+<div class="coupleCardMeta">
+<div class="coupleCardTitleRow">
+<div class="coupleCardTitle" id="profileCoupleName"></div>
+<span class="coupleBadge small" id="profileCoupleBadge" style="display:none;"></span>
+</div>
+<div class="coupleCardSub" id="profileCoupleMeta"></div>
+</div>
+</div>
+<div class="coupleCardBio" id="profileCoupleBio"></div>
+</div>
 <span class="coupleChip" id="profileCoupleChip" style="display:none;"></span>
 </div>
 </div>
@@ -743,6 +756,37 @@
 <span class="slider"></span>
 </label>
 <div class="toggleLabel">Allow partner pings</div>
+</div>
+<div class="panelBox couplesV2Box" id="couplesV2Box" style="margin-top:12px; display:none;">
+<div class="small">Couple card (shared settings)</div>
+<div class="row" style="margin-top:8px; gap:8px; align-items:center;">
+<select aria-label="Couple privacy" id="couplesPrivacySelect">
+<option value="private">Private</option>
+<option value="friends">Friends</option>
+<option value="public">Public</option>
+</select>
+<input id="couplesNameInput" maxlength="48" placeholder="Couple name (optional)" style="flex:1;"/>
+</div>
+<textarea id="couplesBioInput" maxlength="220" placeholder="Couple bio (optional)" style="width:100%; min-height:70px; margin-top:8px;"></textarea>
+<div class="toggleRow" style="margin-top:8px;">
+<label class="switch">
+<input id="couplesShowBadgeToggle" type="checkbox"/>
+<span class="slider"></span>
+</label>
+<div class="toggleLabel">Show couple badge publicly</div>
+</div>
+<div class="toggleRow">
+<label class="switch">
+<input id="couplesBonusesToggle" type="checkbox"/>
+<span class="slider"></span>
+</label>
+<div class="toggleLabel">Enable couple bonuses (tiny)</div>
+</div>
+<div class="row" style="margin-top:8px; gap:8px; align-items:center;">
+<button class="btn secondary" id="couplesSettingsSaveBtn" type="button">Save couple card</button>
+<button class="btn secondary" id="couplesNudgeBtn" type="button" aria-label="Nudge your partner">Nudge</button>
+</div>
+<div class="small" id="couplesV2Status" style="margin-top:6px;"></div>
 </div>
 <div class="row" style="margin-top:10px; gap:8px;">
 <button class="btn danger" id="couplesUnlinkBtn" type="button">Unlink</button>

--- a/public/styles.css
+++ b/public/styles.css
@@ -7221,6 +7221,57 @@ body.comfortMode[data-theme="Iris & Lola Neon"] .chat::after{
   background: rgba(255,255,255,0.08);
   border: 1px solid rgba(255,255,255,0.10);
 }
+.coupleCardBody{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  margin-top:6px;
+}
+.coupleCardHeader{
+  display:flex;
+  gap:12px;
+  align-items:center;
+}
+.coupleCardAvatars{
+  display:flex;
+  gap:6px;
+  align-items:center;
+}
+.coupleCardAvatars .avatarImg,
+.coupleCardAvatars .avatarFallback{
+  width:42px;
+  height:42px;
+  border-radius:999px;
+  flex:0 0 auto;
+}
+.coupleCardMeta{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.coupleCardTitleRow{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  flex-wrap:wrap;
+}
+.coupleCardTitle{
+  font-weight:600;
+  font-size:14px;
+}
+.coupleCardSub{
+  font-size:12px;
+  opacity:0.78;
+}
+.coupleCardBio{
+  font-size:12px;
+  opacity:0.9;
+  line-height:1.4;
+}
+.coupleBadge.small{
+  margin-left:0;
+  font-size:12px;
+}
 
 /* Simple switch for settings toggles */
 .toggleRow{

--- a/scripts/couples-regression.js
+++ b/scripts/couples-regression.js
@@ -1,0 +1,102 @@
+"use strict";
+
+const assert = require("assert");
+const request = require("supertest");
+
+process.env.SESSION_SECRET = process.env.SESSION_SECRET || "test_secret_1234567890";
+
+const { app, startupReady } = require("../server");
+
+async function ensureLogin(agent, username, password) {
+  const reg = await agent.post("/register").send({ username, password });
+  if (reg.status === 409) {
+    const login = await agent.post("/login").send({ username, password });
+    assert.strictEqual(login.status, 200, `Login failed for ${username}: ${login.text}`);
+    return;
+  }
+  assert.strictEqual(reg.status, 200, `Registration failed for ${username}: ${reg.text}`);
+}
+
+async function setCouplesV2Flags(agent, allowlist = []) {
+  const res = await agent.post("/api/owner/flags").send({
+    flags: {
+      COUPLES_V2_ENABLED: true,
+      COUPLES_V2_ALLOWLIST: allowlist,
+    },
+  });
+  assert.strictEqual(res.status, 200, `Failed to set flags: ${res.text}`);
+}
+
+async function run() {
+  await startupReady;
+
+  const ownerAgent = request.agent(app);
+  const partnerAgent = request.agent(app);
+
+  const ownerName = "iri";
+  const partnerName = `partner_${Date.now()}`;
+  const password = "password123";
+
+  await ensureLogin(ownerAgent, ownerName, password);
+  await ensureLogin(partnerAgent, partnerName, password);
+  await setCouplesV2Flags(ownerAgent, [partnerName]);
+
+  const requestRes = await ownerAgent.post("/api/couples/request").send({ targetUsername: partnerName });
+  assert.strictEqual(requestRes.status, 200, `Couple request failed: ${requestRes.text}`);
+
+  const pendingRes = await partnerAgent.get("/api/couples/me");
+  assert.strictEqual(pendingRes.status, 200, `Couple pending fetch failed: ${pendingRes.text}`);
+  const incoming = pendingRes.body?.incoming || [];
+  assert.ok(incoming.length === 1, "Expected one incoming couple request");
+
+  const acceptRes = await partnerAgent.post("/api/couples/respond").send({ linkId: incoming[0].linkId, accept: true });
+  assert.strictEqual(acceptRes.status, 200, `Couple accept failed: ${acceptRes.text}`);
+
+  const ownerMe = await ownerAgent.get("/api/couples/me");
+  const partnerMe = await partnerAgent.get("/api/couples/me");
+  assert.strictEqual(ownerMe.status, 200, `Owner /me failed: ${ownerMe.text}`);
+  assert.strictEqual(partnerMe.status, 200, `Partner /me failed: ${partnerMe.text}`);
+
+  assert.ok(ownerMe.body?.active, "Owner should see active couple");
+  assert.ok(partnerMe.body?.active, "Partner should see active couple");
+  assert.strictEqual(ownerMe.body?.isCoupleMember, true, "Owner should be couple member");
+  assert.strictEqual(partnerMe.body?.isCoupleMember, true, "Partner should be couple member");
+  assert.strictEqual(ownerMe.body?.active?.settingsAvailable, true, "Owner settings should be available");
+  assert.strictEqual(partnerMe.body?.active?.settingsAvailable, true, "Partner settings should be available");
+
+  const settingsResA = await ownerAgent.post("/api/couples/settings").send({
+    privacy: "public",
+    couple_name: "Test Pair",
+    couple_bio: "Testing the couple card.",
+    show_badge: true,
+    bonuses_enabled: false,
+  });
+  assert.strictEqual(settingsResA.status, 200, `Owner settings update failed: ${settingsResA.text}`);
+  assert.strictEqual(settingsResA.body?.couple?.couple_name, "Test Pair", "Owner settings should update couple name");
+
+  const ownerCheck = await ownerAgent.get("/api/couples/me");
+  const partnerCheck = await partnerAgent.get("/api/couples/me");
+  assert.strictEqual(ownerCheck.body?.couple?.couple_name, "Test Pair", "Owner should see updated couple name");
+  assert.strictEqual(partnerCheck.body?.couple?.couple_name, "Test Pair", "Partner should see updated couple name");
+
+  const settingsResB = await partnerAgent.post("/api/couples/settings").send({
+    privacy: "public",
+    couple_name: "Test Pair Updated",
+    couple_bio: "Partner updated the card.",
+    show_badge: true,
+    bonuses_enabled: false,
+  });
+  assert.strictEqual(settingsResB.status, 200, `Partner settings update failed: ${settingsResB.text}`);
+
+  const ownerFinal = await ownerAgent.get("/api/couples/me");
+  const partnerFinal = await partnerAgent.get("/api/couples/me");
+  assert.strictEqual(ownerFinal.body?.couple?.couple_name, "Test Pair Updated", "Owner should see partner update");
+  assert.strictEqual(partnerFinal.body?.couple?.couple_name, "Test Pair Updated", "Partner should see update");
+
+  console.log("Couples regression test passed.");
+}
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -47,6 +47,23 @@ const lastReactionByUserId = new Map(); // userId -> ts
 // --- Room events (in-memory, roomName -> {type,title,endsAt,startedBy})
 const ACTIVE_ROOM_EVENTS = new Map();
 
+function emitToUserIds(userIds, event, payload) {
+  const ids = Array.isArray(userIds) ? userIds : [userIds];
+  for (const uidRaw of ids) {
+    const uid = Number(uidRaw) || 0;
+    if (!uid) continue;
+    const sockets = sessionByUserId.get(uid);
+    if (sockets && sockets.size) {
+      for (const sid of sockets) {
+        io.to(sid).emit(event, payload);
+      }
+    } else {
+      const sid = socketIdByUserId.get(uid);
+      if (sid) io.to(sid).emit(event, payload);
+    }
+  }
+}
+
 
 
 function bumpHeat(userId, delta = 1) {
@@ -545,11 +562,23 @@ try {
         status TEXT NOT NULL DEFAULT 'pending', -- pending | active
         status_emoji TEXT NOT NULL DEFAULT '💜',
         status_label TEXT NOT NULL DEFAULT 'Linked',
+        privacy TEXT NOT NULL DEFAULT 'private',
+        couple_name TEXT,
+        couple_bio TEXT,
+        settings_json TEXT,
+        show_badge BOOLEAN NOT NULL DEFAULT true,
+        bonuses_enabled BOOLEAN NOT NULL DEFAULT false,
         created_at BIGINT NOT NULL,
         activated_at BIGINT,
         updated_at BIGINT NOT NULL
       )
     `);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS privacy TEXT NOT NULL DEFAULT 'private'`);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS couple_name TEXT`);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS couple_bio TEXT`);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS settings_json TEXT`);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS show_badge BOOLEAN NOT NULL DEFAULT true`);
+    await pgPool.query(`ALTER TABLE couple_links ADD COLUMN IF NOT EXISTS bonuses_enabled BOOLEAN NOT NULL DEFAULT false`);
 
     // Best-effort FK constraints (may fail if legacy schemas differ); couples will still work without them.
     try {
@@ -574,10 +603,12 @@ try {
         group_members BOOLEAN NOT NULL DEFAULT false,
         aura BOOLEAN NOT NULL DEFAULT true,
         badge BOOLEAN NOT NULL DEFAULT true,
+        allow_ping BOOLEAN NOT NULL DEFAULT true,
         updated_at BIGINT NOT NULL,
         PRIMARY KEY (link_id, user_id)
       )
     `);
+    await pgPool.query(`ALTER TABLE couple_prefs ADD COLUMN IF NOT EXISTS allow_ping BOOLEAN NOT NULL DEFAULT true`);
     try {
       await pgPool.query(`ALTER TABLE couple_prefs ADD CONSTRAINT couple_prefs_user_fk FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE`);
     } catch {}
@@ -660,6 +691,33 @@ function orderPair(a, b) {
   return x < y ? [x, y] : [y, x];
 }
 
+function normalizeCoupleMembers(couple) {
+  if (!couple) return { user_a_id: 0, user_b_id: 0 };
+  const userA = Number(
+    couple.user_a_id ?? couple.userAId ?? couple.user1_id ?? couple.user1Id ?? couple.user_a ?? 0
+  ) || 0;
+  const userB = Number(
+    couple.user_b_id ?? couple.userBId ?? couple.user2_id ?? couple.user2Id ?? couple.user_b ?? 0
+  ) || 0;
+  return { user_a_id: userA, user_b_id: userB };
+}
+
+function isCoupleMember(userId, couple) {
+  const uid = Number(userId) || 0;
+  if (!uid || !couple) return false;
+  const { user_a_id, user_b_id } = normalizeCoupleMembers(couple);
+  return uid === user_a_id || uid === user_b_id;
+}
+
+function getCouplePartnerId(userId, couple) {
+  const uid = Number(userId) || 0;
+  if (!uid || !couple) return 0;
+  const { user_a_id, user_b_id } = normalizeCoupleMembers(couple);
+  if (uid === user_a_id) return user_b_id;
+  if (uid === user_b_id) return user_a_id;
+  return 0;
+}
+
 async function pgGetCoupleLinkForUser(userId) {
   const uid = Number(userId) || 0;
   if (!uid) return null;
@@ -680,6 +738,31 @@ async function pgGetCoupleLinkForUser(userId) {
   return rows[0] || null;
 }
 
+async function pgGetActiveCoupleLinkForUser(userId) {
+  const uid = Number(userId) || 0;
+  if (!uid) return null;
+  const { rows } = await pgPool.query(
+    `
+    SELECT cl.*,
+           u1.username AS user1_name,
+           u2.username AS user2_name,
+           u1.avatar AS user1_avatar,
+           u2.avatar AS user2_avatar,
+           u1.role AS user1_role,
+           u2.role AS user2_role
+      FROM couple_links cl
+      JOIN users u1 ON u1.id = cl.user1_id
+      JOIN users u2 ON u2.id = cl.user2_id
+     WHERE cl.status='active'
+       AND (cl.user1_id=$1 OR cl.user2_id=$1)
+     ORDER BY cl.updated_at DESC
+     LIMIT 1
+    `,
+    [uid]
+  );
+  return rows[0] || null;
+}
+
 async function pgGetCouplePrefs(linkId, userId) {
   const { rows } = await pgPool.query(
     `SELECT * FROM couple_prefs WHERE link_id=$1 AND user_id=$2 LIMIT 1`,
@@ -688,8 +771,9 @@ async function pgGetCouplePrefs(linkId, userId) {
   return rows[0] || null;
 }
 
-async function pgGetCoupleSummaryFor(userId) {
-  const link = await pgGetCoupleLinkForUser(userId);
+async function pgGetCoupleSummaryFor(user) {
+  const userId = Number(user?.id ?? user?.user_id ?? user?.userId) || 0;
+  const link = await pgGetActiveCoupleLinkForUser(userId);
 
   // Pending links involving this user (incoming/outgoing)
   const { rows: pending } = await pgPool.query(
@@ -725,11 +809,40 @@ async function pgGetCoupleSummaryFor(userId) {
   }
 
   let active = null;
-  if (link && link.status === "active") {
+  let couple = null;
+  let partner = null;
+  if (link && link.status === "active" && isCoupleMember(userId, link)) {
     const prefsMe = await pgGetCouplePrefs(link.id, userId);
-    const partnerId = (Number(link.user1_id) === Number(userId)) ? Number(link.user2_id) : Number(link.user1_id);
+    const partnerId = getCouplePartnerId(userId, link);
     const prefsPartner = await pgGetCouplePrefs(link.id, partnerId);
-    const partnerName = (Number(link.user1_id) === Number(userId)) ? link.user2_name : link.user1_name;
+    const isU1 = Number(link.user1_id) === Number(userId);
+    const partnerName = isU1 ? link.user2_name : link.user1_name;
+    const partnerAvatar = isU1 ? link.user2_avatar : link.user1_avatar;
+    const partnerRole = isU1 ? link.user2_role : link.user1_role;
+
+    couple = {
+      id: link.id,
+      user_a_id: Number(link.user1_id) || 0,
+      user_b_id: Number(link.user2_id) || 0,
+      partner_id: partnerId,
+      status: link.status,
+      created_at: Number(link.created_at) || null,
+      activated_at: Number(link.activated_at || link.created_at) || null,
+      privacy: link.privacy || "private",
+      couple_name: link.couple_name || "",
+      couple_bio: link.couple_bio || "",
+      show_badge: link.show_badge !== false,
+      bonuses_enabled: !!link.bonuses_enabled,
+      status_emoji: link.status_emoji || "💜",
+      status_label: link.status_label || "Linked"
+    };
+
+    partner = {
+      id: partnerId,
+      username: partnerName,
+      avatar: partnerAvatar || "",
+      role: partnerRole || "User"
+    };
 
     active = {
       linkId: link.id,
@@ -738,13 +851,15 @@ async function pgGetCoupleSummaryFor(userId) {
       since: Number(link.activated_at || link.created_at) || null,
       statusEmoji: link.status_emoji || "💜",
       statusLabel: link.status_label || "Linked",
+      settingsAvailable: true,
       prefs: prefsMe ? {
         enabled: !!prefsMe.enabled,
         showProfile: !!prefsMe.show_profile,
         showMembers: !!prefsMe.show_members,
         groupMembers: !!prefsMe.group_members,
         aura: !!prefsMe.aura,
-        badge: !!prefsMe.badge
+        badge: !!prefsMe.badge,
+        allowPing: prefsMe.allow_ping !== false
       } : null,
       partnerPrefs: prefsPartner ? {
         enabled: !!prefsPartner.enabled,
@@ -752,12 +867,22 @@ async function pgGetCoupleSummaryFor(userId) {
         showMembers: !!prefsPartner.show_members,
         groupMembers: !!prefsPartner.group_members,
         aura: !!prefsPartner.aura,
-        badge: !!prefsPartner.badge
-      } : null
+        badge: !!prefsPartner.badge,
+        allowPing: prefsPartner.allow_ping !== false
+      } : null,
+      couple
     };
   }
 
-  return { active, incoming, outgoing };
+  return {
+    active,
+    incoming,
+    outgoing,
+    couple,
+    partner,
+    isCoupleMember: !!(active && active.settingsAvailable),
+    v2Enabled: isCouplesV2EnabledFor(user)
+  };
 }
 
 function canShowCoupleFeature(mePrefs, partnerPrefs, key) {
@@ -771,6 +896,79 @@ function canShowCoupleFeature(mePrefs, partnerPrefs, key) {
   return false;
 }
 
+function canShowCoupleBadge(mePrefs, partnerPrefs, link) {
+  if (!canShowCoupleFeature(mePrefs, partnerPrefs, "badge")) return false;
+  if (link && link.show_badge === false) return false;
+  return true;
+}
+
+async function ensureCoupleLinkedMemories(link) {
+  if (!FEATURE_FLAGS_CACHE?.COUPLES_V2_ENABLED) return;
+  if (!link) return;
+  const userIds = [Number(link.user1_id) || 0, Number(link.user2_id) || 0].filter(Boolean);
+  if (userIds.length !== 2) return;
+  const { rows: users } = await pgPool.query(
+    `SELECT id, username, role FROM users WHERE id = ANY($1::int[])`,
+    [userIds]
+  );
+  const map = new Map(users.map((u) => [Number(u.id), u]));
+  const u1 = map.get(userIds[0]);
+  const u2 = map.get(userIds[1]);
+  if (!u1 || !u2) return;
+  const payloadFor = (self, partner) => ({
+    type: "social",
+    title: "Couple linked",
+    description: `Linked with ${partner.username}.`,
+    icon: "💜",
+    metadata: { partnerId: partner.id, partnerName: partner.username, coupleId: link.id },
+  });
+  if (isCouplesV2EnabledFor(u1)) {
+    void ensureMemory(u1.id, `couple_linked_${link.id}`, payloadFor(u1, u2), u1);
+  }
+  if (isCouplesV2EnabledFor(u2)) {
+    void ensureMemory(u2.id, `couple_linked_${link.id}`, payloadFor(u2, u1), u2);
+  }
+}
+
+async function ensureCoupleMilestoneMemories(link) {
+  if (!FEATURE_FLAGS_CACHE?.COUPLES_V2_ENABLED) return;
+  if (!link) return;
+  const since = Number(link.activated_at || link.activatedAt || link.created_at || link.createdAt) || 0;
+  if (!since) return;
+  const days = Math.floor((Date.now() - since) / 86400000);
+  if (days < 7) return;
+  const userIds = [Number(link.user1_id ?? link.user_a_id) || 0, Number(link.user2_id ?? link.user_b_id) || 0].filter(Boolean);
+  if (userIds.length !== 2) return;
+  const { rows: users } = await pgPool.query(
+    `SELECT id, username, role FROM users WHERE id = ANY($1::int[])`,
+    [userIds]
+  );
+  const map = new Map(users.map((u) => [Number(u.id), u]));
+  const u1 = map.get(userIds[0]);
+  const u2 = map.get(userIds[1]);
+  if (!u1 || !u2) return;
+  const milestones = [
+    { days: 7, key: `couple_days_7_${link.id}`, title: "7 days together", icon: "🫶" },
+    { days: 30, key: `couple_days_30_${link.id}`, title: "30 days together", icon: "💞" }
+  ];
+  for (const milestone of milestones) {
+    if (days < milestone.days) continue;
+    const payloadFor = (self, partner) => ({
+      type: "social",
+      title: milestone.title,
+      description: `${milestone.days} days together with ${partner.username}.`,
+      icon: milestone.icon,
+      metadata: { partnerId: partner.id, partnerName: partner.username, coupleId: link.id, days: milestone.days },
+    });
+    if (isCouplesV2EnabledFor(u1)) {
+      void ensureMemory(u1.id, milestone.key, payloadFor(u1, u2), u1);
+    }
+    if (isCouplesV2EnabledFor(u2)) {
+      void ensureMemory(u2.id, milestone.key, payloadFor(u2, u1), u2);
+    }
+  }
+}
+
 async function pgUpsertCouplePrefs(linkId, userId, patch) {
   const now = Date.now();
   const p = patch || {};
@@ -780,7 +978,8 @@ async function pgUpsertCouplePrefs(linkId, userId, patch) {
     show_members: typeof p.showMembers === "boolean" ? p.showMembers : undefined,
     group_members: typeof p.groupMembers === "boolean" ? p.groupMembers : undefined,
     aura: typeof p.aura === "boolean" ? p.aura : undefined,
-    badge: typeof p.badge === "boolean" ? p.badge : undefined
+    badge: typeof p.badge === "boolean" ? p.badge : undefined,
+    allow_ping: typeof p.allowPing === "boolean" ? p.allowPing : undefined
   };
 
   // If row doesn't exist, insert defaults first
@@ -788,8 +987,8 @@ async function pgUpsertCouplePrefs(linkId, userId, patch) {
   if (!existing) {
     await pgPool.query(
       `
-      INSERT INTO couple_prefs(link_id, user_id, enabled, show_profile, show_members, group_members, aura, badge, updated_at)
-      VALUES($1,$2,true,true,true,false,true,true,$3)
+      INSERT INTO couple_prefs(link_id, user_id, enabled, show_profile, show_members, group_members, aura, badge, allow_ping, updated_at)
+      VALUES($1,$2,true,true,true,false,true,true,true,$3)
       ON CONFLICT (link_id, user_id) DO NOTHING
       `,
       [Number(linkId) || 0, Number(userId) || 0, now]
@@ -1792,6 +1991,47 @@ async function setConfigJson(key, obj) {
   await setConfigValue(key, raw);
   return obj;
 }
+
+let FEATURE_FLAGS_CACHE = {};
+async function refreshFeatureFlags() {
+  try {
+    FEATURE_FLAGS_CACHE = await getConfigJson("feature_flags", {});
+  } catch {
+    FEATURE_FLAGS_CACHE = {};
+  }
+  return FEATURE_FLAGS_CACHE;
+}
+
+function parseFeatureAllowlist(value) {
+  if (!value) return new Set();
+  if (Array.isArray(value)) {
+    return new Set(value.map((item) => String(item).trim().toLowerCase()).filter(Boolean));
+  }
+  if (typeof value === "string") {
+    return new Set(
+      value
+        .split(",")
+        .map((item) => String(item).trim().toLowerCase())
+        .filter(Boolean)
+    );
+  }
+  return new Set();
+}
+
+function isCouplesV2EnabledFor(user, flags = FEATURE_FLAGS_CACHE) {
+  const enabled = !!(flags && flags.COUPLES_V2_ENABLED);
+  if (!enabled) return false;
+  if (requireMinRole(user?.role || "User", "Owner")) return true;
+  const allowlist = parseFeatureAllowlist(flags?.COUPLES_V2_ALLOWLIST);
+  if (!allowlist.size) return false;
+  const username = String(user?.username || "").trim().toLowerCase();
+  const userId = user?.id ?? user?.user_id ?? user?.userId;
+  if (username && allowlist.has(username)) return true;
+  if (userId != null && allowlist.has(String(userId).toLowerCase())) return true;
+  return false;
+}
+
+refreshFeatureFlags().catch(() => {});
 
 function isMemoryFeatureAvailableFor(user) {
   if (MEMORY_SYSTEM_ENABLED) return true;
@@ -4579,7 +4819,7 @@ app.get("/api/restriction", async (req, res) => {
 //
 app.get("/api/owner/flags", requireOwner, async (_req, res) => {
   try {
-    const flags = await getConfigJson("feature_flags", {});
+    const flags = await refreshFeatureFlags();
     res.json({ ok: true, flags });
   } catch (e) {
     res.status(500).json({ ok: false, error: "failed_to_load_flags" });
@@ -4597,6 +4837,7 @@ app.post("/api/owner/flags", requireOwner, express.json({ limit: "64kb" }), asyn
       if (typeof v === "boolean" || typeof v === "number" || typeof v === "string") next[k] = v;
     }
     await setConfigJson("feature_flags", next);
+    FEATURE_FLAGS_CACHE = { ...next };
     try { io.emit("featureFlags:update", next); } catch {}
     res.json({ ok: true, flags: next });
   } catch (e) {
@@ -5926,6 +6167,10 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
           SELECT cl.*,
                  u1.username AS user1_name,
                  u2.username AS user2_name,
+                 u1.avatar AS user1_avatar,
+                 u2.avatar AS user2_avatar,
+                 u1.role AS user1_role,
+                 u2.role AS user2_role,
                  p1.enabled AS p1_enabled, p1.show_profile AS p1_show_profile, p1.show_members AS p1_show_members,
                  p1.group_members AS p1_group_members, p1.aura AS p1_aura, p1.badge AS p1_badge,
                  p2.enabled AS p2_enabled, p2.show_profile AS p2_show_profile, p2.show_members AS p2_show_members,
@@ -5947,6 +6192,10 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
         if (cl) {
           const isU1 = Number(cl.user1_id) === targetId;
           const partnerName = isU1 ? cl.user2_name : cl.user1_name;
+          const partnerId = getCouplePartnerId(targetId, cl);
+          const viewerId = Number(req.session.user?.id) || 0;
+          const isMember = isCoupleMember(viewerId, cl);
+          const privacy = cl.privacy || "private";
 
           const mePrefs = isU1 ? {
             enabled: !!cl.p1_enabled,
@@ -5980,16 +6229,58 @@ app.get("/profile/:username", requireLogin, async (req, res) => {
             badge: !!cl.p1_badge
           };
 
-          if (canShowCoupleFeature(mePrefs, partnerPrefs, "profile")) {
+          let privacyAllows = privacy === "public";
+          if (privacy === "private") privacyAllows = isMember;
+          if (privacy === "friends" && !privacyAllows) {
+            if (isMember) privacyAllows = true;
+            else if (viewerId && viewerId !== targetId && partnerId) {
+              try {
+                if (PG_READY && FRIENDS_READY) {
+                  privacyAllows = (await pgAreFriends(viewerId, targetId)) || (await pgAreFriends(viewerId, partnerId));
+                } else {
+                  privacyAllows = (await dbAreFriends(viewerId, targetId)) || (await dbAreFriends(viewerId, partnerId));
+                }
+              } catch {}
+            }
+          }
+
+          if (privacyAllows && canShowCoupleFeature(mePrefs, partnerPrefs, "profile")) {
             payload.couple = {
               partner: partnerName,
               since: Number(cl.activated_at || cl.created_at) || null,
               statusEmoji: cl.status_emoji || "💜",
               statusLabel: cl.status_label || "Linked",
-              badge: canShowCoupleFeature(mePrefs, partnerPrefs, "badge"),
+              badge: canShowCoupleBadge(mePrefs, partnerPrefs, cl),
               aura: canShowCoupleFeature(mePrefs, partnerPrefs, "aura"),
               showMembers: canShowCoupleFeature(mePrefs, partnerPrefs, "members"),
               groupMembers: canShowCoupleFeature(mePrefs, partnerPrefs, "group")
+            };
+          }
+
+          if (privacyAllows && isCouplesV2EnabledFor(req.session.user)) {
+            const members = [
+              {
+                id: Number(cl.user1_id) || 0,
+                username: cl.user1_name,
+                avatar: avatarUrlFromRow({ avatar: cl.user1_avatar }),
+                role: cl.user1_role || "User"
+              },
+              {
+                id: Number(cl.user2_id) || 0,
+                username: cl.user2_name,
+                avatar: avatarUrlFromRow({ avatar: cl.user2_avatar }),
+                role: cl.user2_role || "User"
+              }
+            ];
+            payload.coupleCard = {
+              coupleName: cl.couple_name || "",
+              coupleBio: cl.couple_bio || "",
+              privacy,
+              showBadge: cl.show_badge !== false,
+              statusEmoji: cl.status_emoji || "💜",
+              statusLabel: cl.status_label || "Linked",
+              since: Number(cl.activated_at || cl.created_at) || null,
+              members
             };
           }
         }
@@ -6147,7 +6438,12 @@ app.get("/api/couples/me", requireLogin, async (req, res) => {
   try {
     if (!PG_READY) return res.status(503).send("DB not ready");
     if (!COUPLES_READY) return res.status(503).send("Couples not ready");
-    const summary = await pgGetCoupleSummaryFor(req.session.user.id);
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
+    if (summary?.v2Enabled && summary?.couple) {
+      ensureCoupleMilestoneMemories(summary.couple).catch((e) => {
+        console.warn("[couples] milestone memory failed:", e?.message || e);
+      });
+    }
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] /me failed:", e?.message || e);
@@ -6198,16 +6494,16 @@ app.post("/api/couples/request", requireLogin, async (req, res) => {
 
     await pgPool.query(
       `
-      INSERT INTO couple_prefs(link_id, user_id, enabled, show_profile, show_members, group_members, aura, badge, updated_at)
+      INSERT INTO couple_prefs(link_id, user_id, enabled, show_profile, show_members, group_members, aura, badge, allow_ping, updated_at)
       VALUES
-        ($1,$2,true,true,true,false,true,true,$4),
-        ($1,$3,true,true,true,false,true,true,$4)
+        ($1,$2,true,true,true,false,true,true,true,$4),
+        ($1,$3,true,true,true,false,true,true,true,$4)
       ON CONFLICT (link_id, user_id) DO NOTHING
       `,
       [linkId, u1, u2, now]
     );
 
-    const summary = await pgGetCoupleSummaryFor(meId);
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] request failed:", e?.message || e);
@@ -6228,11 +6524,12 @@ app.post("/api/couples/respond", requireLogin, async (req, res) => {
     const link = rows[0];
     if (!link) return res.status(404).send("Not found");
     if (link.status !== "pending") return res.status(409).send("Not pending");
-    if (Number(link.user1_id) !== meId && Number(link.user2_id) !== meId) return res.status(403).send("Forbidden");
+    if (!isCoupleMember(meId, link)) return res.status(403).send("Forbidden");
 
     if (!accept) {
       await pgPool.query(`DELETE FROM couple_links WHERE id=$1`, [linkId]);
-      const summary = await pgGetCoupleSummaryFor(meId);
+      emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId });
+      const summary = await pgGetCoupleSummaryFor(req.session.user);
       return res.json(summary);
     }
 
@@ -6241,34 +6538,15 @@ app.post("/api/couples/respond", requireLogin, async (req, res) => {
       `UPDATE couple_links SET status='active', activated_at=$2, updated_at=$2 WHERE id=$1`,
       [linkId, now]
     );
+    emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId });
 
     try {
-      const userIds = [Number(link.user1_id) || 0, Number(link.user2_id) || 0].filter(Boolean);
-      if (userIds.length === 2) {
-        const { rows: users } = await pgPool.query(
-          `SELECT id, username, role FROM users WHERE id = ANY($1::int[])`,
-          [userIds]
-        );
-        const map = new Map(users.map((u) => [Number(u.id), u]));
-        const u1 = map.get(userIds[0]);
-        const u2 = map.get(userIds[1]);
-        if (u1 && u2) {
-          const payloadFor = (self, partner) => ({
-            type: "social",
-            title: "Couple linked",
-            description: `Linked with ${partner.username}.`,
-            icon: "💜",
-            metadata: { partnerId: partner.id, partnerName: partner.username },
-          });
-          void ensureMemory(u1.id, `couple_linked_${u2.id}`, payloadFor(u1, u2), u1);
-          void ensureMemory(u2.id, `couple_linked_${u1.id}`, payloadFor(u2, u1), u2);
-        }
-      }
+      await ensureCoupleLinkedMemories(link);
     } catch (e) {
       console.warn("[couples] memory create failed:", e?.message || e);
     }
 
-    const summary = await pgGetCoupleSummaryFor(meId);
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] respond failed:", e?.message || e);
@@ -6287,10 +6565,11 @@ app.post("/api/couples/unlink", requireLogin, async (req, res) => {
     const { rows } = await pgPool.query(`SELECT user1_id,user2_id FROM couple_links WHERE id=$1 LIMIT 1`, [linkId]);
     const link = rows[0];
     if (!link) return res.status(404).send("Not found");
-    if (Number(link.user1_id) !== meId && Number(link.user2_id) !== meId) return res.status(403).send("Forbidden");
+    if (!isCoupleMember(meId, link)) return res.status(403).send("Forbidden");
 
     await pgPool.query(`DELETE FROM couple_links WHERE id=$1`, [linkId]);
-    const summary = await pgGetCoupleSummaryFor(meId);
+    emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId });
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] unlink failed:", e?.message || e);
@@ -6309,10 +6588,11 @@ app.post("/api/couples/prefs", requireLogin, async (req, res) => {
     const { rows } = await pgPool.query(`SELECT user1_id,user2_id FROM couple_links WHERE id=$1 LIMIT 1`, [linkId]);
     const link = rows[0];
     if (!link) return res.status(404).send("Not found");
-    if (Number(link.user1_id) !== meId && Number(link.user2_id) !== meId) return res.status(403).send("Forbidden");
+    if (!isCoupleMember(meId, link)) return res.status(403).send("Forbidden");
 
     await pgUpsertCouplePrefs(linkId, meId, req.body?.prefs || {});
-    const summary = await pgGetCoupleSummaryFor(meId);
+    emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId });
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] prefs failed:", e?.message || e);
@@ -6332,7 +6612,7 @@ app.post("/api/couples/status", requireLogin, async (req, res) => {
     const link = rows[0];
     if (!link) return res.status(404).send("Not found");
     if (link.status !== "active") return res.status(409).send("Not active");
-    if (Number(link.user1_id) !== meId && Number(link.user2_id) !== meId) return res.status(403).send("Forbidden");
+    if (!isCoupleMember(meId, link)) return res.status(403).send("Forbidden");
 
     const emoji = String(req.body?.statusEmoji || "💜").trim().slice(0, 8) || "💜";
     const label = String(req.body?.statusLabel || "Linked").trim().slice(0, 20) || "Linked";
@@ -6342,12 +6622,89 @@ app.post("/api/couples/status", requireLogin, async (req, res) => {
       `UPDATE couple_links SET status_emoji=$2, status_label=$3, updated_at=$4 WHERE id=$1`,
       [linkId, emoji, label, now]
     );
+    emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId });
 
-    const summary = await pgGetCoupleSummaryFor(meId);
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
     return res.json(summary);
   } catch (e) {
     console.warn("[couples] status failed:", e?.message || e);
     return res.status(500).send("Could not update status");
+  }
+});
+
+app.post("/api/couples/settings", requireLogin, async (req, res) => {
+  try {
+    if (!PG_READY) return res.status(503).send("DB not ready");
+    if (!COUPLES_READY) return res.status(503).send("Couples not ready");
+    if (!isCouplesV2EnabledFor(req.session.user)) return res.status(403).send("Forbidden");
+
+    const link = await pgGetActiveCoupleLinkForUser(req.session.user.id);
+    if (!link) return res.status(404).send("Not linked");
+    if (!isCoupleMember(req.session.user.id, link)) return res.status(403).send("Forbidden");
+
+    const privacyRaw = String(req.body?.privacy || "").trim().toLowerCase();
+    const privacy = ["private", "friends", "public"].includes(privacyRaw) ? privacyRaw : undefined;
+    const coupleName = typeof req.body?.couple_name === "string" ? String(req.body.couple_name).trim().slice(0, 48) : undefined;
+    const coupleBio = typeof req.body?.couple_bio === "string" ? String(req.body.couple_bio).trim().slice(0, 220) : undefined;
+    const showBadge = typeof req.body?.show_badge === "boolean" ? req.body.show_badge : undefined;
+    const bonusesEnabled = typeof req.body?.bonuses_enabled === "boolean" ? req.body.bonuses_enabled : undefined;
+    const now = Date.now();
+
+    const sets = [];
+    const vals = [];
+    if (privacy) { sets.push(`privacy=$${vals.length + 1}`); vals.push(privacy); }
+    if (coupleName !== undefined) { sets.push(`couple_name=$${vals.length + 1}`); vals.push(coupleName || null); }
+    if (coupleBio !== undefined) { sets.push(`couple_bio=$${vals.length + 1}`); vals.push(coupleBio || null); }
+    if (showBadge !== undefined) { sets.push(`show_badge=$${vals.length + 1}`); vals.push(showBadge); }
+    if (bonusesEnabled !== undefined) { sets.push(`bonuses_enabled=$${vals.length + 1}`); vals.push(bonusesEnabled); }
+    sets.push(`updated_at=$${vals.length + 1}`); vals.push(now);
+
+    if (sets.length) {
+      vals.push(link.id);
+      await pgPool.query(`UPDATE couple_links SET ${sets.join(", ")} WHERE id=$${vals.length}`, vals);
+    }
+
+    emitToUserIds([link.user1_id, link.user2_id], "couples:update", { linkId: link.id });
+    const summary = await pgGetCoupleSummaryFor(req.session.user);
+    return res.json(summary);
+  } catch (e) {
+    console.warn("[couples] settings failed:", e?.message || e);
+    return res.status(500).send("Could not update settings");
+  }
+});
+
+const coupleNudgeCooldownMs = 60_000;
+const coupleNudgeLastByUser = new Map(); // key: `${linkId}:${userId}` -> ts
+
+app.post("/api/couples/nudge", requireLogin, async (req, res) => {
+  try {
+    if (!PG_READY) return res.status(503).send("DB not ready");
+    if (!COUPLES_READY) return res.status(503).send("Couples not ready");
+    if (!isCouplesV2EnabledFor(req.session.user)) return res.status(403).send("Forbidden");
+
+    const link = await pgGetActiveCoupleLinkForUser(req.session.user.id);
+    if (!link) return res.status(404).send("Not linked");
+    if (!isCoupleMember(req.session.user.id, link)) return res.status(403).send("Forbidden");
+
+    const partnerId = getCouplePartnerId(req.session.user.id, link);
+    if (!partnerId) return res.status(404).send("Partner not found");
+    const prefsPartner = await pgGetCouplePrefs(link.id, partnerId);
+    if (prefsPartner && prefsPartner.allow_ping === false) return res.status(403).send("Partner muted nudges");
+
+    const key = `${link.id}:${req.session.user.id}`;
+    const last = coupleNudgeLastByUser.get(key) || 0;
+    if (Date.now() - last < coupleNudgeCooldownMs) return res.status(429).send("Slow down");
+    coupleNudgeLastByUser.set(key, Date.now());
+
+    emitToUserIds([partnerId], "couples:nudge", {
+      fromId: req.session.user.id,
+      fromName: req.session.user.username,
+      linkId: link.id
+    });
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[couples] nudge failed:", e?.message || e);
+    return res.status(500).send("Could not send nudge");
   }
 });
 
@@ -7858,6 +8215,7 @@ async function emitUserList(room) {
           SELECT cl.id AS link_id,
                  cl.user1_id, cl.user2_id,
                  cl.status_emoji, cl.status_label,
+                 cl.show_badge,
                  cl.activated_at, cl.created_at,
                  u1.username AS user1_name,
                  u2.username AS user2_name,
@@ -7897,14 +8255,14 @@ async function emitUserList(room) {
           uA.couple = {
             ...base,
             partner: c.user2_name,
-            badge: canShowCoupleFeature(prefsA, prefsB, "badge"),
+            badge: canShowCoupleBadge(prefsA, prefsB, c),
             aura: canShowCoupleFeature(prefsA, prefsB, "aura"),
             group: canShowCoupleFeature(prefsA, prefsB, "group"),
           };
           uB.couple = {
             ...base,
             partner: c.user1_name,
-            badge: canShowCoupleFeature(prefsA, prefsB, "badge"),
+            badge: canShowCoupleBadge(prefsA, prefsB, c),
             aura: canShowCoupleFeature(prefsA, prefsB, "aura"),
             group: canShowCoupleFeature(prefsA, prefsB, "group"),
           };
@@ -7933,8 +8291,11 @@ async function emitUserList(room) {
       seen.add(u.name);
       const c = u.couple;
       if (c && c.group && c.partner && byName.has(c.partner) && !seen.has(c.partner)) {
-        out.push(byName.get(c.partner));
-        seen.add(c.partner);
+        const partnerUser = byName.get(c.partner);
+        if (partnerUser && roleRank(partnerUser.role) === roleRank(u.role)) {
+          out.push(partnerUser);
+          seen.add(c.partner);
+        }
       }
     }
     if (out.length === users.length) users.splice(0, users.length, ...out);
@@ -9699,7 +10060,11 @@ socket.on("disconnect", () => {
 });
 
 // ---- Start
-Promise.allSettled([migrationsReady, pgInitPromise]).then((results) => {
+const startupReady = Promise.allSettled([migrationsReady, pgInitPromise]);
+let SERVER_STARTED = false;
+async function startServer() {
+  if (SERVER_STARTED) return httpServer;
+  const results = await startupReady;
   const [sqliteResult, pgResult] = results;
   if (sqliteResult.status === "rejected") {
     console.error("[startup] SQLite migration failed", sqliteResult.reason);
@@ -9709,10 +10074,21 @@ Promise.allSettled([migrationsReady, pgInitPromise]).then((results) => {
     console.error("[startup] Postgres init failed", pgResult.reason);
   }
 
-  httpServer.listen(PORT, () => {
-    console.log(`Server running on http://localhost:${PORT}`);
+  await new Promise((resolve) => {
+    httpServer.listen(PORT, () => {
+      SERVER_STARTED = true;
+      console.log(`Server running on http://localhost:${PORT}`);
+      resolve();
+    });
   });
-});
+  return httpServer;
+}
+
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { app, httpServer, io, startServer, startupReady };
 
 
 function normalizeUserKey(value) {


### PR DESCRIPTION
### Motivation
- Fix a long-standing bug where only the acceptor could view/change couple settings by replacing ad-hoc acceptor/receiver checks with a canonical membership model. 
- Normalize couple data and provide symmetric APIs so both members see identical options and shared settings live on the couple record. 
- Add low-risk, opt-in "delight" features behind `COUPLES_V2_ENABLED` (per-owner/allowlist): shared couple card, couple memories/milestones and a gentle partner `nudge` with server-side rate limiting.

### Description
- Introduced canonical helpers `normalizeCoupleMembers`, `isCoupleMember`, and `getCouplePartnerId` on the server and a client helper `isCoupleMember` to centralize membership checks and remove requester/acceptor gating. 
- Made couples symmetric in `pgGetCoupleSummaryFor`/`pgGetActiveCoupleLinkForUser` (returns `{ couple, partner, isCoupleMember, v2Enabled }`) and updated all couple endpoints to use `isCoupleMember` only; emits `couples:update` to both members on changes. 
- Extended schema access (migration-friendly) to add couple fields and prefs: `privacy`, `couple_name`, `couple_bio`, `settings_json`, `show_badge`, `bonuses_enabled` and `allow_ping` in `couple_prefs`, plus backfill-safe `ALTER TABLE` calls. 
- Added V2 API and UX: `POST /api/couples/settings` (shared couple card updates), `POST /api/couples/nudge` (rate-limited soft nudge), server-side memory creation helpers `ensureCoupleLinkedMemories` and milestone creation (`7d`, `30d`) when `COUPLES_V2_ENABLED` applies. 
- Frontend updates: new couple profile card in `public/index.html` with avatars/name/bio/privacy, V2 settings controls in profile edit, `couples` UI wiring in `public/app.js`, role-safe pairing in members list (`reorderCouplesInMembers`) and socket listeners for `couples:update`/`couples:nudge`; added styles in `public/styles.css`. 
- Added a regression harness `scripts/couples-regression.js` (uses `supertest`) and `npm` script `test:couples` plus `supertest` dev dependency; refactored server start into `startServer` and exported `{ app, httpServer, io, startServer, startupReady }` to allow programmatic test usage. 

### Testing
- Ran static/syntax checks with `npm run check` which completed successfully (`node --check` passed for server and frontend bundles). 
- Installed dev deps (`supertest`) successfully; added `npm run test:couples` which runs `scripts/couples-regression.js` that reproduces: request -> accept -> both see active couple and can update shared settings. 
- Attempted to start the server (`npm start`) in this environment but Postgres DNS/connection was unavailable (logged `Postgres init error: ENOTFOUND ...`); the regression harness was not executed here due to the environment Postgres connectivity issue (the harness and `test:couples` are included and should pass in CI or an environment with a reachable Postgres instance).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968e5dce1cc8333810865e72d2bcc75)