### PR TITLE
Require 12+ passwords: server-side upgrade flow + blocking UI

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2300,6 +2300,14 @@ const togglePassBtn = document.getElementById("togglePassBtn");
 const captchaWrap = document.getElementById("captchaWrap");
 const captchaWidget = document.getElementById("captchaWidget");
 const captchaNote = document.getElementById("captchaNote");
+const passwordUpgradeView = document.getElementById("passwordUpgradeView");
+const passwordUpgradeForm = document.getElementById("passwordUpgradeForm");
+const upgradeCurrentPass = document.getElementById("upgradeCurrentPass");
+const upgradeNewPass = document.getElementById("upgradeNewPass");
+const upgradeConfirmPass = document.getElementById("upgradeConfirmPass");
+const passwordUpgradeMsg = document.getElementById("passwordUpgradeMsg");
+const passwordUpgradeSubmitBtn = document.getElementById("passwordUpgradeSubmitBtn");
+const passwordUpgradeLogoutBtn = document.getElementById("passwordUpgradeLogoutBtn");
 
 
 // Auth: show/hide password
@@ -10006,6 +10014,7 @@ statusSelect.addEventListener("change", ()=>{
 // ---- auth helpers
 let authUserState = null;
 let authHandlersBound = false;
+let passwordUpgradeHandlersBound = false;
 
 function getAuthUser(){
   return authUserState;
@@ -10027,18 +10036,27 @@ function setView(mode){
     loginView.hidden = false;
     chatView.hidden = true;
     if(restrictedView) restrictedView.hidden = true;
+    if(passwordUpgradeView) passwordUpgradeView.hidden = true;
   }else if(mode === "chat"){
     loginView.hidden = true;
     chatView.hidden = false;
     if(restrictedView) restrictedView.hidden = true;
+    if(passwordUpgradeView) passwordUpgradeView.hidden = true;
   }else if(mode === "restricted"){
     loginView.hidden = true;
     chatView.hidden = true;
     if(restrictedView) restrictedView.hidden = false;
+    if(passwordUpgradeView) passwordUpgradeView.hidden = true;
+  }else if(mode === "password-upgrade"){
+    loginView.hidden = true;
+    chatView.hidden = true;
+    if(restrictedView) restrictedView.hidden = true;
+    if(passwordUpgradeView) passwordUpgradeView.hidden = false;
   }else{
     loginView.hidden = true;
     chatView.hidden = true;
     if(restrictedView) restrictedView.hidden = true;
+    if(passwordUpgradeView) passwordUpgradeView.hidden = true;
   }
 }
 
@@ -10053,6 +10071,49 @@ function setAuthLoading(loading, message = ""){
 
 function setAuthValidation(message = ""){
   if(authValidation) authValidation.textContent = message;
+}
+
+let passwordUpgradeNonce = "";
+let passwordUpgradeSubmitting = false;
+
+function setPasswordUpgradeMessage(message = ""){
+  if(passwordUpgradeMsg) passwordUpgradeMsg.textContent = message;
+}
+
+function setPasswordUpgradeLoading(loading, message = ""){
+  passwordUpgradeSubmitting = loading;
+  if(passwordUpgradeSubmitBtn) passwordUpgradeSubmitBtn.disabled = loading;
+  if(passwordUpgradeLogoutBtn) passwordUpgradeLogoutBtn.disabled = loading;
+  if(upgradeCurrentPass) upgradeCurrentPass.disabled = loading;
+  if(upgradeNewPass) upgradeNewPass.disabled = loading;
+  if(upgradeConfirmPass) upgradeConfirmPass.disabled = loading;
+  if(message) setPasswordUpgradeMessage(message);
+}
+
+function showPasswordUpgradeView({ nonce = "" } = {}){
+  passwordUpgradeNonce = nonce || "";
+  setView("password-upgrade");
+  setPasswordUpgradeLoading(false, "");
+  setPasswordUpgradeMessage("");
+  if(upgradeCurrentPass){
+    upgradeCurrentPass.value = "";
+    upgradeNewPass.value = "";
+    upgradeConfirmPass.value = "";
+    requestAnimationFrame(()=> upgradeCurrentPass?.focus?.());
+  }
+}
+
+async function checkPasswordUpgradeStatus(){
+  try{
+    const res = await fetch("/password-upgrade/status", { credentials: "include" });
+    if(!res.ok) return false;
+    const data = await res.json().catch(()=>({}));
+    if(data?.required){
+      showPasswordUpgradeView({ nonce: data?.nonce || "" });
+      return true;
+    }
+  }catch{}
+  return false;
 }
 
 async function api(path, options){
@@ -10161,6 +10222,7 @@ function initLoginUI(){
   setAuthLoading(false, "");
   setAuthValidation("");
   initCaptcha();
+  initPasswordUpgradeUI();
   if(!authHandlersBound){
     authHandlersBound = true;
     authForm?.addEventListener("submit", (e)=>{
@@ -10173,6 +10235,19 @@ function initLoginUI(){
   if(authUser && !isAuthenticated()){
     requestAnimationFrame(()=> authUser?.focus?.());
   }
+}
+
+function initPasswordUpgradeUI(){
+  if(passwordUpgradeHandlersBound) return;
+  passwordUpgradeHandlersBound = true;
+  passwordUpgradeForm?.addEventListener("submit", (e)=>{
+    e.preventDefault();
+    doPasswordUpgrade();
+  });
+  passwordUpgradeLogoutBtn?.addEventListener("click", (e)=>{
+    e?.preventDefault?.();
+    doLogout();
+  });
 }
 
 const KICK_LENGTH_OPTIONS = [
@@ -10674,9 +10749,67 @@ async function doLogin(){
     resetCaptchaToken();
     return;
   }
+  const payload = safeJsonParse(text, {});
+  if(payload?.code === "PASSWORD_UPGRADE_REQUIRED"){
+    setAuthLoading(false, "");
+    resetCaptchaToken();
+    const pending = await checkPasswordUpgradeStatus();
+    if(!pending){
+      setAuthValidation("Password upgrade required. Please try again.");
+    }
+    return;
+  }
   await initChatApp();
   setAuthLoading(false, "");
   resetCaptchaToken();
+}
+
+async function doPasswordUpgrade(){
+  if(passwordUpgradeSubmitting) return;
+  const currentPassword = upgradeCurrentPass?.value || "";
+  const newPassword = upgradeNewPass?.value || "";
+  const confirmPassword = upgradeConfirmPass?.value || "";
+
+  if(!currentPassword){
+    setPasswordUpgradeMessage("Enter your current password.");
+    upgradeCurrentPass?.focus?.();
+    return;
+  }
+  if(!newPassword){
+    setPasswordUpgradeMessage("Enter a new password.");
+    upgradeNewPass?.focus?.();
+    return;
+  }
+  if(newPassword.length < 12){
+    setPasswordUpgradeMessage("New password must be at least 12 characters.");
+    upgradeNewPass?.focus?.();
+    return;
+  }
+  if(newPassword !== confirmPassword){
+    setPasswordUpgradeMessage("Passwords do not match.");
+    upgradeConfirmPass?.focus?.();
+    return;
+  }
+
+  setPasswordUpgradeLoading(true, "Updating password...");
+  const {res,text} = await api("/password-upgrade", {
+    method: "POST",
+    headers: {"Content-Type":"application/json"},
+    body: JSON.stringify({
+      currentPassword,
+      newPassword,
+      confirmPassword,
+      nonce: passwordUpgradeNonce,
+    })
+  });
+  const payload = safeJsonParse(text, {});
+  if(!res.ok || !payload?.ok){
+    const message = payload?.message || text || "Password upgrade failed.";
+    setPasswordUpgradeLoading(false, message);
+    return;
+  }
+  setPasswordUpgradeLoading(false, "");
+  window.location.reload();
 }
 
 async function doRegister(){
@@ -13609,6 +13742,7 @@ async function bootApp(){
   bindReferralsUI();
   bindRoleDebugUI();
   bindOwnerPanels();
+  initPasswordUpgradeUI();
 
   const sessionUser = await validateSession({ silent: true });
   if(sessionUser){
@@ -13631,6 +13765,8 @@ async function bootApp(){
     await initChatApp();
     return;
   }
+  const pendingUpgrade = await checkPasswordUpgradeStatus();
+  if(pendingUpgrade) return;
   initLoginUI();
 }
 
@@ -13671,7 +13807,7 @@ function focusMainComposer(){
   });
 }
 
-const SOFT_INPUT_SELECTOR = ".menuContent input, .menuContent textarea, .modalContent input, .modalContent textarea, .faqAnswerEdit";
+const SOFT_INPUT_SELECTOR = ".menuContent input, .menuContent textarea, .modalContent input, .modalContent textarea, .faqAnswerEdit, #passwordUpgradeView input";
 
 function updateKeyboardInset(target){
   const vv = window.visualViewport;

--- a/public/index.html
+++ b/public/index.html
@@ -56,7 +56,46 @@
 </form>
 <div class="loginFooter small muted">
           By continuing, you confirm you are 18+ and agree to follow the community rules.
-        </div>
+</div>
+</div>
+</div>
+</div>
+<!-- PASSWORD UPGRADE -->
+<div hidden="" id="passwordUpgradeView">
+<div aria-hidden="true" class="upgradeBackdrop"></div>
+<div class="upgradeShell">
+<div class="upgradeCard loginCard" role="dialog" aria-label="Password upgrade required">
+<div class="loginHeader">
+<h2>Upgrade your password</h2>
+<p>For security, passwords must be 12+ characters.</p>
+</div>
+<form class="loginForm" id="passwordUpgradeForm">
+<div class="field">
+<label for="upgradeCurrentPass">Current password</label>
+<input autocomplete="current-password" id="upgradeCurrentPass" required="" type="password"/>
+</div>
+<div class="field">
+<label for="upgradeNewPass">New password (12+)</label>
+<input autocomplete="new-password" id="upgradeNewPass" required="" type="password"/>
+</div>
+<div class="field">
+<label for="upgradeConfirmPass">Confirm new password</label>
+<input autocomplete="new-password" id="upgradeConfirmPass" required="" type="password"/>
+</div>
+<div class="upgradeHints small muted">
+<div class="upgradeHintsTitle">Quick tips</div>
+<ul>
+<li>Use 3+ words.</li>
+<li>Add numbers or symbols.</li>
+<li>Mix upper/lowercase.</li>
+</ul>
+</div>
+<div aria-live="polite" class="loginValidation" id="passwordUpgradeMsg"></div>
+<div class="row loginActions">
+<button class="btn" id="passwordUpgradeSubmitBtn" type="submit">Update password</button>
+<button class="btn secondary" id="passwordUpgradeLogoutBtn" type="button">Logout</button>
+</div>
+</form>
 </div>
 </div>
 </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1594,6 +1594,57 @@ body.auth-pending #authLoading{
               linear-gradient(180deg, rgba(6,6,12,0.88), rgba(6,6,12,0.96));
 }
 
+#passwordUpgradeView{
+  position: fixed;
+  inset: 0;
+  min-height: var(--vvhPx);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(20px, 4vw, 40px);
+  padding-top: calc(clamp(20px, 4vw, 40px) + env(safe-area-inset-top));
+  padding-bottom: calc(clamp(20px, 4vw, 40px) + env(safe-area-inset-bottom));
+  z-index: 500;
+  background: radial-gradient(900px 520px at 15% 10%, rgba(120,120,255,0.18), transparent 60%),
+              radial-gradient(900px 520px at 85% 15%, rgba(80,220,255,0.16), transparent 55%),
+              linear-gradient(180deg, rgba(6,6,12,0.9), rgba(6,6,12,0.98));
+}
+
+.upgradeBackdrop{
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255,255,255,0.04), transparent 40%, rgba(255,255,255,0.03));
+  pointer-events: none;
+}
+
+.upgradeShell{
+  position: relative;
+  width: min(560px, 100%);
+  z-index: 1;
+}
+
+.upgradeCard{
+  width: 100%;
+}
+
+.upgradeHints{
+  margin: 12px 0;
+}
+
+.upgradeHintsTitle{
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  margin-bottom: 6px;
+}
+
+.upgradeHints ul{
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 6px;
+}
+
 .loginBackdrop{
   position:absolute;
   inset:0;

--- a/server.js
+++ b/server.js
@@ -88,6 +88,7 @@ setInterval(decayHeat, 60_000).unref?.();
 
 const path = require("path");
 const fs = require("fs");
+const crypto = require("crypto");
 const express = require("express");
 const helmet = require("helmet");
 const session = require("express-session");
@@ -1274,6 +1275,15 @@ const loginIpLimiter = rateLimit({
   legacyHeaders: false,
   handler: genericRateLimitHandler,
   keyGenerator: (req) => getClientIp(req),
+});
+
+const passwordUpgradeLimiter = rateLimit({
+  windowMs: 10 * 60 * 1000,
+  limit: Number(process.env.RATE_LIMIT_PASSWORD_UPGRADE || 12),
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  handler: genericRateLimitHandler,
+  keyGenerator: (req) => String(req.session?.passwordUpgrade?.userId || getClientIp(req)),
 });
 
 const registerLimiter = rateLimit({
@@ -4063,6 +4073,34 @@ function clearLoginFailures(key) {
   loginFailureTracker.delete(key);
 }
 
+function getPasswordUpgradeAttemptState(req) {
+  const now = Date.now();
+  const state = req.session?.passwordUpgradeAttempts || { count: 0, resetAt: now + 15 * 60 * 1000, lockedUntil: 0 };
+  if (now > state.resetAt) {
+    state.count = 0;
+    state.resetAt = now + 15 * 60 * 1000;
+    state.lockedUntil = 0;
+  }
+  if (state.lockedUntil && now < state.lockedUntil) {
+    return { blocked: true, retryAfterMs: state.lockedUntil - now, state };
+  }
+  return { blocked: false, state };
+}
+
+function recordPasswordUpgradeFailure(req) {
+  const now = Date.now();
+  const state = getPasswordUpgradeAttemptState(req).state || { count: 0, resetAt: now + 15 * 60 * 1000, lockedUntil: 0 };
+  state.count += 1;
+  if (state.count >= 5) {
+    state.lockedUntil = now + 15 * 60 * 1000;
+  }
+  req.session.passwordUpgradeAttempts = state;
+}
+
+function clearPasswordUpgradeFailures(req) {
+  if (req.session?.passwordUpgradeAttempts) delete req.session.passwordUpgradeAttempts;
+}
+
 async function invalidateSessionsForUserId(userId) {
   if (!userId || !PG_READY) return;
   try {
@@ -4732,15 +4770,34 @@ async function faqReactionPayload(questionId, username){
 }
 
 const COMMON_PASSWORDS = new Set([
+  "123456",
   "password",
   "password123",
+  "1234567",
   "12345678",
   "123456789",
+  "1234567890",
+  "12345678910",
+  "111111",
+  "000000",
+  "qwerty",
   "qwerty123",
+  "qwertyuiop",
+  "abc123",
+  "abc12345",
   "letmein",
-  "welcome",
+  "letmein123",
   "iloveyou",
+  "welcome",
+  "welcome123",
+  "admin",
   "admin123",
+  "monkey",
+  "dragon",
+  "football",
+  "princess",
+  "sunshine",
+  "trustno1",
 ]);
 
 function isPasswordTooWeak(password) {
@@ -4937,6 +4994,25 @@ app.post("/login", loginIpLimiter, async (req, res) => {
         return res.status(401).send("Invalid username or password");
       }
 
+      if (password.length < 12) {
+        const nonce = crypto.randomBytes(18).toString("hex");
+        req.session.user = null;
+        req.session.passwordUpgrade = {
+          userId: pgUser.id,
+          username: pgUser.username,
+          issuedAt: Date.now(),
+          nonce,
+        };
+        clearPasswordUpgradeFailures(req);
+        clearLoginFailures(loginKey);
+        clearLoginFailures(ipKey);
+        logSecurityEvent("password_upgrade_required", { ip, username: pgUser.username, userId: pgUser.id, store: "pg" });
+        return req.session.save((saveErr) => {
+          if (saveErr) return res.status(500).send("Session save failed");
+          return res.json({ ok: false, code: "PASSWORD_UPGRADE_REQUIRED" });
+        });
+      }
+
       const theme = sanitizeThemeNameServer(pgUser.theme || DEFAULT_THEME);
 
       // Mirror into SQLite if missing (some UI/profile/dice logic still reads SQLite)
@@ -5060,6 +5136,25 @@ app.post("/login", loginIpLimiter, async (req, res) => {
     const theme = sanitizeThemeNameServer(row.theme || DEFAULT_THEME);
     if (!row.theme) await dbRunAsync("UPDATE users SET theme = ? WHERE id = ?", [theme, row.id]).catch(() => {});
 
+    if (password.length < 12) {
+      const nonce = crypto.randomBytes(18).toString("hex");
+      req.session.user = null;
+      req.session.passwordUpgrade = {
+        userId: row.id,
+        username: row.username,
+        issuedAt: Date.now(),
+        nonce,
+      };
+      clearPasswordUpgradeFailures(req);
+      clearLoginFailures(loginKey);
+      clearLoginFailures(ipKey);
+      logSecurityEvent("password_upgrade_required", { ip, username: row.username, userId: row.id, store: "sqlite" });
+      return req.session.save((saveErr) => {
+        if (saveErr) return res.status(500).send("Session save failed");
+        return res.json({ ok: false, code: "PASSWORD_UPGRADE_REQUIRED" });
+      });
+    }
+
     // Mirror into Postgres (so /me + progression + persistent systems work)
     await pgPool.query(
       `INSERT INTO users (id, username, password_hash, role, created_at, theme, gold, xp)
@@ -5100,6 +5195,164 @@ app.post("/login", loginIpLimiter, async (req, res) => {
   } catch (e) {
     console.error(e);
     return res.status(500).send("Login failed");
+  }
+});
+
+app.get("/password-upgrade/status", (req, res) => {
+  const pending = req.session?.passwordUpgrade || null;
+  if (!pending?.userId) return res.json({ required: false });
+  return res.json({ required: true, nonce: pending.nonce || "" });
+});
+
+app.get("/password-upgrade", (req, res) => {
+  if (!req.session?.passwordUpgrade?.userId) return res.redirect("/");
+  return res.sendFile(path.join(PUBLIC_DIR, "index.html"));
+});
+
+app.post("/password-upgrade", passwordUpgradeLimiter, async (req, res) => {
+  const pending = req.session?.passwordUpgrade || null;
+  if (!pending?.userId) return res.status(401).json({ ok: false, message: "No password upgrade pending." });
+
+  const ip = getClientIp(req);
+  const attemptState = getPasswordUpgradeAttemptState(req);
+  if (attemptState.blocked) {
+    return res.status(429).json({ ok: false, code: "PASSWORD_UPGRADE_LOCKED", message: "Too many attempts. Try again later." });
+  }
+
+  const currentPassword = String(req.body?.currentPassword || "");
+  const newPassword = String(req.body?.newPassword || "");
+  const confirmPassword = String(req.body?.confirmPassword || "");
+  const nonce = String(req.body?.nonce || "");
+
+  if (pending.nonce && nonce !== pending.nonce) {
+    return res.status(403).json({ ok: false, message: "Invalid session." });
+  }
+
+  if (!currentPassword || !newPassword || !confirmPassword) {
+    return res.status(400).json({ ok: false, message: "Missing required fields." });
+  }
+
+  if (newPassword.length < 12) {
+    return res.status(400).json({ ok: false, message: "Password must be 12+ chars." });
+  }
+  if (newPassword !== confirmPassword) {
+    return res.status(400).json({ ok: false, message: "Passwords do not match." });
+  }
+  if (isPasswordTooWeak(newPassword)) {
+    return res.status(400).json({ ok: false, message: "Password is too common." });
+  }
+
+  try {
+    const userId = Number(pending.userId);
+    const pgUser = await pgGetUserById(userId).catch(() => null);
+    const sqliteRow = await dbGetAsync("SELECT * FROM users WHERE id = ?", [userId]).catch(() => null);
+
+    if (!pgUser && !sqliteRow) {
+      recordPasswordUpgradeFailure(req);
+      logSecurityEvent("password_upgrade_failed", { ip, userId, username: pending.username, reason: "user_not_found" });
+      return res.status(401).json({ ok: false, message: "Password upgrade failed." });
+    }
+
+    let stored = "";
+    if (pgUser?.password_hash) stored = String(pgUser.password_hash || "").trim();
+    else if (sqliteRow?.password_hash) stored = String(sqliteRow.password_hash || "").trim();
+    else if (sqliteRow?.password) stored = String(sqliteRow.password || "").trim();
+
+    const looksBcrypt = stored.startsWith("$2");
+    const matches = looksBcrypt
+      ? await bcrypt.compare(currentPassword, stored)
+      : currentPassword === stored;
+
+    if (!matches) {
+      recordPasswordUpgradeFailure(req);
+      logSecurityEvent("password_upgrade_failed", { ip, userId, username: pending.username, reason: "password_mismatch" });
+      return res.status(401).json({ ok: false, message: "Current password incorrect." });
+    }
+
+    const newHash = await bcrypt.hash(newPassword, 12);
+
+    if (pgUser?.id) {
+      await pgPool.query("UPDATE users SET password_hash = $1 WHERE id = $2", [newHash, pgUser.id]).catch(() => {});
+    } else if (sqliteRow?.id) {
+      const createdAtValue = PG_USERS_CREATED_AT_IS_TIMESTAMP
+        ? new Date(Number(sqliteRow.created_at || Date.now()))
+        : Number(sqliteRow.created_at || Date.now());
+      await pgPool.query(
+        `INSERT INTO users (id, username, password_hash, role, created_at, theme, gold, xp)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+         ON CONFLICT (username) DO UPDATE
+           SET password_hash = EXCLUDED.password_hash,
+               role = COALESCE(users.role, EXCLUDED.role),
+               theme = COALESCE(users.theme, EXCLUDED.theme),
+               gold = COALESCE(users.gold, EXCLUDED.gold),
+               xp = COALESCE(users.xp, EXCLUDED.xp)`,
+        [
+          sqliteRow.id,
+          sqliteRow.username,
+          newHash,
+          sqliteRow.role || "User",
+          createdAtValue,
+          sanitizeThemeNameServer(sqliteRow.theme || DEFAULT_THEME),
+          Number(sqliteRow.gold || 0),
+          Number(sqliteRow.xp || 0),
+        ]
+      ).catch(() => {});
+    }
+
+    if (sqliteRow?.id) {
+      await dbRunAsync("UPDATE users SET password_hash = ?, password = NULL WHERE id = ?", [newHash, sqliteRow.id]).catch(() => {});
+    } else if (pgUser?.id) {
+      await dbRunAsync(
+        `INSERT INTO users (id, username, password_hash, role, created_at, gold, xp, theme)
+         VALUES (?,?,?,?,?,?,?,?)`,
+        [
+          pgUser.id,
+          pgUser.username,
+          newHash,
+          pgUser.role || "User",
+          Number(pgUser.created_at || Date.now()),
+          Number(pgUser.gold || 0),
+          Number(pgUser.xp || 0),
+          sanitizeThemeNameServer(pgUser.theme || DEFAULT_THEME),
+        ]
+      ).catch(() => {});
+    }
+
+    const refreshedPgUser = await pgGetUserById(userId).catch(() => null);
+    const sessionRow = refreshedPgUser || sqliteRow || pgUser;
+    const role = sessionRow?.role || "User";
+    const theme = sanitizeThemeNameServer(sessionRow?.theme || DEFAULT_THEME);
+    const avatar = avatarUrlFromRow(sessionRow) || "";
+    const avatarUpdated = sessionRow?.avatar_updated ?? sessionRow?.avatarUpdated ?? null;
+
+    clearPasswordUpgradeFailures(req);
+    delete req.session.passwordUpgrade;
+
+    req.session.regenerate((regenErr) => {
+      if (regenErr) return res.status(500).json({ ok: false, message: "Session failed." });
+      req.session.user = {
+        id: userId,
+        username: sessionRow?.username || pending.username,
+        role,
+        theme,
+        avatar,
+        avatar_updated: avatarUpdated,
+      };
+      dbRunAsync("UPDATE users SET last_seen = ?, last_status = ? WHERE id = ?", [Date.now(), "Online", userId]).catch(() => {});
+      if (!pgUser && sqliteRow) {
+        awardLoginXp(userId, role);
+        awardDailyLoginGold(sqliteRow);
+      }
+      initGoldTick(userId);
+      logSecurityEvent("password_upgrade_success", { ip, userId, username: sessionRow?.username || pending.username });
+      req.session.save((saveErr) => {
+        if (saveErr) return res.status(500).json({ ok: false, message: "Session save failed." });
+        return res.json({ ok: true });
+      });
+    });
+  } catch (e) {
+    console.error(e);
+    return res.status(500).json({ ok: false, message: "Password upgrade failed." });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Plan: enforce a mandatory server-side password upgrade for logins where the typed password is < 12 chars by creating a short-lived "passwordUpgrade" session state and returning a response that triggers a blocking client UI until the user upgrades their password.
- This closes a security gap introduced by recent hardening while preserving existing login/session semantics, avoiding plaintext storage, and preventing session fixation.

### Description
- Server changes (`server.js`): added `crypto` import, extended common-password denylist, introduced `passwordUpgradeLimiter` and per-session attempt tracking (`passwordUpgradeAttempts`) with lockout, and added audit events `password_upgrade_required`, `password_upgrade_failed`, and `password_upgrade_success` (no passwords logged). Modified `/login` to set `req.session.passwordUpgrade = { userId, username, issuedAt, nonce }` when a valid credential is used but the typed password is < 12 chars, and to return `{ ok: false, code: "PASSWORD_UPGRADE_REQUIRED" }`. Added endpoints `GET /password-upgrade/status`, `GET /password-upgrade` (serves SPA), and `POST /password-upgrade` which re-authenticates current password, validates new password rules (>=12, confirm match, denylist), rate-limits attempts, updates bcrypt hash (12 rounds), regenerates session, and sets normal `req.session.user` on success.
- Client changes (`public/app.js`, `public/index.html`, `public/styles.css`): added a blocking password-upgrade view and minimal styles, wired the SPA to detect a `PASSWORD_UPGRADE_REQUIRED` login response and call `/password-upgrade/status`, show the blocking overlay, accept `currentPassword`, `newPassword`, `confirmPassword`, post to `/password-upgrade` with the session nonce, handle loading / error states, and reload the app on success. The upgrade UI is keyboard-safe for mobile, uses `type="password"` inputs, prevents double-submit, and provides simple strength hints.
- Other notes: the flow is session-bound (cannot upgrade arbitrary user id), compares current password server-side against stored hash (bcrypt or legacy), clears per-session attempt state on success, and regenerates the session to prevent fixation. No new DB schema was added and plaintext passwords are never stored or logged.

### Testing
- Automated: ran `npm run check` (which executes `node --check` for server and client scripts); the check completed successfully.
- No unit tests were added in this change; manual smoke tested that the blocking view renders in the SPA (screenshot produced during development).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e3fd717c83338ab0318ed130eeda)