### PR TITLE
Fix Dice Room media button routing; add dice variants, animations, and session streaks

### DIFF
--- a/dice-utils.js
+++ b/dice-utils.js
@@ -1,0 +1,43 @@
+const DICE_VARIANTS = ["d6", "d20", "2d6", "d100"];
+
+const DICE_VARIANT_LABELS = {
+  d6: "d6",
+  d20: "d20",
+  "2d6": "2d6",
+  d100: "1–100",
+};
+
+function normalizeDiceVariant(variant) {
+  const v = String(variant || "").toLowerCase();
+  return DICE_VARIANTS.includes(v) ? v : null;
+}
+
+function rollDiceVariant(variant) {
+  const v = normalizeDiceVariant(variant) || "d6";
+  if (v === "2d6") {
+    const die1 = Math.floor(Math.random() * 6) + 1;
+    const die2 = Math.floor(Math.random() * 6) + 1;
+    const result = die1 + die2;
+    return {
+      variant: v,
+      result,
+      breakdown: [die1, die2],
+      won: result === 12,
+    };
+  }
+  const max = v === "d6" ? 6 : v === "d20" ? 20 : 100;
+  const result = Math.floor(Math.random() * max) + 1;
+  return {
+    variant: v,
+    result,
+    breakdown: null,
+    won: result === max,
+  };
+}
+
+module.exports = {
+  DICE_VARIANTS,
+  DICE_VARIANT_LABELS,
+  normalizeDiceVariant,
+  rollDiceVariant,
+};

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "echo \"No tests yet\" && exit 0",
+    "test:dice": "node scripts/dice-variant-smoke.js",
     "test:couples": "node scripts/couples-regression.js",
     "test:memory": "node scripts/memory-sanity.js",
     "check": "node --check server.js && node --check public/app.js && node --check public/theme-init.js && node --check database.js",

--- a/public/app.js
+++ b/public/app.js
@@ -757,7 +757,14 @@ let memorySettingsLoaded = false;
 let memoryFilter = "all";
 let memoryLoading = false;
 const memoryCacheByFilter = new Map();
-function displayRoomName(room){ return room==="diceroom" ? "Dice Room" : room; }
+const DICE_ROOM_ID = "diceroom";
+function isDiceRoom(activeRoom){
+  const roomName = typeof activeRoom === "string"
+    ? activeRoom
+    : (activeRoom?.name ?? activeRoom?.id ?? "");
+  return String(roomName || "").toLowerCase() === DICE_ROOM_ID;
+}
+function displayRoomName(room){ return isDiceRoom(room) ? "Dice Room" : room; }
 
 let lastUsers = [];
 let membersViewMode = "room"; // room|friends
@@ -1990,7 +1997,29 @@ let drawerTypingMode = false;
 let drawerFocusOutTimer = null;
 let activeDmUsers = new Set();
 let diceCooldownUntil = 0;
+const DICE_ROLL_COOLDOWN_MS = 1000;
 const DICE_FACES = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
+const DICE_VARIANTS = ["d6", "d20", "2d6", "d100"];
+const DICE_VARIANT_LABELS = {
+  d6: "d6",
+  d20: "d20",
+  "2d6": "2d6",
+  d100: "1–100",
+};
+const DICE_LUCKY_THRESHOLDS = {
+  d6: 6,
+  d20: 20,
+  "2d6": 12,
+  d100: 90,
+};
+let diceVariant = "d6";
+let diceVariantMenuOpen = false;
+const diceSessionStats = {
+  consecutiveRolls: 0,
+  highestRoll: 0,
+  luckyStreak: 0,
+  lastRollAt: 0,
+};
 
 const THEME_LIST = [
   { name: "Minimal Dark", mode: "Dark" },
@@ -2563,6 +2592,9 @@ const mediaMenuImage = document.getElementById("mediaMenuImage");
 const mediaMenuAudioUpload = document.getElementById("mediaMenuAudioUpload");
 const mediaMenuVoice = document.getElementById("mediaMenuVoice");
 const mediaVoiceLabel = document.getElementById("mediaVoiceLabel");
+const diceVariantToggle = document.getElementById("diceVariantToggle");
+const diceVariantMenu = document.getElementById("diceVariantMenu");
+const diceVariantLabel = document.getElementById("diceVariantLabel");
 
 let mediaMenuOpen = false;
 let voiceRec = { recorder: null, stream: null, chunks: [], startedAt: 0 };
@@ -2582,6 +2614,110 @@ function openMediaMenu(){
 function toggleMediaMenu(){
   if(mediaMenuOpen) closeMediaMenu();
   else openMediaMenu();
+}
+
+function updateDiceVariantLabel(){
+  if (!diceVariantLabel) return;
+  diceVariantLabel.textContent = DICE_VARIANT_LABELS[diceVariant] || diceVariant;
+}
+
+function closeDiceVariantMenu(){
+  if (!diceVariantMenu) return;
+  diceVariantMenuOpen = false;
+  diceVariantMenu.hidden = true;
+  diceVariantToggle?.setAttribute("aria-expanded", "false");
+}
+
+function openDiceVariantMenu(){
+  if (!diceVariantMenu) return;
+  diceVariantMenuOpen = true;
+  diceVariantMenu.hidden = false;
+  diceVariantToggle?.setAttribute("aria-expanded", "true");
+}
+
+function toggleDiceVariantMenu(){
+  if (diceVariantMenuOpen) closeDiceVariantMenu();
+  else openDiceVariantMenu();
+}
+
+function setDiceVariant(nextVariant){
+  if (!DICE_VARIANTS.includes(nextVariant)) return;
+  diceVariant = nextVariant;
+  updateDiceVariantLabel();
+  if (diceVariantMenu) {
+    diceVariantMenu.querySelectorAll("[data-variant]").forEach((btn) => {
+      const isActive = btn.dataset.variant === nextVariant;
+      btn.classList.toggle("active", isActive);
+      btn.setAttribute("aria-checked", String(isActive));
+    });
+  }
+}
+
+setDiceVariant(diceVariant);
+
+function resetDiceSessionStats(){
+  diceSessionStats.consecutiveRolls = 0;
+  diceSessionStats.highestRoll = 0;
+  diceSessionStats.luckyStreak = 0;
+  diceSessionStats.lastRollAt = 0;
+}
+
+function isHighRoll(variant, result){
+  const threshold = DICE_LUCKY_THRESHOLDS[variant];
+  if (!threshold) return false;
+  return result >= threshold;
+}
+
+function updateDiceSessionStats(payload){
+  if (!payload || payload.userId !== me?.id) return;
+  const now = Date.now();
+  if (diceSessionStats.lastRollAt && now - diceSessionStats.lastRollAt > 5 * 60 * 1000) {
+    diceSessionStats.consecutiveRolls = 0;
+    diceSessionStats.luckyStreak = 0;
+  }
+  diceSessionStats.lastRollAt = now;
+  diceSessionStats.consecutiveRolls += 1;
+
+  const result = Number(payload.result ?? payload.value ?? 0);
+  if (result > diceSessionStats.highestRoll) {
+    diceSessionStats.highestRoll = result;
+    toast?.(`🎯 New high: ${result}`);
+  }
+
+  if (isHighRoll(payload.variant, result)) {
+    diceSessionStats.luckyStreak += 1;
+  } else {
+    diceSessionStats.luckyStreak = 0;
+  }
+
+  if (diceSessionStats.luckyStreak === 3) {
+    toast?.("🔥 Lucky Streak x3");
+  }
+
+  if (diceSessionStats.consecutiveRolls === 5 || diceSessionStats.consecutiveRolls === 10) {
+    toast?.(`🔥 ${diceSessionStats.consecutiveRolls} roll streak!`);
+  }
+}
+
+function triggerDiceButtonShake(){
+  if (!mediaBtn || PREFERS_REDUCED_MOTION) return;
+  mediaBtn.classList.remove("diceShaking");
+  void mediaBtn.offsetWidth;
+  mediaBtn.classList.add("diceShaking");
+  mediaBtn.addEventListener("animationend", () => mediaBtn.classList.remove("diceShaking"), { once:true });
+}
+
+function rollDiceImmediate(nextVariant = diceVariant){
+  if (!socket || !isDiceRoom(currentRoom)) return;
+  const now = Date.now();
+  if (now < diceCooldownUntil) {
+    const left = Math.max(1, Math.ceil((diceCooldownUntil - now) / 1000));
+    addSystem(`Roll available in ${left}s`);
+    return;
+  }
+  diceCooldownUntil = now + DICE_ROLL_COOLDOWN_MS;
+  triggerDiceButtonShake();
+  socket.emit("dice:roll", { room: currentRoom, variant: nextVariant, clientTs: now });
 }
 
 if(chatShell){
@@ -4324,9 +4460,18 @@ function clearMsgs(){
   unseenMainMessages = 0;
   updateJumpToLatestButton();
 }
-function addSystem(text){
+function isDiceResultSystemMessage(text){
+  if (!isDiceRoom(currentRoom)) return false;
+  const raw = String(text || "");
+  const hasRoll = /rolled/i.test(raw);
+  const hasDiceHint = /[⚀⚁⚂⚃⚄⚅]|d6|d20|2d6|1–100|1-100|d100|🎲/i.test(raw);
+  return hasRoll && hasDiceHint;
+}
+
+function addSystem(text, options = {}){
   const div=document.createElement("div");
   div.className="sys";
+  if (options.className) div.classList.add(options.className);
 
   // Dice Room: make system messages larger, and make dice faces much more visible
   if(currentRoom === "diceroom"){
@@ -7994,17 +8139,13 @@ profileSettingsBtn?.addEventListener("click", async () => {
 });
 
 // unified media button
-mediaBtn?.addEventListener("click", () => {
+mediaBtn?.addEventListener("click", (e) => {
   // Dice Room keeps the "tap to roll" affordance
-  if (currentRoom === "diceroom") {
-    const now = Date.now();
-    if (now < diceCooldownUntil) {
-      const left = Math.max(1, Math.ceil((diceCooldownUntil - now) / 1000));
-      addSystem(`Roll available in ${left}s`);
-      return;
-    }
-    diceCooldownUntil = now + 3000;
-    socket?.emit("dice:roll");
+  if (isDiceRoom(currentRoom)) {
+    e?.preventDefault();
+    e?.stopPropagation();
+    e?.stopImmediatePropagation();
+    rollDiceImmediate(diceVariant);
     return;
   }
   toggleMediaMenu();
@@ -8029,6 +8170,31 @@ mediaMenuAudioUpload?.addEventListener("click", () => {
   closeMediaMenu();
   audioFileInput?.click();
 });
+
+diceVariantToggle?.addEventListener("click", (e) => {
+  if (!isDiceRoom(currentRoom)) return;
+  e.preventDefault();
+  e.stopPropagation();
+  toggleDiceVariantMenu();
+});
+
+diceVariantMenu?.addEventListener("click", (e) => {
+  const btn = e.target.closest("[data-variant]");
+  if (!btn) return;
+  e.preventDefault();
+  e.stopPropagation();
+  const nextVariant = btn.dataset.variant;
+  setDiceVariant(nextVariant);
+  closeDiceVariantMenu();
+});
+
+document.addEventListener("pointerdown", (e) => {
+  if (!diceVariantMenuOpen) return;
+  const t = e.target;
+  if (!t) return;
+  if (diceVariantMenu?.contains(t) || diceVariantToggle?.contains(t)) return;
+  closeDiceVariantMenu();
+}, { capture:true });
 
 async function startVoiceRecording(){
   if (voiceRec.recorder) return;
@@ -8565,8 +8731,10 @@ modal.addEventListener("click", (e)=>{ if(e.target===modal) closeModal(); });
 
 // rooms
 function setActiveRoom(room){
+  const wasDiceRoom = isDiceRoom(currentRoom);
   currentRoom = room;
-  document.body.classList.toggle("dice-room", room === "diceroom");
+  const nowDiceRoom = isDiceRoom(room);
+  document.body.classList.toggle("dice-room", nowDiceRoom);
   nowRoom.textContent = displayRoomName(room);
   roomTitle.textContent = displayRoomName(room);
   msgInput.placeholder = `Message ${displayRoomName(room)}`;
@@ -8575,14 +8743,18 @@ function setActiveRoom(room){
 
   // Dice Room: swap media button to dice roll
   try { closeMediaMenu(); } catch {}
+  try { closeDiceVariantMenu(); } catch {}
   if (mediaBtn) {
-    if (room === "diceroom") {
+    if (nowDiceRoom) {
       mediaBtn.textContent = "🎲";
       mediaBtn.title = "Roll Dice";
     } else {
       mediaBtn.textContent = "＋";
       mediaBtn.title = "Media";
     }
+  }
+  if (wasDiceRoom && !nowDiceRoom) {
+    resetDiceSessionStats();
   }
   document.querySelectorAll(".chan").forEach(el=>{
     el.classList.toggle("active", el.dataset.room === room);
@@ -13343,7 +13515,9 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   }
   updateRoomControlsVisibility();
 
-  socket.on("system", addSystem);
+  socket.on("system", (text) => {
+    addSystem(text, { className: isDiceResultSystemMessage(text) ? "diceResult" : "" });
+  });
 
   // Dice Room UI effects
   const diceOverlay = document.createElement("div");
@@ -13359,17 +13533,23 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   chatMain.appendChild(diceOverlay);
   chatMain.appendChild(confettiLayer);
 
-  function showDiceAnimation(finalValue, won){
+  function showDiceAnimation({ result, variant, won } = {}){
     const faces = ["⚀","⚁","⚂","⚃","⚄","⚅"];
+    const display = variant === "d6" ? (faces[(result || 1) - 1] || "🎲") : String(result ?? "🎲");
     diceOverlay.style.display = "flex";
     diceOverlay.textContent = "🎲";
+    if (PREFERS_REDUCED_MOTION) {
+      diceOverlay.textContent = display;
+      setTimeout(()=>{ diceOverlay.style.display="none"; }, 220);
+      return;
+    }
     let t = 0;
     const iv = setInterval(()=>{
       diceOverlay.textContent = faces[Math.floor(Math.random()*6)];
       t += 1;
       if (t >= 10){
         clearInterval(iv);
-        diceOverlay.textContent = faces[finalValue-1] || "🎲";
+        diceOverlay.textContent = display;
         setTimeout(()=>{ diceOverlay.style.display="none"; }, 350);
         if (won) popConfetti();
       }
@@ -13390,11 +13570,17 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
     setTimeout(()=>{ confettiLayer.style.display="none"; confettiLayer.innerHTML=""; }, 900);
   }
 
-  socket.on("dice:result", ({value, won}) => {
-    diceCooldownUntil = Date.now() + 3000;
-    showDiceAnimation(value, won);
-    // refresh gold display if you already have a refresh_toggle function
-    if (typeof refreshMe === "function") refreshMe();
+  socket.on("dice:result", (payload = {}) => {
+    const result = payload.result ?? payload.value;
+    const variant = payload.variant || "d6";
+    const won = !!payload.won;
+    showDiceAnimation({ result, variant, won });
+    if (payload.userId === me?.id) {
+      diceCooldownUntil = Date.now() + DICE_ROLL_COOLDOWN_MS;
+      updateDiceSessionStats(payload);
+      if (typeof refreshMe === "function") refreshMe();
+    }
+    if (payload.username) noteDiceRoll(payload.username, result);
   });
   socket.on("dice:error", (msg)=> {
     const m = String(msg||"");
@@ -13405,11 +13591,7 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
     }
     addSystem(msg);
   });
-  socket.on("dice:rolled", ({value, won, username}) => {
-    // show animation for other rollers too (nice-to-have)
-    showDiceAnimation(value, won);
-    if (username) noteDiceRoll(username, value);
-  });
+  updateDiceVariantLabel();
 
   socket.on("command response", handleCommandResponse);
   socket.on("user list", (users)=>{
@@ -14233,6 +14415,13 @@ function closeMediaSheet() {
 }
 
 mediaBtnEl?.addEventListener("click", e => {
+  if (isDiceRoom(currentRoom)) {
+    e.preventDefault();
+    e.stopPropagation();
+    e.stopImmediatePropagation();
+    rollDiceImmediate(diceVariant);
+    return;
+  }
   e.preventDefault();
   e.stopPropagation();
   openMediaSheet();

--- a/public/index.html
+++ b/public/index.html
@@ -421,6 +421,18 @@
 
   <!-- unified media button + pop-up menu -->
   <button class="iconBtn" id="mediaBtn" title="Media" type="button">＋</button>
+  <div class="diceVariantWrap" id="diceVariantWrap">
+    <button aria-expanded="false" aria-haspopup="menu" class="iconBtn diceVariantToggle" id="diceVariantToggle" title="Dice variants" type="button">
+      <span class="diceVariantLabel" id="diceVariantLabel">d6</span>
+      <span aria-hidden="true" class="diceVariantChevron">▾</span>
+    </button>
+    <div class="diceVariantMenu" hidden="" id="diceVariantMenu" role="menu">
+      <button aria-checked="true" class="diceVariantOption active" data-variant="d6" role="menuitemradio" type="button">d6</button>
+      <button aria-checked="false" class="diceVariantOption" data-variant="d20" role="menuitemradio" type="button">d20</button>
+      <button aria-checked="false" class="diceVariantOption" data-variant="2d6" role="menuitemradio" type="button">2d6</button>
+      <button aria-checked="false" class="diceVariantOption" data-variant="d100" role="menuitemradio" type="button">1–100</button>
+    </div>
+  </div>
   <div class="mediaMenu" hidden="" id="mediaMenu">
     <button class="mediaMenuItem" id="mediaMenuImage" type="button" title="Upload image">
       <span class="mediaIcon">🖼️</span><span class="mediaLabel">Image</span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2975,6 +2975,65 @@ body.dice-room .sys .diceFace{
   font-size:26px;
   line-height:1;
 }
+#mediaBtn.diceShaking{
+  animation: diceShake 320ms ease-in-out;
+}
+.diceVariantWrap{
+  display:none;
+  position:relative;
+}
+body.dice-room .diceVariantWrap{
+  display:inline-flex;
+}
+.diceVariantToggle{
+  height:44px;
+  border-radius:14px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
+  padding:0 12px;
+  font-size:12px;
+  font-weight:800;
+  line-height:1;
+}
+.diceVariantChevron{
+  font-size:11px;
+  opacity:0.7;
+}
+.diceVariantMenu{
+  position:absolute;
+  left:0;
+  bottom: calc(100% + 10px);
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  padding:10px;
+  border-radius:14px;
+  border:1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 85%, transparent);
+  box-shadow: var(--shadowMd);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  z-index: 210;
+  min-width:96px;
+}
+.diceVariantMenu[hidden]{ display:none; }
+.diceVariantOption{
+  border:0;
+  background: color-mix(in srgb, var(--panel2) 70%, transparent);
+  color: var(--text);
+  padding:8px 10px;
+  border-radius:12px;
+  font-size:13px;
+  font-weight:700;
+  cursor:pointer;
+  text-align:left;
+}
+.diceVariantOption.active{
+  background: color-mix(in srgb, var(--accent) 22%, var(--panel2));
+  color: var(--textStrong, var(--text));
+}
 .mediaMenu{
   position:absolute;
   left:12px;
@@ -4054,6 +4113,32 @@ body.lockScroll{ overflow:hidden; }
   background: transparent;
   padding:0;
   cursor:pointer;
+}
+
+.sys.diceResult{
+  animation: diceResultPop 240ms ease-out;
+}
+
+@keyframes diceShake{
+  0%{ transform: translateX(0) rotate(0); }
+  20%{ transform: translateX(-2px) rotate(-6deg); }
+  40%{ transform: translateX(2px) rotate(6deg); }
+  60%{ transform: translateX(-2px) rotate(-4deg); }
+  80%{ transform: translateX(2px) rotate(4deg); }
+  100%{ transform: translateX(0) rotate(0); }
+}
+
+@keyframes diceResultPop{
+  0%{ transform: scale(0.96); }
+  55%{ transform: scale(1.03); }
+  100%{ transform: scale(1); }
+}
+
+@media (prefers-reduced-motion: reduce){
+  #mediaBtn.diceShaking,
+  .sys.diceResult{
+    animation:none !important;
+  }
 }
 .dmAvatarBtn .avatar{
   width:28px;

--- a/scripts/dice-variant-smoke.js
+++ b/scripts/dice-variant-smoke.js
@@ -1,0 +1,35 @@
+const assert = require("assert");
+const { DICE_VARIANTS, normalizeDiceVariant, rollDiceVariant } = require("../dice-utils");
+
+const runs = 50;
+
+assert.strictEqual(normalizeDiceVariant("d6"), "d6");
+assert.strictEqual(normalizeDiceVariant("D20"), "d20");
+assert.strictEqual(normalizeDiceVariant("2d6"), "2d6");
+assert.strictEqual(normalizeDiceVariant("d100"), "d100");
+assert.strictEqual(normalizeDiceVariant("nope"), null);
+
+for (const variant of DICE_VARIANTS) {
+  for (let i = 0; i < runs; i += 1) {
+    const roll = rollDiceVariant(variant);
+    assert.strictEqual(roll.variant, variant);
+    if (variant === "d6") {
+      assert.ok(roll.result >= 1 && roll.result <= 6);
+      assert.strictEqual(roll.won, roll.result === 6);
+    } else if (variant === "d20") {
+      assert.ok(roll.result >= 1 && roll.result <= 20);
+      assert.strictEqual(roll.won, roll.result === 20);
+    } else if (variant === "2d6") {
+      assert.ok(roll.result >= 2 && roll.result <= 12);
+      assert.ok(Array.isArray(roll.breakdown));
+      assert.strictEqual(roll.breakdown.length, 2);
+      assert.strictEqual(roll.result, roll.breakdown[0] + roll.breakdown[1]);
+      assert.strictEqual(roll.won, roll.result === 12);
+    } else if (variant === "d100") {
+      assert.ok(roll.result >= 1 && roll.result <= 100);
+      assert.strictEqual(roll.won, roll.result === 100);
+    }
+  }
+}
+
+console.log("dice-variant-smoke: ok");

--- a/server.js
+++ b/server.js
@@ -37,6 +37,8 @@ const ONLINE_USERS = new Set();
 // --- Owner session map (in-memory)
 const sessionMetaBySocketId = new Map(); // socket.id -> meta
 const sessionByUserId = new Map(); // userId -> Set(socket.id)
+const DICE_ROLL_MIN_INTERVAL_MS = 1000;
+const diceRollRateByUserId = new Map();
 
 // --- Behaviour heat score (in-memory; admin/owner only)
 const heatByUserId = new Map(); // userId -> number
@@ -98,6 +100,7 @@ const rateLimit = require("express-rate-limit");
 const multer = require("multer");
 const { Pool } = require("pg");
 const http = require("http");
+const { DICE_VARIANTS, DICE_VARIANT_LABELS, normalizeDiceVariant, rollDiceVariant } = require("./dice-utils");
 
 // ---- Safety nets (prevents silent crashes in prod) ----
 process.on("unhandledRejection", (err) => {
@@ -9338,15 +9341,49 @@ socket.on("join room", ({ room, status }) => {
 });
 
   // Dice Room mini-game
-  socket.on("dice:roll", () => {
+  socket.on("dice:roll", (payload = {}) => {
     const room = socket.currentRoom;
+    const requestedRoom = typeof payload.room === "string" ? sanitizeRoomName(payload.room) : null;
+    if (requestedRoom && requestedRoom !== room) {
+      socket.emit("dice:error", "Invalid room for dice roll.");
+      return;
+    }
     if (room !== "diceroom") {
       socket.emit("dice:error", "You can only roll dice in Dice Room.");
       return;
     }
 
+    const variant = normalizeDiceVariant(payload.variant);
+    if (!variant || !DICE_VARIANTS.includes(variant)) {
+      socket.emit("dice:error", "Invalid dice variant.");
+      return;
+    }
+
     const now = Date.now();
     const uid = socket.user.id;
+    const lastLocal = diceRollRateByUserId.get(uid) || 0;
+    if (now - lastLocal < DICE_ROLL_MIN_INTERVAL_MS) {
+      socket.emit(
+        "dice:error",
+        `Roll available in ${Math.ceil((DICE_ROLL_MIN_INTERVAL_MS - (now - lastLocal)) / 1000)}s.`
+      );
+      return;
+    }
+    diceRollRateByUserId.set(uid, now);
+
+    const formatDiceSystemMessage = ({ result, breakdown, won, deltaGold }) => {
+      const faceMap = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
+      let display = String(result);
+      if (variant === "d6") {
+        display = faceMap[result - 1] || result;
+      } else if (variant === "2d6" && Array.isArray(breakdown)) {
+        display = `${result} (2d6: ${breakdown.join("+")})`;
+      } else {
+        display = `${result} (${DICE_VARIANT_LABELS[variant] || variant})`;
+      }
+      const suffix = won ? "🎉 (+500 Gold!)" : "🎲 (-50 Gold!)";
+      return `${socket.user.username} rolled ${display} ${suffix}`;
+    };
 
     (async () => {
       try {
@@ -9358,8 +9395,11 @@ socket.on("join room", ({ room, status }) => {
           }
 
           const last = Number(row.lastDiceRollAt || 0);
-          if (now - last < 3000) {
-            socket.emit("dice:error", `Roll available in ${Math.ceil((3000 - (now - last)) / 1000)}s.`);
+          if (now - last < DICE_ROLL_MIN_INTERVAL_MS) {
+            socket.emit(
+              "dice:error",
+              `Roll available in ${Math.ceil((DICE_ROLL_MIN_INTERVAL_MS - (now - last)) / 1000)}s.`
+            );
             return;
           }
 
@@ -9369,10 +9409,9 @@ socket.on("join room", ({ room, status }) => {
             return;
           }
 
-          const value = Math.floor(Math.random() * 6) + 1; // 1..6
-          const won = value === 6;
-          const deltaGold = won ? 500 : -50;
-          const sixGain = won ? 1 : 0;
+          const roll = rollDiceVariant(variant);
+          const deltaGold = roll.won ? 500 : -50;
+          const sixGain = variant === "d6" && roll.won ? 1 : 0;
 
           await pgPool.query(
             `UPDATE users
@@ -9383,26 +9422,37 @@ socket.on("join room", ({ room, status }) => {
             [deltaGold, now, sixGain, uid]
           );
 
-          socket.emit("dice:result", { value, won, deltaGold });
+          const payloadBase = {
+            userId: uid,
+            username: socket.user.username,
+            variant,
+            result: roll.result,
+            value: roll.result,
+            breakdown: roll.breakdown,
+            won: roll.won,
+            serverTs: now,
+          };
+
+          socket.emit("dice:result", { ...payloadBase, deltaGold });
+          socket.to(room).emit("dice:result", payloadBase);
           emitProgressionUpdate(uid);
 
-          const faces = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
-          const face = faces[value - 1] || value;
-          const msg = won
-            ? `${socket.user.username} rolled ${face} 🎉 (+500 Gold!)`
-            : `${socket.user.username} rolled ${face} 🎲 (-50 Gold!)`;
-          io.to(room).emit("system", msg);
+          io.to(room).emit("system", formatDiceSystemMessage({ ...roll, deltaGold }));
 
-          io.to(room).emit("dice:rolled", { userId: uid, username: socket.user.username, value, won });
-          if (won) {
-            void ensureMemory(uid, "dice_jackpot", {
-              type: "rare",
-              title: "Dice jackpot!",
-              description: "Landed the jackpot roll in Dice Room.",
-              icon: "🎲",
-              room_id: room,
-              metadata: { value, deltaGold },
-            }, socket.user);
+          if (roll.won) {
+            void ensureMemory(
+              uid,
+              "dice_jackpot",
+              {
+                type: "rare",
+                title: "Dice jackpot!",
+                description: "Landed the jackpot roll in Dice Room.",
+                icon: "🎲",
+                room_id: room,
+                metadata: { value: roll.result, deltaGold, variant },
+              },
+              socket.user
+            );
           }
           return;
         }
@@ -9418,8 +9468,11 @@ socket.on("join room", ({ room, status }) => {
         }
 
         const last = Number(row.lastDiceRollAt || 0);
-        if (now - last < 3000) {
-          socket.emit("dice:error", `Roll available in ${Math.ceil((3000 - (now - last)) / 1000)}s.`);
+        if (now - last < DICE_ROLL_MIN_INTERVAL_MS) {
+          socket.emit(
+            "dice:error",
+            `Roll available in ${Math.ceil((DICE_ROLL_MIN_INTERVAL_MS - (now - last)) / 1000)}s.`
+          );
           return;
         }
 
@@ -9429,10 +9482,9 @@ socket.on("join room", ({ room, status }) => {
           return;
         }
 
-        const value = Math.floor(Math.random() * 6) + 1; // 1..6
-        const won = value === 6;
-        const deltaGold = won ? 500 : -50;
-        const sixGain = won ? 1 : 0;
+        const roll = rollDiceVariant(variant);
+        const deltaGold = roll.won ? 500 : -50;
+        const sixGain = variant === "d6" && roll.won ? 1 : 0;
 
         db.run(
           `UPDATE users SET gold = MAX(0, gold + ?), lastDiceRollAt=?, dice_sixes = dice_sixes + ? WHERE id=?`,
@@ -9443,26 +9495,37 @@ socket.on("join room", ({ room, status }) => {
               return;
             }
 
-            socket.emit("dice:result", { value, won, deltaGold });
+            const payloadBase = {
+              userId: uid,
+              username: socket.user.username,
+              variant,
+              result: roll.result,
+              value: roll.result,
+              breakdown: roll.breakdown,
+              won: roll.won,
+              serverTs: now,
+            };
+
+            socket.emit("dice:result", { ...payloadBase, deltaGold });
+            socket.to(room).emit("dice:result", payloadBase);
             emitProgressionUpdate(uid);
 
-            const faces = ["⚀", "⚁", "⚂", "⚃", "⚄", "⚅"];
-            const face = faces[value - 1] || value;
-            const msg = won
-              ? `${socket.user.username} rolled ${face} 🎉 (+500 Gold!)`
-              : `${socket.user.username} rolled ${face} 🎲 (-50 Gold!)`;
-            io.to(room).emit("system", msg);
+            io.to(room).emit("system", formatDiceSystemMessage({ ...roll, deltaGold }));
 
-            io.to(room).emit("dice:rolled", { userId: uid, username: socket.user.username, value, won });
-            if (won) {
-              void ensureMemory(uid, "dice_jackpot", {
-                type: "rare",
-                title: "Dice jackpot!",
-                description: "Landed the jackpot roll in Dice Room.",
-                icon: "🎲",
-                room_id: room,
-                metadata: { value, deltaGold },
-              }, socket.user);
+            if (roll.won) {
+              void ensureMemory(
+                uid,
+                "dice_jackpot",
+                {
+                  type: "rare",
+                  title: "Dice jackpot!",
+                  description: "Landed the jackpot roll in Dice Room.",
+                  icon: "🎲",
+                  room_id: room,
+                  metadata: { value: roll.result, deltaGold, variant },
+                },
+                socket.user
+              );
             }
           }
         );


### PR DESCRIPTION
### Motivation
- Prevent the Dice Room media button from opening the global media menu and make the dice button context-aware so rolling is immediate in Dice Room.
- Provide a small Dice Room–scoped UX for selecting roll variants and deliver consistent server-side roll generation and validation.
- Add lightweight roll/result animations and session-only streak/achievement feedback to make rolling more fun without persisting additional data.

### Description
- Client: add `isDiceRoom`, `rollDiceImmediate`, a tiny `diceVariant` picker UI anchored next to the media/dice button, and logic to stop event propagation so the media menu does not open in Dice Room; the composer button now rolls immediately when in Dice Room and opens media elsewhere.
- Client: implement a small variant picker (d6, d20, 2d6, 1–100), a shake animation on roll, a pop animation for result system messages, and session-only streak tracking (consecutive rolls, highest roll, lucky streak toasts); animations respect `prefers-reduced-motion`.
- Server: add shared `dice-utils.js` and wire server-side `dice:roll` handling to validate variants, enforce a per-user rate limit, generate roll results (server RNG), and emit `dice:result` payloads to the room with `{ userId, username, variant, result, breakdown?, won, serverTs }`.
- Files added/modified: `dice-utils.js` (new), `scripts/dice-variant-smoke.js` (new), `server.js` (dice:roll validation/rate-limit/results), `public/app.js` (routing, picker, animations, streaks), `public/index.html` (picker markup), `public/styles.css` (scoped styles/animations), `package.json` (test script).

### Testing
- Ran `npm run check` (syntax/quick checks via `node --check`) and it completed successfully.
- Ran the new smoke script `npm run test:dice` which executed `scripts/dice-variant-smoke.js` and reported success.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2601b4b88333a2b706af33079f4c)