### PR TITLE
Add nested room hierarchy (masters → categories → rooms), owner management UI, and persistence

### DIFF
--- a/database.js
+++ b/database.js
@@ -72,6 +72,90 @@ async function seedDefaultRooms() {
   }
 }
 
+async function ensureRoomHierarchySqlite() {
+  const now = Date.now();
+  await run(`
+    CREATE TABLE IF NOT EXISTS room_master_categories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT UNIQUE NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL
+    )
+  `);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS room_categories (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      master_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      created_at INTEGER NOT NULL,
+      UNIQUE(master_id, name)
+    )
+  `);
+
+  await run(`CREATE INDEX IF NOT EXISTS idx_room_categories_master ON room_categories(master_id)`);
+
+  await ensureColumns("rooms", [
+    ["category_id", "category_id INTEGER"],
+    ["room_sort_order", "room_sort_order INTEGER NOT NULL DEFAULT 0"],
+    ["created_by_user_id", "created_by_user_id INTEGER"],
+    ["is_user_room", "is_user_room INTEGER NOT NULL DEFAULT 0"],
+  ]);
+
+  await ensureColumns("users", [
+    ["room_master_collapsed", "room_master_collapsed TEXT NOT NULL DEFAULT '{}'"],
+    ["room_category_collapsed", "room_category_collapsed TEXT NOT NULL DEFAULT '{}'"],
+  ]);
+
+  const masterSeed = [
+    { name: "Site Rooms", sort_order: 0 },
+    { name: "User Rooms", sort_order: 1 },
+  ];
+
+  for (const m of masterSeed) {
+    await run(
+      `INSERT OR IGNORE INTO room_master_categories (name, sort_order, created_at) VALUES (?, ?, ?)`,
+      [m.name, m.sort_order, now]
+    );
+  }
+
+  const masters = await all(`SELECT id, name FROM room_master_categories`);
+  const masterByName = new Map(masters.map((m) => [m.name, m.id]));
+
+  for (const master of masters) {
+    await run(
+      `INSERT OR IGNORE INTO room_categories (master_id, name, sort_order, created_at) VALUES (?, 'Uncategorized', 0, ?)`,
+      [master.id, now]
+    );
+  }
+
+  const categories = await all(
+    `SELECT id, master_id, name FROM room_categories WHERE lower(name) = 'uncategorized'`
+  );
+  const uncategorizedByMasterId = new Map(categories.map((c) => [c.master_id, c.id]));
+
+  const rooms = await all(
+    `SELECT name, category_id, created_by, created_by_user_id, is_user_room FROM rooms`
+  );
+
+  for (const room of rooms) {
+    if (room.category_id != null) continue;
+    const createdBy = room.created_by_user_id ?? room.created_by ?? null;
+    const isUserRoom = Number(room.is_user_room || 0) === 1 || createdBy != null;
+    const masterName = isUserRoom ? "User Rooms" : "Site Rooms";
+    const masterId = masterByName.get(masterName);
+    const categoryId = masterId ? uncategorizedByMasterId.get(masterId) : null;
+    if (!categoryId) continue;
+    await run(`UPDATE rooms SET category_id=?, room_sort_order=COALESCE(room_sort_order, 0) WHERE name=?`, [
+      categoryId,
+      room.name,
+    ]);
+  }
+
+  await run(`UPDATE rooms SET room_sort_order=0 WHERE room_sort_order IS NULL`);
+}
+
 async function runSqliteMigrations() {
   await run(`
     CREATE TABLE IF NOT EXISTS users (
@@ -105,6 +189,8 @@ async function runSqliteMigrations() {
     ["pinned_message_ids", "pinned_message_ids TEXT"],
     ["maintenance_mode", "maintenance_mode INTEGER NOT NULL DEFAULT 0"],
   ]);
+
+  await ensureRoomHierarchySqlite();
 
   await seedDefaultRooms();
 

--- a/public/app.js
+++ b/public/app.js
@@ -756,6 +756,8 @@ let memoryEnabled = false;
 let memorySettingsLoaded = false;
 let memoryFilter = "all";
 let memoryLoading = false;
+let roomStructure = { masters: [], categories: [], rooms: [] };
+let roomCollapseState = { master: {}, category: {} };
 const memoryCacheByFilter = new Map();
 const DICE_ROOM_ID = "diceroom";
 function isDiceRoom(activeRoom){
@@ -2212,6 +2214,7 @@ const appealsUnlockBtn = document.getElementById("appealsUnlockBtn");
 
 const app = document.getElementById("app");
 const addRoomBtn = document.getElementById("addRoomBtn");
+const manageRoomsBtn = document.getElementById("manageRoomsBtn");
 const menuToggleBtn = document.getElementById("menuToggleBtn");
 const chanHeaderTitle = document.getElementById("chanHeaderTitle");
 const roomsPanel = document.getElementById("roomsPanel");
@@ -2225,6 +2228,29 @@ const latestUpdateViewBtn = document.getElementById("latestUpdateViewBtn");
 const latestUpdateReactions = document.getElementById("latestUpdateReactions");
 let latestUpdateExpanded = false;
 const changelogList = document.getElementById("changelogList");
+const roomManageModal = document.getElementById("roomManageModal");
+const roomManageCloseBtn = document.getElementById("roomManageCloseBtn");
+const roomMasterCreateInput = document.getElementById("roomMasterCreateInput");
+const roomMasterCreateBtn = document.getElementById("roomMasterCreateBtn");
+const roomMasterList = document.getElementById("roomMasterList");
+const roomMasterMsg = document.getElementById("roomMasterMsg");
+const roomCategoryMasterSelect = document.getElementById("roomCategoryMasterSelect");
+const roomCategoryCreateInput = document.getElementById("roomCategoryCreateInput");
+const roomCategoryCreateBtn = document.getElementById("roomCategoryCreateBtn");
+const roomCategoryList = document.getElementById("roomCategoryList");
+const roomCategoryMsg = document.getElementById("roomCategoryMsg");
+const roomManageMasterSelect = document.getElementById("roomManageMasterSelect");
+const roomManageCategorySelect = document.getElementById("roomManageCategorySelect");
+const roomManageRoomList = document.getElementById("roomManageRoomList");
+const roomManageMsg = document.getElementById("roomManageMsg");
+const roomCreateModal = document.getElementById("roomCreateModal");
+const roomCreateCloseBtn = document.getElementById("roomCreateCloseBtn");
+const roomCreateNameInput = document.getElementById("roomCreateNameInput");
+const roomCreateMasterSelect = document.getElementById("roomCreateMasterSelect");
+const roomCreateCategorySelect = document.getElementById("roomCreateCategorySelect");
+const roomCreateSubmitBtn = document.getElementById("roomCreateSubmitBtn");
+const roomCreateCancelBtn = document.getElementById("roomCreateCancelBtn");
+const roomCreateMsg = document.getElementById("roomCreateMsg");
 
 // Shared date formatter for Changelog + FAQ.
 // IMPORTANT: keep this at top-level so it is in scope everywhere.
@@ -8893,6 +8919,12 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && couplesModal && couplesModal.style.display !== "none") {
     closeCouplesModal();
   }
+  if (e.key === "Escape" && roomManageModal && roomManageModal.style.display !== "none") {
+    closeRoomManageModal();
+  }
+  if (e.key === "Escape" && roomCreateModal && roomCreateModal.style.display !== "none") {
+    closeRoomCreateModal();
+  }
 });
 
 closeModalBtn.addEventListener("click", closeModal);
@@ -8987,6 +9019,30 @@ function joinRoom(room){
   closeDrawers();
 }
 chanList.addEventListener("click", (e)=>{
+  const masterToggle = e.target.closest("[data-room-master-toggle]");
+  if(masterToggle){
+    const masterId = masterToggle.dataset.roomMasterToggle;
+    const wrapper = masterToggle.closest(".roomMaster");
+    if(wrapper){
+      const collapsed = !wrapper.classList.contains("collapsed");
+      wrapper.classList.toggle("collapsed", collapsed);
+      roomCollapseState.master[String(masterId)] = collapsed;
+      persistRoomMasterCollapse(masterId, collapsed);
+    }
+    return;
+  }
+  const categoryToggle = e.target.closest("[data-room-category-toggle]");
+  if(categoryToggle){
+    const categoryId = categoryToggle.dataset.roomCategoryToggle;
+    const wrapper = categoryToggle.closest(".roomCategory");
+    if(wrapper){
+      const collapsed = !wrapper.classList.contains("collapsed");
+      wrapper.classList.toggle("collapsed", collapsed);
+      roomCollapseState.category[String(categoryId)] = collapsed;
+      persistRoomCategoryCollapse(categoryId, collapsed);
+    }
+    return;
+  }
   const el=e.target.closest(".chan");
   if(!el) return;
   const r=el.dataset.room;
@@ -8998,30 +9054,287 @@ function sanitizeRoomClient(r){
   return r;
 }
 
-function renderRoomsList(rooms){
+function normalizeRoomStructurePayload(payload){
+  if(!payload || typeof payload !== "object") return null;
+  const masters = Array.isArray(payload.masters) ? payload.masters : [];
+  const categories = Array.isArray(payload.categories) ? payload.categories : [];
+  const rooms = Array.isArray(payload.rooms) ? payload.rooms : [];
+  const userCollapse = payload.userCollapse && typeof payload.userCollapse === "object" ? payload.userCollapse : null;
+  return { masters, categories, rooms, userCollapse };
+}
+
+function cleanCollapseMap(raw){
+  if(!raw || typeof raw !== "object") return {};
+  const out = {};
+  for(const [key, val] of Object.entries(raw)){
+    out[String(key)] = !!val;
+  }
+  return out;
+}
+
+function setRoomStructure(payload, { updateCollapse = true } = {}){
+  const normalized = normalizeRoomStructurePayload(payload);
+  if(!normalized) return false;
+  roomStructure = {
+    masters: normalized.masters,
+    categories: normalized.categories,
+    rooms: normalized.rooms,
+  };
+  if(updateCollapse && normalized.userCollapse){
+    roomCollapseState = {
+      master: cleanCollapseMap(normalized.userCollapse.master),
+      category: cleanCollapseMap(normalized.userCollapse.category),
+    };
+  }
+  renderRoomsList(roomStructure);
+  if(roomManageModal && roomManageModal.style.display !== "none" && !roomManageModal.hidden){
+    refreshRoomManageUi();
+  }
+  return true;
+}
+
+function sortByOrderThenName(a, b, orderKey){
+  const diff = Number(a?.[orderKey] || 0) - Number(b?.[orderKey] || 0);
+  if(diff !== 0) return diff;
+  return String(a?.name || "").localeCompare(String(b?.name || ""), undefined, { sensitivity: "base" });
+}
+
+function ensureDefaultMasters(masters){
+  const out = [...masters];
+  const byName = new Map(out.map((m) => [String(m.name || ""), m]));
+  if(!byName.has("Site Rooms")){
+    out.push({ id: "temp-site", name: "Site Rooms", sort_order: 0, temporary: true });
+  }
+  if(!byName.has("User Rooms")){
+    out.push({ id: "temp-user", name: "User Rooms", sort_order: 1, temporary: true });
+  }
+  return out;
+}
+
+function ensureUncategorized(categories, masterId){
+  const existing = categories.find((c) => String(c.master_id) === String(masterId) && String(c.name || "") === "Uncategorized");
+  if(existing) return existing;
+  return { id: `temp-uncat-${masterId}`, master_id: masterId, name: "Uncategorized", sort_order: 0, temporary: true };
+}
+
+function getDefaultMasterIds(masters){
+  const site = masters.find((m) => String(m.name || "") === "Site Rooms");
+  const user = masters.find((m) => String(m.name || "") === "User Rooms");
+  return { site: site?.id, user: user?.id };
+}
+
+function renderRoomsList(structureOrRooms){
+  if(Array.isArray(structureOrRooms)){
+    withFlip(chanList, "data-flip-key", () => {
+      chanList.innerHTML = "";
+      for(const r of structureOrRooms || []){
+        const div = document.createElement("div");
+        div.className = "chan" + (r === currentRoom ? " active" : "");
+        div.dataset.room = r;
+        div.dataset.flipKey = `room-${r}`;
+        div.textContent = displayRoomName(r);
+        chanList.appendChild(div);
+      }
+    });
+    return;
+  }
+
+  const payload = normalizeRoomStructurePayload(structureOrRooms) || { masters: [], categories: [], rooms: [] };
+  const masters = ensureDefaultMasters(payload.masters || []);
+  const categories = payload.categories || [];
+  const rooms = payload.rooms || [];
+  const categoriesByMaster = new Map();
+  const categoryById = new Map();
+  for(const cat of categories){
+    if(!cat) continue;
+    const masterId = cat.master_id;
+    if(!categoriesByMaster.has(masterId)) categoriesByMaster.set(masterId, []);
+    categoriesByMaster.get(masterId).push(cat);
+    categoryById.set(String(cat.id), cat);
+  }
+
+  const masterIds = getDefaultMasterIds(masters);
+  const fallbackCategories = new Map();
+  for(const master of masters){
+    const ensured = ensureUncategorized(categories, master.id);
+    fallbackCategories.set(String(master.id), ensured);
+    if(!categoriesByMaster.has(master.id)) categoriesByMaster.set(master.id, []);
+    if(ensured.temporary) categoriesByMaster.get(master.id).push(ensured);
+  }
+
+  const roomsByCategory = new Map();
+  for(const room of rooms){
+    const categoryId = room?.category_id;
+    if(categoryId && categoryById.has(String(categoryId))){
+      if(!roomsByCategory.has(String(categoryId))) roomsByCategory.set(String(categoryId), []);
+      roomsByCategory.get(String(categoryId)).push(room);
+      continue;
+    }
+
+    const isUserRoom = Number(room?.is_user_room || 0) === 1;
+    const fallbackMasterId = isUserRoom ? masterIds.user : masterIds.site;
+    const fallbackCategory = fallbackCategories.get(String(fallbackMasterId));
+    if(!fallbackCategory) continue;
+    const fallbackId = String(fallbackCategory.id);
+    if(!roomsByCategory.has(fallbackId)) roomsByCategory.set(fallbackId, []);
+    roomsByCategory.get(fallbackId).push({ ...room, category_id: fallbackCategory.id });
+  }
+
   withFlip(chanList, "data-flip-key", () => {
     chanList.innerHTML = "";
-    for(const r of rooms || []){
-      const div = document.createElement("div");
-      div.className = "chan" + (r === currentRoom ? " active" : "");
-      div.dataset.room = r;
-      div.dataset.flipKey = `room-${r}`;
-      div.textContent = displayRoomName(r); // no '#'
-      chanList.appendChild(div);
+    const sortedMasters = [...masters].sort((a, b) => sortByOrderThenName(a, b, "sort_order"));
+    for(const master of sortedMasters){
+      const masterId = master.id;
+      const masterWrap = document.createElement("div");
+      masterWrap.className = "roomMaster";
+      masterWrap.dataset.masterId = masterId;
+      if(roomCollapseState.master[String(masterId)]) masterWrap.classList.add("collapsed");
+
+      const masterHeader = document.createElement("button");
+      masterHeader.type = "button";
+      masterHeader.className = "roomMasterHeader";
+      masterHeader.dataset.roomMasterToggle = String(masterId);
+      masterHeader.innerHTML = `
+        <span class="roomHeaderLabel">
+          <span class="roomChevron">▾</span>
+          <span>${escapeHtml(master.name || "Rooms")}</span>
+        </span>
+      `;
+
+      const masterBody = document.createElement("div");
+      masterBody.className = "roomMasterBody";
+
+      const masterCategories = (categoriesByMaster.get(masterId) || [])
+        .sort((a, b) => sortByOrderThenName(a, b, "sort_order"));
+
+      for(const category of masterCategories){
+        const categoryId = category.id;
+        const categoryWrap = document.createElement("div");
+        categoryWrap.className = "roomCategory";
+        categoryWrap.dataset.categoryId = categoryId;
+        if(roomCollapseState.category[String(categoryId)]) categoryWrap.classList.add("collapsed");
+
+        const categoryHeader = document.createElement("button");
+        categoryHeader.type = "button";
+        categoryHeader.className = "roomCategoryHeader";
+        categoryHeader.dataset.roomCategoryToggle = String(categoryId);
+        categoryHeader.innerHTML = `
+          <span class="roomHeaderLabel">
+            <span class="roomChevron">▾</span>
+            <span>${escapeHtml(category.name || "Category")}</span>
+          </span>
+        `;
+
+        const categoryBody = document.createElement("div");
+        categoryBody.className = "roomCategoryBody";
+        const roomList = document.createElement("div");
+        roomList.className = "roomList";
+        const categoryRooms = (roomsByCategory.get(String(categoryId)) || [])
+          .sort((a, b) => sortByOrderThenName(a, b, "room_sort_order"));
+
+        for(const r of categoryRooms){
+          const name = r?.name || r;
+          if(!name) continue;
+          const div = document.createElement("div");
+          div.className = "chan" + (name === currentRoom ? " active" : "");
+          div.dataset.room = name;
+          div.dataset.flipKey = `room-${name}`;
+          div.textContent = displayRoomName(name);
+          roomList.appendChild(div);
+        }
+
+        categoryBody.appendChild(roomList);
+        categoryWrap.appendChild(categoryHeader);
+        categoryWrap.appendChild(categoryBody);
+        masterBody.appendChild(categoryWrap);
+      }
+
+      masterWrap.appendChild(masterHeader);
+      masterWrap.appendChild(masterBody);
+      chanList.appendChild(masterWrap);
     }
   });
 }
 
 async function loadRooms(){
   const {res, text} = await api("/rooms", { method:"GET" });
-  if(!res.ok) return;
+  if(!res.ok){
+    renderRoomsList((roomStructure.rooms || []).map((r) => r?.name || r).filter(Boolean));
+    return;
+  }
   try{
-    const rooms = JSON.parse(text);
-    renderRoomsList(rooms);
-  }catch{}
+    const payload = JSON.parse(text);
+    const applied = setRoomStructure(payload);
+    if(!applied && Array.isArray(payload)) renderRoomsList(payload);
+  }catch{
+    renderRoomsList((roomStructure.rooms || []).map((r) => r?.name || r).filter(Boolean));
+  }
+}
+
+function openRoomCreateModal(){
+  if(!roomCreateModal) return;
+  if(roomCreateMsg) roomCreateMsg.textContent = "";
+  if(roomCreateNameInput) roomCreateNameInput.value = "";
+  populateRoomCreateSelects();
+  roomCreateModal.hidden = false;
+  roomCreateModal.style.display = "flex";
+  roomCreateModal.classList.remove("modal-closing");
+  if(PREFERS_REDUCED_MOTION){
+    roomCreateModal.classList.add("modal-visible");
+  }else{
+    requestAnimationFrame(()=> roomCreateModal.classList.add("modal-visible"));
+  }
+  requestAnimationFrame(()=> roomCreateNameInput?.focus?.());
+}
+
+function closeRoomCreateModal(){
+  if(!roomCreateModal) return;
+  roomCreateModal.classList.remove("modal-visible");
+  if(PREFERS_REDUCED_MOTION){
+    roomCreateModal.style.display = "none";
+    roomCreateModal.hidden = true;
+    return;
+  }
+  roomCreateModal.classList.add("modal-closing");
+  setTimeout(()=>{
+    roomCreateModal.style.display = "none";
+    roomCreateModal.hidden = true;
+    roomCreateModal.classList.remove("modal-closing");
+  }, 140);
+}
+
+async function submitCreateRoom(){
+  const raw = String(roomCreateNameInput?.value || "");
+  const name = sanitizeRoomClient(raw);
+  if(!name){
+    if(roomCreateMsg) roomCreateMsg.textContent = "Invalid room name.";
+    return;
+  }
+  const masterId = roomCreateMasterSelect?.value || "";
+  const categoryId = roomCreateCategorySelect?.value || "";
+  const payload = { name };
+  if(categoryId) payload.category_id = Number(categoryId) || categoryId;
+  if(masterId) payload.master_id = Number(masterId) || masterId;
+
+  const {res, text} = await api("/rooms", {
+    method:"POST",
+    headers: {"Content-Type":"application/json"},
+    body: JSON.stringify(payload),
+  });
+  if(!res.ok){
+    if(roomCreateMsg) roomCreateMsg.textContent = text || "Failed to create room.";
+    return;
+  }
+  closeRoomCreateModal();
+  await loadRooms();
+  joinRoom(name);
 }
 
 async function createRoomFlow(){
+  if(roomCreateModal){
+    openRoomCreateModal();
+    return;
+  }
   const raw = prompt("New room name (letters/numbers/_/-):");
   if(!raw) return;
   const name = sanitizeRoomClient(raw);
@@ -9037,15 +9350,359 @@ async function createRoomFlow(){
     return;
   }
 
-  // rooms will also update via socket event, but we can refresh immediately:
   await loadRooms();
   joinRoom(name);
+}
+
+function getSortedMasters({ includeTemporary = true } = {}){
+  const masters = ensureDefaultMasters(roomStructure.masters || []);
+  const sorted = [...masters].sort((a, b) => sortByOrderThenName(a, b, "sort_order"));
+  if(includeTemporary) return sorted;
+  return sorted.filter((m) => !m.temporary && !String(m.id || "").startsWith("temp-"));
+}
+
+function getSortedCategories(masterId, { includeTemporary = true } = {}){
+  const categories = (roomStructure.categories || []).filter((c) => String(c.master_id) === String(masterId));
+  let list = [...categories].sort((a, b) => sortByOrderThenName(a, b, "sort_order"));
+  const ensured = ensureUncategorized(list, masterId);
+  if(!list.find((c) => String(c.name || "") === "Uncategorized")) list = [...list, ensured];
+  list.sort((a, b) => sortByOrderThenName(a, b, "sort_order"));
+  if(includeTemporary) return list;
+  return list.filter((c) => !c.temporary && !String(c.id || "").startsWith("temp-"));
+}
+
+function getSortedRoomsForCategory(categoryId){
+  const rooms = (roomStructure.rooms || []).filter((r) => String(r.category_id) === String(categoryId));
+  return [...rooms].sort((a, b) => sortByOrderThenName(a, b, "room_sort_order"));
+}
+
+function populateSelect(el, options, selectedValue){
+  if(!el) return;
+  el.innerHTML = "";
+  for(const opt of options){
+    const option = document.createElement("option");
+    option.value = opt.value;
+    option.textContent = opt.label;
+    if(String(opt.value) === String(selectedValue)) option.selected = true;
+    el.appendChild(option);
+  }
+}
+
+function populateRoomCreateSelects(){
+  const masters = getSortedMasters();
+  const defaultMaster = masters.find((m) => m.name === "Site Rooms") || masters[0];
+  const masterId = roomCreateMasterSelect?.value || defaultMaster?.id || "";
+  populateSelect(
+    roomCreateMasterSelect,
+    masters.map((m) => ({ value: m.id, label: m.name })),
+    masterId
+  );
+  const categories = masterId ? getSortedCategories(masterId) : [];
+  const defaultCategory = categories.find((c) => c.name === "Uncategorized") || categories[0];
+  populateSelect(
+    roomCreateCategorySelect,
+    categories.map((c) => ({ value: c.id, label: c.name })),
+    defaultCategory?.id || ""
+  );
+}
+
+function populateManageMasterSelects(){
+  const masters = getSortedMasters({ includeTemporary: false });
+  populateSelect(
+    roomCategoryMasterSelect,
+    masters.map((m) => ({ value: m.id, label: m.name })),
+    roomCategoryMasterSelect?.value || masters[0]?.id || ""
+  );
+  populateSelect(
+    roomManageMasterSelect,
+    masters.map((m) => ({ value: m.id, label: m.name })),
+    roomManageMasterSelect?.value || masters[0]?.id || ""
+  );
+  populateManageCategorySelects();
+}
+
+function populateManageCategorySelects(){
+  const masterId = roomManageMasterSelect?.value || "";
+  const categories = masterId ? getSortedCategories(masterId, { includeTemporary: false }) : [];
+  populateSelect(
+    roomManageCategorySelect,
+    categories.map((c) => ({ value: c.id, label: c.name })),
+    roomManageCategorySelect?.value || categories[0]?.id || ""
+  );
+}
+
+function renderRoomMasterList(){
+  if(!roomMasterList) return;
+  const masters = getSortedMasters({ includeTemporary: false });
+  roomMasterList.innerHTML = "";
+  for(const master of masters){
+    const row = document.createElement("div");
+    row.className = "roomManageRow";
+    const isDefault = master.name === "Site Rooms" || master.name === "User Rooms";
+    row.innerHTML = `
+      <div class="label">${escapeHtml(master.name)}</div>
+      <div class="actions">
+        <button class="btn secondary" data-action="rename">Rename</button>
+        <button class="btn secondary" data-action="up">Up</button>
+        <button class="btn secondary" data-action="down">Down</button>
+        <button class="btn danger" data-action="delete">Delete</button>
+      </div>
+    `;
+    if(isDefault){
+      row.querySelectorAll("[data-action='rename'], [data-action='delete']").forEach((btn) => { btn.disabled = true; });
+    }
+    const actions = row.querySelector(".actions");
+    actions?.addEventListener("click", async (e) => {
+      const btn = e.target.closest("button");
+      if(!btn) return;
+      const action = btn.dataset.action;
+      if(action === "rename"){
+        const next = prompt("Rename master:", master.name);
+        if(!next) return;
+        await api(`/api/room-masters/${master.id}`, {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ name: next })
+        });
+      }
+      if(action === "delete"){
+        if(!confirm(`Delete master "${master.name}"? Rooms will move to Site Rooms.`)) return;
+        await api(`/api/room-masters/${master.id}`, { method:"DELETE" });
+      }
+      if(action === "up" || action === "down"){
+        const index = masters.findIndex((m) => String(m.id) === String(master.id));
+        const swapWith = action === "up" ? index - 1 : index + 1;
+        if(swapWith < 0 || swapWith >= masters.length) return;
+        const orderedIds = [...masters].map((m) => m.id);
+        [orderedIds[index], orderedIds[swapWith]] = [orderedIds[swapWith], orderedIds[index]];
+        await api("/api/room-masters/reorder", {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ orderedIds })
+        });
+      }
+      await loadRooms();
+    });
+    roomMasterList.appendChild(row);
+  }
+}
+
+function renderRoomCategoryList(){
+  if(!roomCategoryList) return;
+  const masterId = roomCategoryMasterSelect?.value || "";
+  const masters = getSortedMasters({ includeTemporary: false });
+  const categories = masterId ? getSortedCategories(masterId, { includeTemporary: false }) : [];
+  roomCategoryList.innerHTML = "";
+  for(const category of categories){
+    const row = document.createElement("div");
+    row.className = "roomManageRow";
+    const isDefault = String(category.name || "") === "Uncategorized";
+    const masterOptions = masters.map((m) => `<option value="${m.id}">${escapeHtml(m.name)}</option>`).join("");
+    row.innerHTML = `
+      <div class="label">${escapeHtml(category.name)}</div>
+      <select class="roomManageMoveSelect">${masterOptions}</select>
+      <div class="actions">
+        <button class="btn secondary" data-action="rename">Rename</button>
+        <button class="btn secondary" data-action="up">Up</button>
+        <button class="btn secondary" data-action="down">Down</button>
+        <button class="btn secondary" data-action="move">Move</button>
+        <button class="btn danger" data-action="delete">Delete</button>
+      </div>
+    `;
+    const moveSelect = row.querySelector(".roomManageMoveSelect");
+    if(moveSelect) moveSelect.value = masterId;
+    if(isDefault && moveSelect) moveSelect.disabled = true;
+    if(isDefault){
+      row.querySelectorAll("[data-action='rename'], [data-action='delete'], [data-action='move']")
+        .forEach((btn) => { btn.disabled = true; });
+    }
+    const actions = row.querySelector(".actions");
+    actions?.addEventListener("click", async (e) => {
+      const btn = e.target.closest("button");
+      if(!btn) return;
+      const action = btn.dataset.action;
+      if(action === "rename"){
+        const next = prompt("Rename subcategory:", category.name);
+        if(!next) return;
+        await api(`/api/room-categories/${category.id}`, {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ name: next })
+        });
+      }
+      if(action === "delete"){
+        if(!confirm(`Delete subcategory "${category.name}"?`)) return;
+        await api(`/api/room-categories/${category.id}`, { method:"DELETE" });
+      }
+      if(action === "move"){
+        const targetMaster = moveSelect?.value || "";
+        if(!targetMaster || targetMaster === String(masterId)) return;
+        await api(`/api/room-categories/${category.id}`, {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ master_id: Number(targetMaster) || targetMaster })
+        });
+      }
+      if(action === "up" || action === "down"){
+        const index = categories.findIndex((c) => String(c.id) === String(category.id));
+        const swapWith = action === "up" ? index - 1 : index + 1;
+        if(swapWith < 0 || swapWith >= categories.length) return;
+        const orderedIds = [...categories].map((c) => c.id);
+        [orderedIds[index], orderedIds[swapWith]] = [orderedIds[swapWith], orderedIds[index]];
+        await api("/api/room-categories/reorder", {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ master_id: Number(masterId) || masterId, orderedIds })
+        });
+      }
+      await loadRooms();
+    });
+    roomCategoryList.appendChild(row);
+  }
+}
+
+function renderRoomManageRoomsList(){
+  if(!roomManageRoomList) return;
+  const masterId = roomManageMasterSelect?.value || "";
+  const categoryId = roomManageCategorySelect?.value || "";
+  const categories = masterId ? getSortedCategories(masterId) : [];
+  const rooms = categoryId ? getSortedRoomsForCategory(categoryId) : [];
+  const masterOptions = getSortedMasters().map((m) => ({
+    master: m,
+    categories: getSortedCategories(m.id),
+  }));
+  const moveOptions = masterOptions
+    .flatMap((entry) => entry.categories.map((c) => ({
+      value: c.id,
+      label: `${entry.master.name} / ${c.name}`,
+    })));
+  roomManageRoomList.innerHTML = "";
+  for(const room of rooms){
+    const row = document.createElement("div");
+    row.className = "roomManageRow";
+    const optionsMarkup = moveOptions.map((opt) => `<option value="${opt.value}">${escapeHtml(opt.label)}</option>`).join("");
+    row.innerHTML = `
+      <div class="label">${escapeHtml(displayRoomName(room.name))}</div>
+      <select class="roomManageMoveSelect">${optionsMarkup}</select>
+      <div class="actions">
+        <button class="btn secondary" data-action="up">Up</button>
+        <button class="btn secondary" data-action="down">Down</button>
+        <button class="btn secondary" data-action="move">Move</button>
+      </div>
+    `;
+    const moveSelect = row.querySelector(".roomManageMoveSelect");
+    if(moveSelect) moveSelect.value = categoryId;
+    const actions = row.querySelector(".actions");
+    actions?.addEventListener("click", async (e) => {
+      const btn = e.target.closest("button");
+      if(!btn) return;
+      const action = btn.dataset.action;
+      if(action === "move"){
+        const target = moveSelect?.value || "";
+        if(!target || target === String(categoryId)) return;
+        await api(`/api/rooms/${encodeURIComponent(room.name)}/move`, {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ category_id: Number(target) || target })
+        });
+      }
+      if(action === "up" || action === "down"){
+        const index = rooms.findIndex((r) => r.name === room.name);
+        const swapWith = action === "up" ? index - 1 : index + 1;
+        if(swapWith < 0 || swapWith >= rooms.length) return;
+        const orderedIds = [...rooms].map((r) => r.name);
+        [orderedIds[index], orderedIds[swapWith]] = [orderedIds[swapWith], orderedIds[index]];
+        await api("/api/rooms/reorder", {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ category_id: Number(categoryId) || categoryId, orderedIds })
+        });
+      }
+      await loadRooms();
+    });
+    roomManageRoomList.appendChild(row);
+  }
+}
+
+function refreshRoomManageUi(){
+  populateManageMasterSelects();
+  renderRoomMasterList();
+  renderRoomCategoryList();
+  renderRoomManageRoomsList();
+}
+
+function openRoomManageModal(){
+  if(!roomManageModal) return;
+  if(!me || roleRank(me.role) < roleRank("Owner")) return;
+  if(roomMasterMsg) roomMasterMsg.textContent = "";
+  if(roomCategoryMsg) roomCategoryMsg.textContent = "";
+  if(roomManageMsg) roomManageMsg.textContent = "";
+  const activeTab = document.querySelector("[data-room-manage-tab].active")?.dataset?.roomManageTab || "masters";
+  setRoomManageTab(activeTab);
+  roomManageModal.hidden = false;
+  roomManageModal.style.display = "flex";
+  roomManageModal.classList.remove("modal-closing");
+  if(PREFERS_REDUCED_MOTION){
+    roomManageModal.classList.add("modal-visible");
+  }else{
+    requestAnimationFrame(()=> roomManageModal.classList.add("modal-visible"));
+  }
+}
+
+function closeRoomManageModal(){
+  if(!roomManageModal) return;
+  roomManageModal.classList.remove("modal-visible");
+  if(PREFERS_REDUCED_MOTION){
+    roomManageModal.style.display = "none";
+    roomManageModal.hidden = true;
+    return;
+  }
+  roomManageModal.classList.add("modal-closing");
+  setTimeout(()=>{
+    roomManageModal.style.display = "none";
+    roomManageModal.hidden = true;
+    roomManageModal.classList.remove("modal-closing");
+  }, 140);
+}
+
+function setRoomManageTab(tab){
+  const next = tab || "masters";
+  document.querySelectorAll("[data-room-manage-tab]").forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.roomManageTab === next);
+  });
+  document.querySelectorAll("[data-room-manage-section]").forEach((section) => {
+    section.classList.toggle("active", section.dataset.roomManageSection === next);
+  });
+  refreshRoomManageUi();
+}
+
+async function persistRoomMasterCollapse(masterId, collapsed){
+  if(!masterId || !Number.isFinite(Number(masterId))) return;
+  await api("/api/users/me/room-master-collapsed", {
+    method:"PATCH",
+    headers: { "Content-Type":"application/json" },
+    body: JSON.stringify({ master_id: masterId, collapsed }),
+  });
+}
+
+async function persistRoomCategoryCollapse(categoryId, collapsed){
+  if(!categoryId || !Number.isFinite(Number(categoryId))) return;
+  await api("/api/users/me/room-category-collapsed", {
+    method:"PATCH",
+    headers: { "Content-Type":"application/json" },
+    body: JSON.stringify({ category_id: categoryId, collapsed }),
+  });
 }
 
 function updateRoomControlsVisibility(){
   if(addRoomBtn){
     const canCreate = me && roleRank(me.role) >= roleRank("Co-owner");
     addRoomBtn.style.display = rightPanelMode === "rooms" && canCreate ? "inline-flex" : "none";
+  }
+  if(manageRoomsBtn){
+    const isOwner = me && roleRank(me.role) >= roleRank("Owner");
+    manageRoomsBtn.style.display = rightPanelMode === "rooms" && isOwner ? "inline-flex" : "none";
+    if(!isOwner) closeRoomManageModal();
   }
 }
 
@@ -13667,6 +14324,7 @@ window.addEventListener("online", () => {
     try{ socket.connect(); }catch(_){}
   }
 });
+socket.on("roomStructure:update", (payload)=>setRoomStructure(payload, { updateCollapse: false }));
 socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   socket.on("changelog updated", ()=>{
     changelogDirty = true;
@@ -13697,6 +14355,56 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   if(addRoomBtn){
     addRoomBtn.addEventListener("click", createRoomFlow);
   }
+  if(manageRoomsBtn){
+    manageRoomsBtn.addEventListener("click", openRoomManageModal);
+  }
+  roomManageCloseBtn?.addEventListener("click", closeRoomManageModal);
+  roomManageModal?.addEventListener("click", (e)=>{ if(e.target === roomManageModal) closeRoomManageModal(); });
+  roomCreateCloseBtn?.addEventListener("click", closeRoomCreateModal);
+  roomCreateCancelBtn?.addEventListener("click", closeRoomCreateModal);
+  roomCreateModal?.addEventListener("click", (e)=>{ if(e.target === roomCreateModal) closeRoomCreateModal(); });
+  roomCreateSubmitBtn?.addEventListener("click", submitCreateRoom);
+  roomCreateMasterSelect?.addEventListener("change", populateRoomCreateSelects);
+  roomCategoryMasterSelect?.addEventListener("change", renderRoomCategoryList);
+  roomManageMasterSelect?.addEventListener("change", () => {
+    populateManageCategorySelects();
+    renderRoomManageRoomsList();
+  });
+  roomManageCategorySelect?.addEventListener("change", renderRoomManageRoomsList);
+  document.querySelectorAll("[data-room-manage-tab]").forEach((btn)=>{
+    btn.addEventListener("click", ()=> setRoomManageTab(btn.dataset.roomManageTab));
+  });
+  roomMasterCreateBtn?.addEventListener("click", async () => {
+    const name = String(roomMasterCreateInput?.value || "").trim();
+    if(roomMasterMsg) roomMasterMsg.textContent = "";
+    if(!name){
+      if(roomMasterMsg) roomMasterMsg.textContent = "Enter a master name.";
+      return;
+    }
+    await api("/api/room-masters", {
+      method:"POST",
+      headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ name })
+    });
+    if(roomMasterCreateInput) roomMasterCreateInput.value = "";
+    await loadRooms();
+  });
+  roomCategoryCreateBtn?.addEventListener("click", async () => {
+    const masterId = roomCategoryMasterSelect?.value || "";
+    const name = String(roomCategoryCreateInput?.value || "").trim();
+    if(roomCategoryMsg) roomCategoryMsg.textContent = "";
+    if(!masterId || !name){
+      if(roomCategoryMsg) roomCategoryMsg.textContent = "Select a master and name.";
+      return;
+    }
+    await api("/api/room-categories", {
+      method:"POST",
+      headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ master_id: Number(masterId) || masterId, name })
+    });
+    if(roomCategoryCreateInput) roomCategoryCreateInput.value = "";
+    await loadRooms();
+  });
   updateRoomControlsVisibility();
 
   socket.on("system", (text) => {

--- a/public/index.html
+++ b/public/index.html
@@ -150,6 +150,7 @@
 <div class="row" style="gap:6px;">
 <button class="iconBtn smallIcon" id="channelsCloseBtn" title="Close" type="button">✕</button>
 <button class="iconBtn smallIcon" id="menuToggleBtn" title="Menu" type="button">☰</button>
+<button class="iconBtn smallIcon" id="manageRoomsBtn" title="Manage rooms" type="button">⋯</button>
 <button class="iconBtn smallIcon" id="addRoomBtn" title="Create room" type="button">＋</button>
 </div>
 </div>
@@ -623,6 +624,88 @@
 </span>
 <span class="iconLabel">Change</span>
 </button>
+</div>
+</div>
+
+<div id="roomManageModal" class="roomModal" hidden="">
+<div class="modalCard roomModalCard">
+<div class="modalTop">
+<strong>Manage Rooms</strong>
+<button class="iconBtn smallIcon" id="roomManageCloseBtn" title="Close" type="button">✕</button>
+</div>
+<div class="modalBody roomModalBody">
+<div class="tabs roomManageTabs">
+<button class="tab active" data-room-manage-tab="masters" type="button">Masters</button>
+<button class="tab" data-room-manage-tab="categories" type="button">Subcategories</button>
+<button class="tab" data-room-manage-tab="rooms" type="button">Rooms</button>
+</div>
+<div class="roomManageSection active" data-room-manage-section="masters">
+<div class="field">
+<label for="roomMasterCreateInput">New master</label>
+<div class="row" style="gap:8px; flex-wrap:wrap;">
+<input id="roomMasterCreateInput" maxlength="40" placeholder="Master name"/>
+<button class="btn" id="roomMasterCreateBtn" type="button">Create</button>
+</div>
+<div class="msgline" id="roomMasterMsg"></div>
+</div>
+<div class="roomManageList" id="roomMasterList"></div>
+</div>
+<div class="roomManageSection" data-room-manage-section="categories">
+<div class="field">
+<label for="roomCategoryMasterSelect">Master</label>
+<select id="roomCategoryMasterSelect"></select>
+</div>
+<div class="field">
+<label for="roomCategoryCreateInput">New subcategory</label>
+<div class="row" style="gap:8px; flex-wrap:wrap;">
+<input id="roomCategoryCreateInput" maxlength="40" placeholder="Subcategory name"/>
+<button class="btn" id="roomCategoryCreateBtn" type="button">Create</button>
+</div>
+<div class="msgline" id="roomCategoryMsg"></div>
+</div>
+<div class="roomManageList" id="roomCategoryList"></div>
+</div>
+<div class="roomManageSection" data-room-manage-section="rooms">
+<div class="field">
+<label for="roomManageMasterSelect">Master</label>
+<select id="roomManageMasterSelect"></select>
+</div>
+<div class="field">
+<label for="roomManageCategorySelect">Subcategory</label>
+<select id="roomManageCategorySelect"></select>
+</div>
+<div class="roomManageList" id="roomManageRoomList"></div>
+<div class="msgline" id="roomManageMsg"></div>
+</div>
+</div>
+</div>
+</div>
+
+<div id="roomCreateModal" class="roomModal" hidden="">
+<div class="modalCard roomModalCard">
+<div class="modalTop">
+<strong>Create Room</strong>
+<button class="iconBtn smallIcon" id="roomCreateCloseBtn" title="Close" type="button">✕</button>
+</div>
+<div class="modalBody roomModalBody">
+<div class="field">
+<label for="roomCreateNameInput">Room name</label>
+<input id="roomCreateNameInput" maxlength="24" placeholder="room-name"/>
+</div>
+<div class="field">
+<label for="roomCreateMasterSelect">Master group</label>
+<select id="roomCreateMasterSelect"></select>
+</div>
+<div class="field">
+<label for="roomCreateCategorySelect">Subcategory</label>
+<select id="roomCreateCategorySelect"></select>
+</div>
+<div class="row" style="gap:8px; flex-wrap:wrap;">
+<button class="btn" id="roomCreateSubmitBtn" type="button">Create</button>
+<button class="btn secondary" id="roomCreateCancelBtn" type="button">Cancel</button>
+<div class="msgline" id="roomCreateMsg"></div>
+</div>
+</div>
 </div>
 </div>
 <span aria-hidden="true" class="profilePresenceDot" id="profilePresenceDot"></span>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2304,6 +2304,111 @@ body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + e
 .chan:hover{ background:color-mix(in srgb, var(--panel) 80%, transparent); color:var(--text); }
 .chan.active{ background:var(--panel); color:var(--text); border:1px solid var(--border); }
 .hash{ color:var(--muted); }
+.roomMaster,
+.roomCategory{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.roomMasterHeader,
+.roomCategoryHeader{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px;
+  width:100%;
+  padding:8px 10px;
+  border-radius:var(--radiusMd);
+  border:1px solid transparent;
+  background:color-mix(in srgb, var(--panel) 85%, transparent);
+  color:var(--text);
+  font-weight:800;
+  cursor:pointer;
+  text-align:left;
+  font:inherit;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.roomCategoryHeader{
+  font-weight:700;
+  background:color-mix(in srgb, var(--panel) 78%, transparent);
+}
+.roomMasterHeader:hover,
+.roomCategoryHeader:hover{
+  border-color:var(--border);
+  background:color-mix(in srgb, var(--panel) 92%, transparent);
+}
+.roomHeaderLabel{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  min-width:0;
+}
+.roomChevron{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  font-size:12px;
+  transition: transform 0.18s ease;
+  opacity:0.8;
+}
+.roomMaster.collapsed .roomMasterHeader .roomChevron,
+.roomCategory.collapsed .roomCategoryHeader .roomChevron{
+  transform:rotate(-90deg);
+}
+.roomMasterBody,
+.roomCategoryBody{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  margin-left:6px;
+  padding-left:6px;
+  border-left:1px solid color-mix(in srgb, var(--border) 70%, transparent);
+}
+.roomCategoryBody{
+  margin-left:10px;
+}
+.roomMaster.collapsed .roomMasterBody,
+.roomCategory.collapsed .roomCategoryBody{
+  display:none;
+}
+.roomList{
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  padding-left:4px;
+}
+.roomManageList{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+.roomManageSection{ display:none; flex-direction:column; gap:12px; }
+.roomManageSection.active{ display:flex; }
+.roomManageTabs{ margin-top:0; }
+.roomManageRow{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  flex-wrap:wrap;
+  background:color-mix(in srgb, var(--panel) 90%, transparent);
+  border:1px solid var(--border);
+  border-radius:var(--radiusMd);
+  padding:8px;
+}
+.roomManageRow .label{
+  font-weight:800;
+  flex:1;
+  min-width:120px;
+}
+.roomManageRow .actions{
+  display:flex;
+  gap:6px;
+  flex-wrap:wrap;
+}
+.roomManageRow .btn{
+  min-height:32px;
+  padding:6px 10px;
+}
 
 .bottomBar{
   background:var(--panel);
@@ -3470,6 +3575,28 @@ body:not(.polish-pack) .tonePicker{
   z-index: 401; /* above main modal */
 }
 #couplesModal.modal-visible{ opacity: 1; }
+.roomModal{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  overflow: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: 18px;
+  z-index: 402;
+}
+.roomModal.modal-visible{ opacity: 1; }
+.roomModalCard{
+  width: min(840px, calc(100vw - 36px));
+}
+.roomModalBody{
+  padding: 0 12px 16px;
+}
 .modalCard{
   position: relative;
   display: flex;

--- a/server.js
+++ b/server.js
@@ -353,6 +353,8 @@ const pgInitPromise = (async () => {
         last_status TEXT,
         theme TEXT NOT NULL DEFAULT 'Minimal Dark',
         prefs_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+        room_master_collapsed TEXT NOT NULL DEFAULT '{}',
+        room_category_collapsed TEXT NOT NULL DEFAULT '{}',
         gold INTEGER NOT NULL DEFAULT 0,
         xp INTEGER NOT NULL DEFAULT 0,
         lastMessageXpAt BIGINT,
@@ -374,6 +376,79 @@ const pgInitPromise = (async () => {
         expire TIMESTAMP NOT NULL
       );
     `);
+
+    await pgPool.query(`
+      CREATE TABLE IF NOT EXISTS room_master_categories (
+        id SERIAL PRIMARY KEY,
+        name TEXT UNIQUE NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at BIGINT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS room_categories (
+        id SERIAL PRIMARY KEY,
+        master_id INTEGER NOT NULL REFERENCES room_master_categories(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at BIGINT NOT NULL,
+        UNIQUE(master_id, name)
+      );
+      CREATE TABLE IF NOT EXISTS rooms (
+        name TEXT PRIMARY KEY,
+        created_by INTEGER,
+        created_at BIGINT NOT NULL,
+        slowmode_seconds INTEGER NOT NULL DEFAULT 0,
+        is_locked INTEGER NOT NULL DEFAULT 0,
+        pinned_message_ids TEXT,
+        maintenance_mode INTEGER NOT NULL DEFAULT 0,
+        category_id INTEGER REFERENCES room_categories(id) ON DELETE SET NULL,
+        room_sort_order INTEGER NOT NULL DEFAULT 0,
+        created_by_user_id INTEGER,
+        is_user_room INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+
+    const roomCols = [
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS slowmode_seconds INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS is_locked INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS pinned_message_ids TEXT`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS maintenance_mode INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS category_id INTEGER`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS room_sort_order INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS is_user_room INTEGER NOT NULL DEFAULT 0`,
+    ];
+    for (const q of roomCols) {
+      try { await pgPool.query(q); } catch (_) {}
+    }
+
+    try {
+      const now = Date.now();
+      await pgPool.query(
+        `INSERT INTO room_master_categories (name, sort_order, created_at)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (name) DO NOTHING`,
+        ["Site Rooms", 0, now]
+      );
+      await pgPool.query(
+        `INSERT INTO room_master_categories (name, sort_order, created_at)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (name) DO NOTHING`,
+        ["User Rooms", 1, now]
+      );
+      const { rows: masterRows } = await pgPool.query(
+        `SELECT id, name FROM room_master_categories WHERE name IN ('Site Rooms', 'User Rooms')`
+      );
+      for (const master of masterRows || []) {
+        await pgPool.query(
+          `INSERT INTO room_categories (master_id, name, sort_order, created_at)
+           VALUES ($1, 'Uncategorized', 0, $2)
+           ON CONFLICT (master_id, name) DO NOTHING`,
+          [master.id, now]
+        );
+      }
+    } catch (e) {
+      console.warn("[pg-init] room hierarchy seed failed:", e?.message || e);
+    }
 
     // Changelog tables (Postgres) — ensures changelog persists across restarts
     await pgPool.query(`
@@ -530,6 +605,8 @@ try {
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS last_status TEXT`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS theme TEXT NOT NULL DEFAULT 'Minimal Dark'`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS prefs_json JSONB NOT NULL DEFAULT '{}'::jsonb`,
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS room_master_collapsed TEXT NOT NULL DEFAULT '{}'`,
+      `ALTER TABLE users ADD COLUMN IF NOT EXISTS room_category_collapsed TEXT NOT NULL DEFAULT '{}'`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS gold INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS xp INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE users ADD COLUMN IF NOT EXISTS "lastMessageXpAt" BIGINT`,
@@ -2913,8 +2990,20 @@ const commandRegistry = {
     handler: async ({ args, room, actor }) => {
       const name = sanitizeRoomName(args[0] || "");
       if (!name) return { ok: false, message: "Invalid room" };
-      await dbRunAsync(`INSERT OR IGNORE INTO rooms (name, created_by, created_at) VALUES (?, ?, ?)`, [name, actor.id, Date.now()]);
-      io.emit("rooms update", (await dbAllAsync(`SELECT name FROM rooms ORDER BY name ASC`)).map((r) => r.name));
+      const resolved = await resolveRoomCategoryId({ isUserRoom: false });
+      const categoryId = resolved?.categoryId ?? null;
+      const nextSort = categoryId
+        ? await dbGetAsync(`SELECT COALESCE(MAX(room_sort_order), 0) as maxSort FROM rooms WHERE category_id = ?`, [
+          categoryId,
+        ])
+        : { maxSort: 0 };
+      const sortOrder = Number(nextSort?.maxSort || 0) + 1;
+      await dbRunAsync(
+        `INSERT OR IGNORE INTO rooms (name, created_by, created_at, category_id, room_sort_order, created_by_user_id, is_user_room)
+         VALUES (?, ?, ?, ?, ?, ?, 0)`,
+        [name, actor.id, Date.now(), categoryId, sortOrder, actor.id]
+      );
+      await emitRoomStructureUpdate();
       return { ok: true, message: `Created room #${name}` };
     },
   },
@@ -2928,7 +3017,7 @@ const commandRegistry = {
       if (!name) return { ok: false, message: "Invalid room" };
       await dbRunAsync(`DELETE FROM rooms WHERE name=?`, [name]);
       await dbRunAsync(`DELETE FROM messages WHERE room=?`, [name]);
-      io.emit("rooms update", (await dbAllAsync(`SELECT name FROM rooms ORDER BY name ASC`)).map((r) => r.name));
+      await emitRoomStructureUpdate();
       return { ok: true, message: `Deleted room #${name}` };
     },
   },
@@ -3961,6 +4050,131 @@ function sanitizeRoomName(r) {
   r = r.toLowerCase();
   r = r.replace(/[^a-z0-9_-]/g, "");
   return r.slice(0, 24);
+}
+
+const DEFAULT_ROOM_MASTERS = ["Site Rooms", "User Rooms"];
+const DEFAULT_ROOM_CATEGORY = "Uncategorized";
+
+function sanitizeRoomGroupName(name) {
+  const clean = String(name || "").trim().replace(/\s+/g, " ");
+  return clean.slice(0, 40);
+}
+
+function normalizeRoomGroupName(name) {
+  return String(name || "").trim().toLowerCase();
+}
+
+async function getUserRoomCollapseState(userId) {
+  const fallback = { master: {}, category: {} };
+  if (!userId) return fallback;
+  let row = null;
+  try {
+    const { rows } = await pgPool.query(
+      `SELECT room_master_collapsed, room_category_collapsed FROM users WHERE id = $1 LIMIT 1`,
+      [userId]
+    );
+    row = rows[0] || null;
+  } catch {}
+
+  if (!row) {
+    try {
+      row = await dbGetAsync(
+        "SELECT room_master_collapsed, room_category_collapsed FROM users WHERE id = ?",
+        [userId]
+      );
+    } catch {}
+  }
+
+  const master = safeJsonParse(row?.room_master_collapsed || "{}", {});
+  const category = safeJsonParse(row?.room_category_collapsed || "{}", {});
+  return {
+    master: master && typeof master === "object" ? master : {},
+    category: category && typeof category === "object" ? category : {},
+  };
+}
+
+async function buildRoomStructure() {
+  const masters = await dbAllAsync(
+    `SELECT id, name, sort_order FROM room_master_categories ORDER BY sort_order ASC, name ASC`
+  );
+  const categories = await dbAllAsync(
+    `SELECT id, master_id, name, sort_order FROM room_categories ORDER BY sort_order ASC, name ASC`
+  );
+  const rooms = await dbAllAsync(
+    `SELECT name, category_id, room_sort_order, slowmode_seconds, is_locked, maintenance_mode,
+            created_by, created_by_user_id, is_user_room
+       FROM rooms
+      ORDER BY room_sort_order ASC, name ASC`
+  );
+  return {
+    masters,
+    categories,
+    rooms: (rooms || []).map((r) => ({
+      id: r.name,
+      name: r.name,
+      category_id: r.category_id,
+      room_sort_order: Number(r.room_sort_order || 0),
+      slowmode_seconds: Number(r.slowmode_seconds || 0),
+      is_locked: Number(r.is_locked || 0),
+      maintenance_mode: Number(r.maintenance_mode || 0),
+      created_by: r.created_by ?? null,
+      created_by_user_id: r.created_by_user_id ?? null,
+      is_user_room: Number(r.is_user_room || 0),
+    })),
+  };
+}
+
+async function buildRoomStructurePayload(userId) {
+  const base = await buildRoomStructure();
+  const userCollapse = await getUserRoomCollapseState(userId);
+  return { ...base, userCollapse };
+}
+
+async function emitRoomStructureUpdate() {
+  const payload = await buildRoomStructure();
+  io.emit("roomStructure:update", payload);
+  io.emit("rooms update", (payload.rooms || []).map((r) => r.name));
+}
+
+async function getDefaultMasterIds() {
+  const rows = await dbAllAsync(
+    `SELECT id, name FROM room_master_categories WHERE name IN (?, ?)`,
+    DEFAULT_ROOM_MASTERS
+  );
+  const map = new Map(rows.map((row) => [row.name, row.id]));
+  return {
+    site: map.get("Site Rooms") || null,
+    user: map.get("User Rooms") || null,
+  };
+}
+
+async function getUncategorizedCategoryId(masterId) {
+  if (!masterId) return null;
+  const row = await dbGetAsync(
+    `SELECT id FROM room_categories WHERE master_id = ? AND lower(name) = lower(?) LIMIT 1`,
+    [masterId, DEFAULT_ROOM_CATEGORY]
+  );
+  return row?.id ?? null;
+}
+
+async function resolveRoomCategoryId({ categoryId, masterId, isUserRoom }) {
+  let categoryRow = null;
+  if (categoryId) {
+    categoryRow = await dbGetAsync(
+      `SELECT id, master_id FROM room_categories WHERE id = ? LIMIT 1`,
+      [categoryId]
+    );
+  }
+  if (!categoryRow && masterId) {
+    const fallbackId = await getUncategorizedCategoryId(masterId);
+    if (fallbackId) return { categoryId: fallbackId, masterId };
+  }
+  if (categoryRow) return { categoryId: categoryRow.id, masterId: categoryRow.master_id };
+
+  const defaults = await getDefaultMasterIds();
+  const fallbackMasterId = isUserRoom ? defaults.user : defaults.site;
+  const fallbackCategoryId = await getUncategorizedCategoryId(fallbackMasterId);
+  return { categoryId: fallbackCategoryId, masterId: fallbackMasterId };
 }
 function normalizeDmPair(a, b) {
   const aId = Number(a);
@@ -6286,42 +6500,437 @@ app.post("/api/me/award-gold", strictLimiter, requireLogin, (req, res) => {
   });
 });
 // ---- Rooms API
-app.get("/rooms", requireLogin, (_req, res) => {
-  db.all(`SELECT name FROM rooms ORDER BY name ASC`, [], (err, rows) => {
-    if (err) return res.status(500).send("Failed");
-    return res.json((rows || []).map(r => r.name));
-  });
+app.get("/rooms", requireLogin, async (req, res) => {
+  try {
+    const payload = await buildRoomStructurePayload(req.session?.user?.id);
+    return res.json(payload);
+  } catch (e) {
+    console.warn("[rooms] failed to load room structure", e?.message || e);
+    return res.status(500).send("Failed");
+  }
 });
 
 // Co-owner+ can create rooms
-app.post("/rooms", strictLimiter, requireLogin, (req, res) => {
+app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }), async (req, res) => {
   const actor = req.session.user;
   if (!requireMinRole(actor.role, "Co-owner")) return res.status(403).send("Forbidden");
 
   const name = sanitizeRoomName(req.body?.name || req.body?.room || "");
   if (!name) return res.status(400).send("Invalid room name");
 
-  db.get(`SELECT name FROM rooms WHERE name=?`, [name], (err, row) => {
-    if (err) return res.status(500).send("Failed");
+  try {
+    const row = await dbGetAsync(`SELECT name FROM rooms WHERE name=?`, [name]);
     if (row) return res.status(409).send("Room already exists");
 
-    db.run(
-      `INSERT INTO rooms (name, created_by, created_at) VALUES (?, ?, ?)`,
-      [name, actor.id, Date.now()],
-      (insErr) => {
-        if (insErr) return res.status(500).send("Failed to create room");
+    const requestedCategoryId = Number(req.body?.category_id) || null;
+    const requestedMasterId = Number(req.body?.master_id) || null;
+    const requestedUserRoom = req.body?.is_user_room ? true : false;
+    const resolved = await resolveRoomCategoryId({
+      categoryId: requestedCategoryId,
+      masterId: requestedMasterId,
+      isUserRoom: requestedUserRoom,
+    });
+    const categoryId = resolved?.categoryId ?? null;
+    const categoryRow = categoryId
+      ? await dbGetAsync(
+        `SELECT c.id, c.master_id, m.name as master_name
+           FROM room_categories c
+           JOIN room_master_categories m ON m.id = c.master_id
+          WHERE c.id = ? LIMIT 1`,
+        [categoryId]
+      )
+      : null;
+    const isUserRoom = categoryRow?.master_name === "User Rooms" ? 1 : 0;
+    const nextSort = categoryId
+      ? await dbGetAsync(`SELECT COALESCE(MAX(room_sort_order), 0) as maxSort FROM rooms WHERE category_id = ?`, [
+        categoryId,
+      ])
+      : { maxSort: 0 };
+    const sortOrder = Number(nextSort?.maxSort || 0) + 1;
 
-        logModAction({ actor, action: "room.create", room: name, details: null });
-
-        db.all(`SELECT name FROM rooms ORDER BY name ASC`, [], (_e2, rows2) => {
-          io.emit("rooms update", (rows2 || []).map(r => r.name));
-        });
-
-        return res.json({ ok: true, name });
-      }
+    await dbRunAsync(
+      `INSERT INTO rooms (name, created_by, created_at, category_id, room_sort_order, created_by_user_id, is_user_room)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      [name, actor.id, Date.now(), categoryId, sortOrder, actor.id, isUserRoom]
     );
-  });
+
+    logModAction({ actor, action: "room.create", room: name, details: null });
+    await emitRoomStructureUpdate();
+
+    return res.json({ ok: true, name });
+  } catch (e) {
+    console.warn("[rooms] create failed", e?.message || e);
+    return res.status(500).send("Failed to create room");
+  }
 });
+
+// ---- Room structure management (Owner-only)
+app.post("/api/room-masters", strictLimiter, requireOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const name = sanitizeRoomGroupName(req.body?.name || "");
+  if (!name) return res.status(400).send("Invalid name");
+  try {
+    const existing = await dbGetAsync(`SELECT id FROM room_master_categories WHERE lower(name) = lower(?)`, [name]);
+    if (existing) return res.status(409).send("Master exists");
+    const maxRow = await dbGetAsync(`SELECT COALESCE(MAX(sort_order), 0) as maxSort FROM room_master_categories`);
+    const sortOrder = Number(maxRow?.maxSort || 0) + 1;
+    const now = Date.now();
+    const ins = await dbRunAsync(
+      `INSERT INTO room_master_categories (name, sort_order, created_at) VALUES (?, ?, ?)`,
+      [name, sortOrder, now]
+    );
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true, id: ins?.lastID || null, name, sort_order: sortOrder });
+  } catch (e) {
+    console.warn("[room-masters] create failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/room-masters/reorder", strictLimiter, requireOwner, express.json({ limit: "32kb" }), async (req, res) => {
+  const orderedIds = Array.isArray(req.body?.orderedIds) ? req.body.orderedIds : null;
+  if (!orderedIds?.length) return res.status(400).send("Missing order");
+  try {
+    for (let i = 0; i < orderedIds.length; i += 1) {
+      const id = Number(orderedIds[i]);
+      if (!id) continue;
+      await dbRunAsync(`UPDATE room_master_categories SET sort_order = ? WHERE id = ?`, [i, id]);
+    }
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-masters] reorder failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/room-masters/:id", strictLimiter, requireOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).send("Invalid master");
+  try {
+    const row = await dbGetAsync(`SELECT id, name FROM room_master_categories WHERE id = ?`, [id]);
+    if (!row) return res.status(404).send("Not found");
+    const updates = [];
+    const params = [];
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, "name")) {
+      const name = sanitizeRoomGroupName(req.body?.name || "");
+      if (!name) return res.status(400).send("Invalid name");
+      if (DEFAULT_ROOM_MASTERS.includes(row.name) && name !== row.name) {
+        return res.status(400).send("Cannot rename default master");
+      }
+      const existing = await dbGetAsync(
+        `SELECT id FROM room_master_categories WHERE lower(name) = lower(?) AND id != ?`,
+        [name, id]
+      );
+      if (existing) return res.status(409).send("Name exists");
+      updates.push("name = ?");
+      params.push(name);
+    }
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, "sort_order")) {
+      const sortOrder = Number(req.body?.sort_order);
+      if (Number.isFinite(sortOrder)) {
+        updates.push("sort_order = ?");
+        params.push(sortOrder);
+      }
+    }
+    if (!updates.length) return res.json({ ok: true });
+    params.push(id);
+    await dbRunAsync(`UPDATE room_master_categories SET ${updates.join(", ")} WHERE id = ?`, params);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-masters] patch failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.delete("/api/room-masters/:id", strictLimiter, requireOwner, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).send("Invalid master");
+  try {
+    const row = await dbGetAsync(`SELECT id, name FROM room_master_categories WHERE id = ?`, [id]);
+    if (!row) return res.status(404).send("Not found");
+    if (DEFAULT_ROOM_MASTERS.includes(row.name)) {
+      return res.status(400).send("Cannot delete default master");
+    }
+    const defaults = await getDefaultMasterIds();
+    const fallbackCategoryId = await getUncategorizedCategoryId(defaults.site);
+    const categories = await dbAllAsync(`SELECT id FROM room_categories WHERE master_id = ?`, [id]);
+    const categoryIds = categories.map((c) => c.id).filter(Boolean);
+    if (categoryIds.length && fallbackCategoryId) {
+      const placeholders = categoryIds.map(() => "?").join(",");
+      await dbRunAsync(
+        `UPDATE rooms SET category_id = ? WHERE category_id IN (${placeholders})`,
+        [fallbackCategoryId, ...categoryIds]
+      );
+    }
+    await dbRunAsync(`DELETE FROM room_categories WHERE master_id = ?`, [id]);
+    await dbRunAsync(`DELETE FROM room_master_categories WHERE id = ?`, [id]);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-masters] delete failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.post("/api/room-categories", strictLimiter, requireOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const masterId = Number(req.body?.master_id);
+  const name = sanitizeRoomGroupName(req.body?.name || "");
+  if (!masterId) return res.status(400).send("Invalid master");
+  if (!name) return res.status(400).send("Invalid name");
+  try {
+    const master = await dbGetAsync(`SELECT id FROM room_master_categories WHERE id = ?`, [masterId]);
+    if (!master) return res.status(404).send("Master not found");
+    const existing = await dbGetAsync(
+      `SELECT id FROM room_categories WHERE master_id = ? AND lower(name) = lower(?)`,
+      [masterId, name]
+    );
+    if (existing) return res.status(409).send("Category exists");
+    const maxRow = await dbGetAsync(
+      `SELECT COALESCE(MAX(sort_order), 0) as maxSort FROM room_categories WHERE master_id = ?`,
+      [masterId]
+    );
+    const sortOrder = Number(maxRow?.maxSort || 0) + 1;
+    const now = Date.now();
+    const ins = await dbRunAsync(
+      `INSERT INTO room_categories (master_id, name, sort_order, created_at) VALUES (?, ?, ?, ?)`,
+      [masterId, name, sortOrder, now]
+    );
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true, id: ins?.lastID || null, master_id: masterId, name });
+  } catch (e) {
+    console.warn("[room-categories] create failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/room-categories/reorder", strictLimiter, requireOwner, express.json({ limit: "32kb" }), async (req, res) => {
+  const masterId = Number(req.body?.master_id);
+  const orderedIds = Array.isArray(req.body?.orderedIds) ? req.body.orderedIds : null;
+  if (!masterId || !orderedIds?.length) return res.status(400).send("Invalid order");
+  try {
+    for (let i = 0; i < orderedIds.length; i += 1) {
+      const id = Number(orderedIds[i]);
+      if (!id) continue;
+      await dbRunAsync(
+        `UPDATE room_categories SET sort_order = ? WHERE id = ? AND master_id = ?`,
+        [i, id, masterId]
+      );
+    }
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-categories] reorder failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/room-categories/:id", strictLimiter, requireOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).send("Invalid category");
+  try {
+    const row = await dbGetAsync(`SELECT id, name, master_id FROM room_categories WHERE id = ?`, [id]);
+    if (!row) return res.status(404).send("Not found");
+    const updates = [];
+    const params = [];
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, "name")) {
+      const name = sanitizeRoomGroupName(req.body?.name || "");
+      if (!name) return res.status(400).send("Invalid name");
+      if (normalizeRoomGroupName(row.name) === normalizeRoomGroupName(DEFAULT_ROOM_CATEGORY) && name !== row.name) {
+        return res.status(400).send("Cannot rename Uncategorized");
+      }
+      const targetMaster = Number(req.body?.master_id) || row.master_id;
+      const existing = await dbGetAsync(
+        `SELECT id FROM room_categories WHERE master_id = ? AND lower(name) = lower(?) AND id != ?`,
+        [targetMaster, name, id]
+      );
+      if (existing) return res.status(409).send("Name exists");
+      updates.push("name = ?");
+      params.push(name);
+    }
+
+    let nextMasterId = row.master_id;
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, "master_id")) {
+      const masterId = Number(req.body?.master_id);
+      if (!masterId) return res.status(400).send("Invalid master");
+      if (normalizeRoomGroupName(row.name) === normalizeRoomGroupName(DEFAULT_ROOM_CATEGORY) && masterId !== row.master_id) {
+        return res.status(400).send("Cannot move Uncategorized");
+      }
+      const masterRow = await dbGetAsync(`SELECT id FROM room_master_categories WHERE id = ?`, [masterId]);
+      if (!masterRow) return res.status(404).send("Master not found");
+      nextMasterId = masterId;
+      updates.push("master_id = ?");
+      params.push(masterId);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(req.body || {}, "sort_order")) {
+      const sortOrder = Number(req.body?.sort_order);
+      if (Number.isFinite(sortOrder)) {
+        updates.push("sort_order = ?");
+        params.push(sortOrder);
+      }
+    }
+
+    if (!updates.length) return res.json({ ok: true });
+
+    if (nextMasterId !== row.master_id && !Object.prototype.hasOwnProperty.call(req.body || {}, "sort_order")) {
+      const maxRow = await dbGetAsync(
+        `SELECT COALESCE(MAX(sort_order), 0) as maxSort FROM room_categories WHERE master_id = ?`,
+        [nextMasterId]
+      );
+      const sortOrder = Number(maxRow?.maxSort || 0) + 1;
+      updates.push("sort_order = ?");
+      params.push(sortOrder);
+    }
+
+    params.push(id);
+    await dbRunAsync(`UPDATE room_categories SET ${updates.join(", ")} WHERE id = ?`, params);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-categories] patch failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.delete("/api/room-categories/:id", strictLimiter, requireOwner, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!id) return res.status(400).send("Invalid category");
+  try {
+    const row = await dbGetAsync(`SELECT id, name, master_id FROM room_categories WHERE id = ?`, [id]);
+    if (!row) return res.status(404).send("Not found");
+    if (normalizeRoomGroupName(row.name) === normalizeRoomGroupName(DEFAULT_ROOM_CATEGORY)) {
+      return res.status(400).send("Cannot delete Uncategorized");
+    }
+    const fallbackCategoryId = await getUncategorizedCategoryId(row.master_id);
+    if (fallbackCategoryId) {
+      await dbRunAsync(`UPDATE rooms SET category_id = ? WHERE category_id = ?`, [fallbackCategoryId, id]);
+    }
+    await dbRunAsync(`DELETE FROM room_categories WHERE id = ?`, [id]);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[room-categories] delete failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/rooms/:id/move", strictLimiter, requireOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  try {
+    const roomRow = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [roomName]);
+    if (!roomRow) return res.status(404).send("Not found");
+    const requestedCategoryId = Number(req.body?.category_id) || null;
+    const resolved = await resolveRoomCategoryId({ categoryId: requestedCategoryId, isUserRoom: false });
+    const categoryId = resolved?.categoryId ?? null;
+    const categoryRow = categoryId
+      ? await dbGetAsync(
+        `SELECT c.id, m.name as master_name
+           FROM room_categories c
+           JOIN room_master_categories m ON m.id = c.master_id
+          WHERE c.id = ? LIMIT 1`,
+        [categoryId]
+      )
+      : null;
+    const isUserRoom = categoryRow?.master_name === "User Rooms" ? 1 : 0;
+    let sortOrder = Number(req.body?.room_sort_order);
+    if (!Number.isFinite(sortOrder)) {
+      const maxRow = categoryId
+        ? await dbGetAsync(`SELECT COALESCE(MAX(room_sort_order), 0) as maxSort FROM rooms WHERE category_id = ?`, [
+          categoryId,
+        ])
+        : { maxSort: 0 };
+      sortOrder = Number(maxRow?.maxSort || 0) + 1;
+    }
+    await dbRunAsync(
+      `UPDATE rooms SET category_id = ?, room_sort_order = ?, is_user_room = ? WHERE name = ?`,
+      [categoryId, sortOrder, isUserRoom, roomName]
+    );
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[rooms] move failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/rooms/reorder", strictLimiter, requireOwner, express.json({ limit: "32kb" }), async (req, res) => {
+  const categoryId = Number(req.body?.category_id);
+  const orderedIds = Array.isArray(req.body?.orderedIds) ? req.body.orderedIds : null;
+  if (!categoryId || !orderedIds?.length) return res.status(400).send("Invalid order");
+  try {
+    for (let i = 0; i < orderedIds.length; i += 1) {
+      const roomName = sanitizeRoomName(orderedIds[i] || "");
+      if (!roomName) continue;
+      await dbRunAsync(
+        `UPDATE rooms SET room_sort_order = ? WHERE name = ? AND category_id = ?`,
+        [i, roomName, categoryId]
+      );
+    }
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[rooms] reorder failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+// ---- Room collapse persistence
+app.patch(
+  "/api/users/me/room-master-collapsed",
+  strictLimiter,
+  requireLogin,
+  express.json({ limit: "8kb" }),
+  async (req, res) => {
+    const userId = req.session?.user?.id;
+    const masterId = String(req.body?.master_id || "").trim();
+    const collapsed = !!req.body?.collapsed;
+    if (!masterId) return res.status(400).send("Invalid master");
+    try {
+      const current = await getUserRoomCollapseState(userId);
+      const next = { ...(current.master || {}) };
+      next[masterId] = collapsed;
+      const serialized = JSON.stringify(next);
+      await dbRunAsync(`UPDATE users SET room_master_collapsed = ? WHERE id = ?`, [serialized, userId]);
+      try {
+        await pgPool.query(`UPDATE users SET room_master_collapsed = $1 WHERE id = $2`, [serialized, userId]);
+      } catch {}
+      return res.json({ ok: true });
+    } catch (e) {
+      console.warn("[rooms] master collapse failed", e?.message || e);
+      return res.status(500).send("Failed");
+    }
+  }
+);
+
+app.patch(
+  "/api/users/me/room-category-collapsed",
+  strictLimiter,
+  requireLogin,
+  express.json({ limit: "8kb" }),
+  async (req, res) => {
+    const userId = req.session?.user?.id;
+    const categoryId = String(req.body?.category_id || "").trim();
+    const collapsed = !!req.body?.collapsed;
+    if (!categoryId) return res.status(400).send("Invalid category");
+    try {
+      const current = await getUserRoomCollapseState(userId);
+      const next = { ...(current.category || {}) };
+      next[categoryId] = collapsed;
+      const serialized = JSON.stringify(next);
+      await dbRunAsync(`UPDATE users SET room_category_collapsed = ? WHERE id = ?`, [serialized, userId]);
+      try {
+        await pgPool.query(`UPDATE users SET room_category_collapsed = $1 WHERE id = $2`, [serialized, userId]);
+      } catch {}
+      return res.json({ ok: true });
+    } catch (e) {
+      console.warn("[rooms] category collapse failed", e?.message || e);
+      return res.status(500).send("Failed");
+    }
+  }
+);
 
 // ---- Changelog API
 app.get("/api/changelog", requireLogin, async (req, res) => {


### PR DESCRIPTION
### Motivation

- Reduce room list clutter by grouping rooms into a collapsible master/category hierarchy and give Owners safe controls to manage that hierarchy.
- Persist per-user collapse state and room assignments so structure changes are live and survive reloads.
- Keep backwards compatibility: seed default masters/categories, backfill existing rooms, and avoid breaking existing room/DM behavior.

### Description

- Database: added SQLite migration/backfill in `database.js` to create `room_master_categories` and `room_categories`, add `category_id`, `room_sort_order`, `created_by_user_id`, and `is_user_room` to `rooms`, and add `room_master_collapsed` / `room_category_collapsed` to `users`; Postgres schema creation/column adds and seeding were added in `server.js` to mirror these changes and create defaults (`Site Rooms`, `User Rooms`, and their `Uncategorized`).
- Server/API/sockets: implemented structure builders and payloads (`buildRoomStructure`/`buildRoomStructurePayload`), emit `roomStructure:update` and updated `rooms update` emissions, and added Owner-only endpoints for masters/categories/rooms (create/patch/delete/reorder/move) plus per-user collapse persistence endpoints under `/api/users/me/*` in `server.js`.
- Client UI: replaced flat room list rendering with nested rendering of masters → categories → rooms, persisted per-user collapse toggles via new API endpoints, added Owner-only in-site management modal and a Create Room modal that allow selecting master + category when creating rooms, and added corresponding CSS styles in `public/styles.css` and DOM in `public/index.html` with supporting logic in `public/app.js` to keep live updates in sync via sockets.
- Safety: default masters/categories are protected (cannot delete/rename defaults), fallback handling for missing categories uses `Uncategorized`, and existing rooms are backfilled into sensible defaults.

### Testing

- Started the app with `node server.js` to validate migrations and server boot; the server started and served HTTP, while Postgres init logged a DNS/ENOTFOUND error in this environment (expected when no PG connection is configured) but fallbacks allowed the app to run.
- Performed a UI smoke run with Playwright to load the app and capture a screenshot (`artifacts/room-hierarchy.png`), demonstrating the nested room list and Owner controls rendering; the script completed and produced the artifact.
- No unit/integration test suite was added; all verification here was runtime/manual/SMOKE-level and succeeded given the local environment constraints (PG unavailable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696af78440a88333ac35beae26910010)