### PR TITLE
Add Survival Simulator room and simulation engine

### DIFF
--- a/database.js
+++ b/database.js
@@ -66,7 +66,7 @@ async function migrateLegacyPasswords() {
 
 async function seedDefaultRooms() {
   const now = Date.now();
-  const seedRooms = ["main", "nsfw", "music", "diceroom"];
+  const seedRooms = ["main", "nsfw", "music", "diceroom", "survivalsimulator"];
   for (const r of seedRooms) {
     await run(`INSERT OR IGNORE INTO rooms (name, created_by, created_at) VALUES (?, NULL, ?)`, [r, now]);
   }
@@ -193,6 +193,69 @@ async function runSqliteMigrations() {
   await ensureRoomHierarchySqlite();
 
   await seedDefaultRooms();
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS survival_seasons (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      room_id INTEGER NOT NULL,
+      created_by_user_id INTEGER NOT NULL,
+      title TEXT NOT NULL,
+      status TEXT NOT NULL,
+      day_index INTEGER NOT NULL DEFAULT 1,
+      phase TEXT NOT NULL DEFAULT 'day',
+      rng_seed TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS survival_participants (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      season_id INTEGER NOT NULL,
+      user_id INTEGER NOT NULL,
+      display_name TEXT NOT NULL,
+      avatar_url TEXT,
+      alive INTEGER NOT NULL DEFAULT 1,
+      hp INTEGER NOT NULL DEFAULT 100,
+      kills INTEGER NOT NULL DEFAULT 0,
+      alliance_id INTEGER,
+      inventory_json TEXT DEFAULT '[]',
+      traits_json TEXT DEFAULT '{}',
+      last_event_at INTEGER,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (season_id) REFERENCES survival_seasons(id) ON DELETE CASCADE
+    )
+  `);
+  await run(`CREATE INDEX IF NOT EXISTS idx_survival_participants_season ON survival_participants(season_id)`);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS survival_alliances (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      season_id INTEGER NOT NULL,
+      name TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (season_id) REFERENCES survival_seasons(id) ON DELETE CASCADE
+    )
+  `);
+  await run(`CREATE INDEX IF NOT EXISTS idx_survival_alliances_season ON survival_alliances(season_id)`);
+
+  await run(`
+    CREATE TABLE IF NOT EXISTS survival_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      season_id INTEGER NOT NULL,
+      day_index INTEGER NOT NULL,
+      phase TEXT NOT NULL,
+      order_index INTEGER NOT NULL,
+      text TEXT NOT NULL,
+      involved_user_ids_json TEXT DEFAULT '[]',
+      outcome_json TEXT DEFAULT '{}',
+      created_at INTEGER NOT NULL,
+      FOREIGN KEY (season_id) REFERENCES survival_seasons(id) ON DELETE CASCADE
+    )
+  `);
+  await run(`CREATE INDEX IF NOT EXISTS idx_survival_events_season ON survival_events(season_id)`);
+  await run(`CREATE INDEX IF NOT EXISTS idx_survival_events_day_phase ON survival_events(season_id, day_index, phase)`);
 
   const userColumns = [
     ["password_hash", "password_hash TEXT"],

--- a/public/app.js
+++ b/public/app.js
@@ -805,13 +805,24 @@ let roomStructure = { masters: [], categories: [], rooms: [] };
 let roomCollapseState = { master: {}, category: {} };
 const memoryCacheByFilter = new Map();
 const DICE_ROOM_ID = "diceroom";
+const SURVIVAL_ROOM_ID = "survivalsimulator";
 function isDiceRoom(activeRoom){
   const roomName = typeof activeRoom === "string"
     ? activeRoom
     : (activeRoom?.name ?? activeRoom?.id ?? "");
   return String(roomName || "").toLowerCase() === DICE_ROOM_ID;
 }
-function displayRoomName(room){ return isDiceRoom(room) ? "Dice Room" : room; }
+function isSurvivalRoom(activeRoom){
+  const roomName = typeof activeRoom === "string"
+    ? activeRoom
+    : (activeRoom?.name ?? activeRoom?.id ?? "");
+  return String(roomName || "").toLowerCase() === SURVIVAL_ROOM_ID;
+}
+function displayRoomName(room){
+  if (isDiceRoom(room)) return "Dice Room";
+  if (isSurvivalRoom(room)) return "Survival Simulator";
+  return room;
+}
 
 let lastUsers = [];
 let membersViewMode = "room"; // room|friends
@@ -2070,6 +2081,18 @@ const diceSessionStats = {
   luckyStreak: 0,
   lastRollAt: 0,
 };
+let survivalState = {
+  season: null,
+  participants: [],
+  alliances: [],
+  events: [],
+  history: [],
+  selectedSeasonId: null,
+  logBeforeId: null,
+  winner: null,
+};
+let survivalAutoRunTimer = null;
+let survivalAutoRunning = false;
 const luckState = {
   luck: 0,
   rollStreak: 0,
@@ -2685,6 +2708,35 @@ const luckMeterBar = document.getElementById("luckMeterBar");
 const luckMeterBarText = document.getElementById("luckMeterBarText");
 const luckMeterValue = document.getElementById("luckMeterValue");
 const luckMeterStreak = document.getElementById("luckMeterStreak");
+const survivalPanel = document.getElementById("survivalPanel");
+const survivalSeasonTitle = document.getElementById("survivalSeasonTitle");
+const survivalStatus = document.getElementById("survivalStatus");
+const survivalDayPhase = document.getElementById("survivalDayPhase");
+const survivalAliveCount = document.getElementById("survivalAliveCount");
+const survivalNewSeasonBtn = document.getElementById("survivalNewSeasonBtn");
+const survivalAdvanceBtn = document.getElementById("survivalAdvanceBtn");
+const survivalAutoRunBtn = document.getElementById("survivalAutoRunBtn");
+const survivalEndBtn = document.getElementById("survivalEndBtn");
+const survivalRosterBtn = document.getElementById("survivalRosterBtn");
+const survivalLogBtn = document.getElementById("survivalLogBtn");
+const survivalHistorySelect = document.getElementById("survivalHistorySelect");
+const survivalLogFeed = document.getElementById("survivalLogFeed");
+const survivalLogList = document.getElementById("survivalLogList");
+const survivalNewSeasonModal = document.getElementById("survivalNewSeasonModal");
+const survivalNewSeasonClose = document.getElementById("survivalNewSeasonClose");
+const survivalSeasonTitleInput = document.getElementById("survivalSeasonTitleInput");
+const survivalParticipantList = document.getElementById("survivalParticipantList");
+const survivalCouplesToggle = document.getElementById("survivalCouplesToggle");
+const survivalChaosToggle = document.getElementById("survivalChaosToggle");
+const survivalSeasonStartBtn = document.getElementById("survivalSeasonStartBtn");
+const survivalSeasonMsg = document.getElementById("survivalSeasonMsg");
+const survivalRosterModal = document.getElementById("survivalRosterModal");
+const survivalRosterClose = document.getElementById("survivalRosterClose");
+const survivalRosterList = document.getElementById("survivalRosterList");
+const survivalLogModal = document.getElementById("survivalLogModal");
+const survivalLogClose = document.getElementById("survivalLogClose");
+const survivalLogModalList = document.getElementById("survivalLogModalList");
+const survivalLogLoadBtn = document.getElementById("survivalLogLoadBtn");
 
 let mediaMenuOpen = false;
 let voiceRec = { recorder: null, stream: null, chunks: [], startedAt: 0 };
@@ -2695,6 +2747,9 @@ try {
   const nowDiceRoom = isDiceRoom(currentRoom);
   if (diceVariantWrap) diceVariantWrap.style.display = nowDiceRoom ? "" : "none";
   if (luckMeter) luckMeter.style.display = nowDiceRoom ? "" : "none";
+  const nowSurvivalRoom = isSurvivalRoom(currentRoom);
+  if (survivalPanel) survivalPanel.hidden = !nowSurvivalRoom;
+  if (survivalLogFeed) survivalLogFeed.hidden = !nowSurvivalRoom;
 } catch {}
 
 function closeMediaMenu(){
@@ -2845,28 +2900,370 @@ function requestLuckState(force = false){
   socket.emit("luck:get");
 }
 
-diceInfoBtn?.addEventListener("click", (e)=>{
-  e.preventDefault();
-  e.stopPropagation();
-  // Don't stack menus on top of each other
-  if (diceVariantMenuOpen) closeDiceVariantMenu();
-  toggleDicePayout();
-});
+function survivalIsOwner(){
+  return me && roleRank(me.role) >= roleRank("Co-owner");
+}
 
-document.addEventListener("click", (e)=>{
-  if (!dicePayoutOpen) return;
-  const t = e.target;
-  if (t && (dicePayoutPopover?.contains(t) || diceInfoBtn?.contains(t))) return;
-  closeDicePayout();
-}, { passive:true });
+function updateSurvivalHistorySelect() {
+  if (!survivalHistorySelect) return;
+  const history = survivalState.history || [];
+  survivalHistorySelect.innerHTML = "";
+  const placeholder = document.createElement("option");
+  placeholder.value = "";
+  placeholder.textContent = history.length ? "Select season" : "No history yet";
+  survivalHistorySelect.appendChild(placeholder);
+  history.forEach((season) => {
+    const opt = document.createElement("option");
+    opt.value = season.id;
+    const winner = season.winner ? ` — Winner: ${season.winner}` : "";
+    opt.textContent = `${season.title}${winner}`;
+    survivalHistorySelect.appendChild(opt);
+  });
+  if (survivalState.selectedSeasonId) {
+    survivalHistorySelect.value = String(survivalState.selectedSeasonId);
+  }
+}
 
-setDiceVariant(diceVariant);
+function getSurvivalAliveCount() {
+  return (survivalState.participants || []).filter((p) => p.alive).length;
+}
 
-function resetDiceSessionStats(){
-  diceSessionStats.consecutiveRolls = 0;
-  diceSessionStats.highestRoll = 0;
-  diceSessionStats.luckyStreak = 0;
-  diceSessionStats.lastRollAt = 0;
+function renderSurvivalPanel() {
+  if (!survivalPanel) return;
+  const season = survivalState.season;
+  const aliveCount = getSurvivalAliveCount();
+  if (survivalSeasonTitle) survivalSeasonTitle.textContent = season ? season.title : "No season";
+  if (survivalStatus) {
+    let statusLabel = season ? season.status : "idle";
+    if (season?.status === "finished" && survivalState.winner) {
+      statusLabel = `finished — ${survivalState.winner}`;
+    }
+    survivalStatus.textContent = statusLabel;
+  }
+  if (survivalDayPhase) {
+    const day = season?.day_index ? `Day ${season.day_index}` : "Day 1";
+    const phase = season?.phase ? capitalize(season.phase) : "Day";
+    survivalDayPhase.textContent = `${day} — ${phase}`;
+  }
+  if (survivalAliveCount) survivalAliveCount.textContent = `Alive: ${aliveCount}`;
+
+  if (survivalNewSeasonBtn) survivalNewSeasonBtn.disabled = !survivalIsOwner();
+  if (survivalAdvanceBtn) survivalAdvanceBtn.disabled = !survivalIsOwner() || !season || season.status !== "running";
+  if (survivalAutoRunBtn) survivalAutoRunBtn.disabled = !survivalIsOwner() || !season || season.status !== "running";
+  if (survivalEndBtn) survivalEndBtn.disabled = !survivalIsOwner() || !season;
+  if (survivalAutoRunBtn) survivalAutoRunBtn.textContent = survivalAutoRunning ? "Stop Auto" : "Auto-Run";
+  updateSurvivalHistorySelect();
+}
+
+function getSurvivalEventIcon(outcome = {}) {
+  const type = outcome?.type;
+  if (type === "kill" || type === "betray") return "☠️";
+  if (type === "alliance") return "🤝";
+  if (type === "injure") return "🩹";
+  if (type === "heal" || type === "protect") return "💚";
+  if (type === "loot" || type === "steal") return "🎒";
+  if (type === "winner") return "🏆";
+  if (type === "draw") return "⚠️";
+  return "✨";
+}
+
+function renderSurvivalLog(targetEl, events) {
+  if (!targetEl) return;
+  targetEl.innerHTML = "";
+  if (!events || !events.length) {
+    const empty = document.createElement("div");
+    empty.className = "survivalLogText";
+    empty.textContent = "No events yet.";
+    targetEl.appendChild(empty);
+    return;
+  }
+  let lastHeader = "";
+  (events || []).forEach((event) => {
+    const header = `Day ${event.day_index} — ${capitalize(event.phase || "day")}`;
+    if (header !== lastHeader) {
+      const divider = document.createElement("div");
+      divider.className = "survivalLogDivider";
+      divider.textContent = header;
+      targetEl.appendChild(divider);
+      lastHeader = header;
+    }
+    const row = document.createElement("div");
+    row.className = "survivalLogItem";
+    const icon = document.createElement("div");
+    icon.className = "survivalLogIcon";
+    icon.textContent = getSurvivalEventIcon(event.outcome || {});
+    const text = document.createElement("div");
+    text.className = "survivalLogText";
+    text.textContent = event.text || "";
+    row.appendChild(icon);
+    row.appendChild(text);
+    targetEl.appendChild(row);
+  });
+}
+
+function renderSurvivalRoster() {
+  if (!survivalRosterList) return;
+  survivalRosterList.innerHTML = "";
+  const alliances = new Map((survivalState.alliances || []).map((a) => [a.id, a.name]));
+  const participants = (survivalState.participants || []).slice().sort((a, b) => Number(b.alive) - Number(a.alive));
+  participants.forEach((p) => {
+    const row = document.createElement("div");
+    row.className = "survivalRosterRow";
+    row.classList.toggle("dead", !p.alive);
+    const avatar = document.createElement("div");
+    avatar.className = "survivalRosterAvatar";
+    if (p.avatar_url) avatar.style.backgroundImage = `url('${p.avatar_url}')`;
+    const meta = document.createElement("div");
+    meta.className = "survivalRosterMeta";
+    const name = document.createElement("div");
+    name.className = "survivalRosterName";
+    name.textContent = p.display_name;
+    const stats = document.createElement("div");
+    stats.className = "survivalRosterStats";
+    const status = document.createElement("span");
+    status.className = `survivalRosterStatus ${p.alive ? "alive" : "dead"}`;
+    status.textContent = p.alive ? "Alive" : "Down";
+    const allianceName = p.alliance_id ? alliances.get(p.alliance_id) : null;
+    stats.textContent = `${status.textContent} • ${p.kills || 0} KOs${allianceName ? ` • ${allianceName}` : ""}`;
+    meta.appendChild(name);
+    meta.appendChild(stats);
+    row.appendChild(avatar);
+    row.appendChild(meta);
+    row.addEventListener("click", () => {
+      if (p.display_name) openMemberProfile(p.display_name);
+    });
+    survivalRosterList.appendChild(row);
+  });
+}
+
+async function loadSurvivalCurrent() {
+  if (!isSurvivalRoom(currentRoom)) return;
+  const { res, text } = await api("/api/survival/current", { method: "GET" });
+  if (!res.ok) return;
+  const payload = safeJsonParse(text, null);
+  if (!payload) return;
+  applySurvivalPayload(payload, { replaceEvents: true });
+}
+
+async function loadSurvivalSeason(seasonId, { beforeId = null } = {}) {
+  if (!seasonId) return null;
+  const url = beforeId ? `/api/survival/seasons/${seasonId}?before=${encodeURIComponent(beforeId)}` : `/api/survival/seasons/${seasonId}`;
+  const { res, text } = await api(url, { method: "GET" });
+  if (!res.ok) return null;
+  const payload = safeJsonParse(text, null);
+  if (!payload) return null;
+  return payload;
+}
+
+function applySurvivalPayload(payload, { replaceEvents = false } = {}) {
+  if (payload.season) survivalState.season = payload.season;
+  if (Array.isArray(payload.participants)) survivalState.participants = payload.participants;
+  if (Array.isArray(payload.alliances)) survivalState.alliances = payload.alliances;
+  if (payload.winner !== undefined) survivalState.winner = payload.winner;
+  if (Array.isArray(payload.history)) survivalState.history = payload.history;
+  if (Array.isArray(payload.events)) {
+    if (replaceEvents) {
+      survivalState.events = payload.events;
+    } else {
+      survivalState.events = [...payload.events];
+    }
+    survivalState.logBeforeId = payload.events?.[0]?.id || survivalState.logBeforeId;
+  }
+  if (!survivalState.selectedSeasonId && payload.season) {
+    survivalState.selectedSeasonId = payload.season.id;
+  }
+  renderSurvivalPanel();
+  renderSurvivalLog(survivalLogList, survivalState.events);
+}
+
+async function openSurvivalNewSeasonModal() {
+  if (!survivalNewSeasonModal) return;
+  if (!survivalIsOwner()) return toast("Only Owner/Co-Owner can start a season.");
+  survivalSeasonMsg.textContent = "";
+  const now = new Date();
+  if (survivalSeasonTitleInput) {
+    survivalSeasonTitleInput.value = `Season — ${now.toLocaleString()}`;
+  }
+  const users = (lastUsers || []).filter((u) => u?.name);
+  survivalParticipantList.innerHTML = "";
+  if (survivalCouplesToggle) survivalCouplesToggle.checked = false;
+  if (survivalChaosToggle) survivalChaosToggle.checked = false;
+  users.forEach((user) => {
+    if (!user?.id) return;
+    const row = document.createElement("label");
+    row.className = "survivalParticipantRow";
+    row.innerHTML = `<input type="checkbox" value="${user.id}"/> ${escapeHtml(user.name)}`;
+    survivalParticipantList.appendChild(row);
+  });
+  survivalNewSeasonModal.hidden = false;
+  survivalNewSeasonModal.style.display = "flex";
+  survivalNewSeasonModal.classList.remove("modal-closing");
+  if (PREFERS_REDUCED_MOTION) {
+    survivalNewSeasonModal.classList.add("modal-visible");
+  } else {
+    requestAnimationFrame(() => survivalNewSeasonModal.classList.add("modal-visible"));
+  }
+}
+
+function closeSurvivalNewSeasonModal() {
+  if (!survivalNewSeasonModal) return;
+  survivalNewSeasonModal.classList.remove("modal-visible");
+  survivalNewSeasonModal.classList.add("modal-closing");
+  setTimeout(() => {
+    survivalNewSeasonModal.style.display = "none";
+    survivalNewSeasonModal.classList.remove("modal-closing");
+    survivalNewSeasonModal.hidden = true;
+  }, 140);
+}
+
+function openSurvivalRosterModal() {
+  if (!survivalRosterModal) return;
+  renderSurvivalRoster();
+  survivalRosterModal.hidden = false;
+  survivalRosterModal.style.display = "flex";
+  survivalRosterModal.classList.remove("modal-closing");
+  if (PREFERS_REDUCED_MOTION) {
+    survivalRosterModal.classList.add("modal-visible");
+  } else {
+    requestAnimationFrame(() => survivalRosterModal.classList.add("modal-visible"));
+  }
+}
+
+function closeSurvivalRosterModal() {
+  if (!survivalRosterModal) return;
+  survivalRosterModal.classList.remove("modal-visible");
+  survivalRosterModal.classList.add("modal-closing");
+  setTimeout(() => {
+    survivalRosterModal.style.display = "none";
+    survivalRosterModal.classList.remove("modal-closing");
+    survivalRosterModal.hidden = true;
+  }, 140);
+}
+
+function openSurvivalLogModal() {
+  if (!survivalLogModal) return;
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
+  survivalLogModal.hidden = false;
+  survivalLogModal.style.display = "flex";
+  survivalLogModal.classList.remove("modal-closing");
+  if (PREFERS_REDUCED_MOTION) {
+    survivalLogModal.classList.add("modal-visible");
+  } else {
+    requestAnimationFrame(() => survivalLogModal.classList.add("modal-visible"));
+  }
+}
+
+function closeSurvivalLogModal() {
+  if (!survivalLogModal) return;
+  survivalLogModal.classList.remove("modal-visible");
+  survivalLogModal.classList.add("modal-closing");
+  setTimeout(() => {
+    survivalLogModal.style.display = "none";
+    survivalLogModal.classList.remove("modal-closing");
+    survivalLogModal.hidden = true;
+  }, 140);
+}
+
+async function startSurvivalSeason() {
+  if (!survivalIsOwner()) return;
+  const mode = document.querySelector("input[name='survivalPickMode']:checked")?.value || "online";
+  const selected = Array.from(
+    survivalParticipantList.querySelectorAll("input[type='checkbox']:checked")
+  ).map((el) => Number(el.value));
+  const onlineIds = (lastUsers || []).map((u) => u?.id).filter((id) => Number.isInteger(id));
+  const participantIds = mode === "select" ? selected : onlineIds;
+  if (participantIds.length < 2) {
+    if (survivalSeasonMsg) survivalSeasonMsg.textContent = "Pick at least two participants.";
+    return;
+  }
+  if (survivalSeasonStartBtn) survivalSeasonStartBtn.disabled = true;
+  if (survivalSeasonMsg) survivalSeasonMsg.textContent = "Starting season...";
+  try {
+    const payload = {
+      title: survivalSeasonTitleInput?.value || "",
+      participant_user_ids: participantIds,
+      options: {
+        includeCouples: !!survivalCouplesToggle?.checked,
+        chaoticMode: !!survivalChaosToggle?.checked,
+      },
+    };
+    const { res, text } = await api("/api/survival/seasons", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) throw new Error(text || "Failed");
+    const data = safeJsonParse(text, null);
+    if (data) applySurvivalPayload(data, { replaceEvents: true });
+    closeSurvivalNewSeasonModal();
+  } catch (err) {
+    if (survivalSeasonMsg) survivalSeasonMsg.textContent = err?.message || "Failed to start season.";
+  } finally {
+    if (survivalSeasonStartBtn) survivalSeasonStartBtn.disabled = false;
+  }
+}
+
+async function advanceSurvivalSeason() {
+  if (!survivalIsOwner()) return;
+  const seasonId = survivalState.season?.id;
+  if (!seasonId) return;
+  try {
+    const { res, text } = await api(`/api/survival/seasons/${seasonId}/advance`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{}",
+    });
+    if (!res.ok) throw new Error(text || "Failed");
+    const data = safeJsonParse(text, null);
+    if (data) applySurvivalPayload(data, { replaceEvents: true });
+  } catch (err) {
+    toast(err?.message || "Could not advance season.");
+  }
+}
+
+async function endSurvivalSeason() {
+  if (!survivalIsOwner()) return;
+  const seasonId = survivalState.season?.id;
+  if (!seasonId) return;
+  if (!confirm("End this season early?")) return;
+  try {
+    const { res, text } = await api(`/api/survival/seasons/${seasonId}/end`, { method: "POST" });
+    if (!res.ok) throw new Error(text || "Failed");
+    const data = safeJsonParse(text, null);
+    if (data) applySurvivalPayload(data, { replaceEvents: true });
+  } catch (err) {
+    toast(err?.message || "Could not end season.");
+  }
+}
+
+function startSurvivalAutoRun() {
+  if (survivalAutoRunTimer) return;
+  survivalAutoRunning = true;
+  renderSurvivalPanel();
+  survivalAutoRunTimer = setInterval(async () => {
+    if (!survivalState.season || survivalState.season.status !== "running") {
+      stopSurvivalAutoRun();
+      return;
+    }
+    await advanceSurvivalSeason();
+  }, 2200);
+}
+
+function stopSurvivalAutoRun() {
+  if (survivalAutoRunTimer) clearInterval(survivalAutoRunTimer);
+  survivalAutoRunTimer = null;
+  survivalAutoRunning = false;
+  renderSurvivalPanel();
+}
+
+async function loadOlderSurvivalLog() {
+  const seasonId = survivalState.selectedSeasonId || survivalState.season?.id;
+  if (!seasonId || !survivalState.logBeforeId) return;
+  const payload = await loadSurvivalSeason(seasonId, { beforeId: survivalState.logBeforeId });
+  if (!payload || !payload.events?.length) return;
+  survivalState.logBeforeId = payload.events[0]?.id || survivalState.logBeforeId;
+  survivalState.events = [...payload.events, ...survivalState.events];
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
 }
 
 function isHighRoll(variant, result){
@@ -3531,6 +3928,11 @@ function escapeHtml(s){
   return String(s).replace(/[&<>"']/g, m => ({
     "&":"&amp;", "<":"&lt;", ">":"&gt;", '"':"&quot;", "'":"&#039;"
   }[m]));
+}
+
+function capitalize(value){
+  const str = String(value || "");
+  return str ? str.charAt(0).toUpperCase() + str.slice(1) : "";
 }
 
 // Linkify plain-text URLs into safe anchors.
@@ -8970,17 +9372,63 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && roomCreateModal && roomCreateModal.style.display !== "none") {
     closeRoomCreateModal();
   }
+  if (e.key === "Escape" && survivalNewSeasonModal && survivalNewSeasonModal.style.display !== "none") {
+    closeSurvivalNewSeasonModal();
+  }
+  if (e.key === "Escape" && survivalRosterModal && survivalRosterModal.style.display !== "none") {
+    closeSurvivalRosterModal();
+  }
+  if (e.key === "Escape" && survivalLogModal && survivalLogModal.style.display !== "none") {
+    closeSurvivalLogModal();
+  }
 });
 
 closeModalBtn.addEventListener("click", closeModal);
 modal.addEventListener("click", (e)=>{ if(e.target===modal) closeModal(); });
 
+survivalNewSeasonBtn?.addEventListener("click", openSurvivalNewSeasonModal);
+survivalNewSeasonClose?.addEventListener("click", closeSurvivalNewSeasonModal);
+survivalNewSeasonModal?.addEventListener("click", (e) => {
+  if (e.target === survivalNewSeasonModal) closeSurvivalNewSeasonModal();
+});
+survivalSeasonStartBtn?.addEventListener("click", startSurvivalSeason);
+survivalAdvanceBtn?.addEventListener("click", advanceSurvivalSeason);
+survivalEndBtn?.addEventListener("click", endSurvivalSeason);
+survivalRosterBtn?.addEventListener("click", openSurvivalRosterModal);
+survivalRosterClose?.addEventListener("click", closeSurvivalRosterModal);
+survivalRosterModal?.addEventListener("click", (e) => {
+  if (e.target === survivalRosterModal) closeSurvivalRosterModal();
+});
+survivalLogBtn?.addEventListener("click", openSurvivalLogModal);
+survivalLogClose?.addEventListener("click", closeSurvivalLogModal);
+survivalLogModal?.addEventListener("click", (e) => {
+  if (e.target === survivalLogModal) closeSurvivalLogModal();
+});
+survivalLogLoadBtn?.addEventListener("click", loadOlderSurvivalLog);
+survivalAutoRunBtn?.addEventListener("click", () => {
+  if (!survivalAutoRunning) startSurvivalAutoRun();
+  else stopSurvivalAutoRun();
+});
+survivalHistorySelect?.addEventListener("change", async (e) => {
+  const val = e.target.value;
+  if (!val) return;
+  const payload = await loadSurvivalSeason(val);
+  if (!payload) return;
+  survivalState.selectedSeasonId = payload.season?.id || Number(val);
+  applySurvivalPayload(payload, { replaceEvents: true });
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
+  renderSurvivalRoster();
+});
+
 // rooms
 function setActiveRoom(room){
   const wasDiceRoom = isDiceRoom(currentRoom);
+  const wasSurvivalRoom = isSurvivalRoom(currentRoom);
   currentRoom = room;
   const nowDiceRoom = isDiceRoom(room);
+  const nowSurvivalRoom = isSurvivalRoom(room);
   document.body.classList.toggle("dice-room", nowDiceRoom);
+  document.body.classList.toggle("survival-room", nowSurvivalRoom);
   nowRoom.textContent = displayRoomName(room);
   roomTitle.textContent = displayRoomName(room);
   msgInput.placeholder = `Message ${displayRoomName(room)}`;
@@ -8989,9 +9437,20 @@ function setActiveRoom(room){
   // Ensure room-specific UI doesn't leak into other rooms.
   if (diceVariantWrap) diceVariantWrap.style.display = nowDiceRoom ? "" : "none";
   if (luckMeter) luckMeter.style.display = nowDiceRoom ? "" : "none";
+  if (survivalPanel) survivalPanel.hidden = !nowSurvivalRoom;
+  if (survivalLogFeed) survivalLogFeed.hidden = !nowSurvivalRoom;
   // If a modal is open that is built around room/profile context, close it when switching rooms.
   try {
     if (couplesModal && couplesModal.style.display && couplesModal.style.display !== "none") closeCouplesModal();
+  } catch {}
+  try {
+    if (survivalRosterModal && survivalRosterModal.style.display && survivalRosterModal.style.display !== "none") closeSurvivalRosterModal();
+  } catch {}
+  try {
+    if (survivalLogModal && survivalLogModal.style.display && survivalLogModal.style.display !== "none") closeSurvivalLogModal();
+  } catch {}
+  try {
+    if (survivalNewSeasonModal && survivalNewSeasonModal.style.display && survivalNewSeasonModal.style.display !== "none") closeSurvivalNewSeasonModal();
   } catch {}
 
 
@@ -9014,6 +9473,12 @@ function setActiveRoom(room){
   if (nowDiceRoom) {
     renderLuckMeter();
     requestLuckState();
+  }
+  if (wasSurvivalRoom && !nowSurvivalRoom) {
+    stopSurvivalAutoRun();
+  }
+  if (nowSurvivalRoom) {
+    loadSurvivalCurrent();
   }
   document.querySelectorAll(".chan").forEach(el=>{
     el.classList.toggle("active", el.dataset.room === room);
@@ -14343,6 +14808,23 @@ initAppealsDurationSelect();
     try{
       if(typeof playSound === "function") playSound("mention");
     }catch(_){}
+  });
+
+  socket.on("survival:update", (payload = {}) => {
+    if (!isSurvivalRoom(currentRoom)) return;
+    if (!payload || typeof payload !== "object") return;
+    applySurvivalPayload(payload, { replaceEvents: true });
+  });
+
+  socket.on("survival:events", (payload = {}) => {
+    if (!isSurvivalRoom(currentRoom)) return;
+    if (!payload || payload.seasonId !== survivalState.season?.id) return;
+    if (!Array.isArray(payload.events)) return;
+    survivalState.events = [...survivalState.events, ...payload.events];
+    renderSurvivalLog(survivalLogList, survivalState.events);
+    if (survivalLogModal && survivalLogModal.style.display !== "none") {
+      renderSurvivalLog(survivalLogModalList, survivalState.events);
+    }
   });
 
 socket.on("disconnect", (reason) => {

--- a/public/index.html
+++ b/public/index.html
@@ -392,6 +392,57 @@
 </div>
 </div>
 </div>
+<div class="modal" hidden="" id="survivalNewSeasonModal">
+<div class="modalCard survivalModal">
+<div class="modalTop">
+<strong>New Survival Season</strong>
+<button aria-label="Close" class="iconBtn" id="survivalNewSeasonClose" type="button">✕</button>
+</div>
+<div class="modalBody">
+<label class="fieldLabel">Title
+  <input id="survivalSeasonTitleInput" maxlength="120" placeholder="Season — ..." type="text"/>
+</label>
+<div class="survivalPicker">
+  <div class="survivalPickerModes">
+    <label><input checked="" name="survivalPickMode" type="radio" value="online"/> Everyone online</label>
+    <label><input name="survivalPickMode" type="radio" value="select"/> Select users</label>
+  </div>
+  <div class="survivalParticipantList" id="survivalParticipantList"></div>
+</div>
+<div class="survivalOptions">
+  <label><input id="survivalCouplesToggle" type="checkbox"/> Include Couples synergy</label>
+  <label><input id="survivalChaosToggle" type="checkbox"/> Chaotic mode</label>
+</div>
+<div class="modalActions">
+  <button class="btn" id="survivalSeasonStartBtn" type="button">Start</button>
+</div>
+<div class="small muted" id="survivalSeasonMsg"></div>
+</div>
+</div>
+</div>
+<div class="modal" hidden="" id="survivalRosterModal">
+<div class="modalCard survivalModal">
+<div class="modalTop">
+<strong>Survival Roster</strong>
+<button aria-label="Close" class="iconBtn" id="survivalRosterClose" type="button">✕</button>
+</div>
+<div class="modalBody">
+<div class="survivalRosterList" id="survivalRosterList"></div>
+</div>
+</div>
+</div>
+<div class="modal" hidden="" id="survivalLogModal">
+<div class="modalCard survivalModal">
+<div class="modalTop">
+<strong>Survival Log</strong>
+<button aria-label="Close" class="iconBtn" id="survivalLogClose" type="button">✕</button>
+</div>
+<div class="modalBody">
+<button class="btn secondary small" id="survivalLogLoadBtn" type="button">Load older</button>
+<div class="survivalLogList" id="survivalLogModalList"></div>
+</div>
+</div>
+</div>
 <div class="luckMeter" id="luckMeter">
   <div class="luckMeterHeader">
     <span class="luckMeterTitle">🍀 Luck</span>
@@ -401,6 +452,38 @@
   <div aria-label="Luck meter" class="luckMeterBar" id="luckMeterBar" role="meter" aria-valuemin="-2.0" aria-valuemax="0.30" aria-valuenow="0">
     <span class="luckMeterBarText" id="luckMeterBarText">|------------^------------|</span>
   </div>
+</div>
+<div class="survivalPanel" hidden="" id="survivalPanel">
+  <div class="survivalPanelHeader">
+    <div class="survivalPanelTitle">
+      <span class="survivalPanelName">Survival Simulator</span>
+      <span class="survivalPanelSeasonTitle" id="survivalSeasonTitle">No season</span>
+      <span class="survivalPanelStatus" id="survivalStatus">No season</span>
+    </div>
+    <div class="survivalPanelMeta">
+      <span class="survivalPanelPhase" id="survivalDayPhase">Day 1 — Day</span>
+      <span class="survivalPanelAlive" id="survivalAliveCount">Alive: 0</span>
+    </div>
+  </div>
+  <div class="survivalPanelControls">
+    <div class="survivalPanelGroup">
+      <button class="btn secondary small" id="survivalNewSeasonBtn" type="button">New Season</button>
+      <button class="btn secondary small" id="survivalAdvanceBtn" type="button">Advance</button>
+      <button class="btn secondary small" id="survivalAutoRunBtn" type="button">Auto-Run</button>
+      <button class="btn secondary small" id="survivalEndBtn" type="button">Reset/End</button>
+    </div>
+    <div class="survivalPanelGroup">
+      <button class="btn secondary small" id="survivalRosterBtn" type="button">View Roster</button>
+      <button class="btn secondary small" id="survivalLogBtn" type="button">View Log</button>
+      <label class="survivalHistoryLabel">History
+        <select id="survivalHistorySelect"></select>
+      </label>
+    </div>
+  </div>
+</div>
+<div class="survivalLogFeed" hidden="" id="survivalLogFeed">
+  <div class="survivalLogHeader">Recent Log</div>
+  <div class="survivalLogList" id="survivalLogList"></div>
 </div>
 <div class="msgs" id="msgs"></div>
 <div class="typing" id="typing"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2634,6 +2634,207 @@ body.dice-room .luckMeter{
 .luckMeterBarText{
   color:var(--text);
 }
+/* Survival Simulator panel */
+.survivalPanel{
+  display:none;
+  position: sticky;
+  top:0;
+  z-index:120;
+  margin:8px 12px 6px;
+  padding:12px 14px;
+  border-radius:16px;
+  border:1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 88%, transparent);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+}
+body.survival-room .survivalPanel{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.survivalPanelHeader{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:space-between;
+  gap:6px 14px;
+}
+.survivalPanelTitle{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  font-weight:800;
+}
+.survivalPanelName{
+  font-size:14px;
+}
+.survivalPanelSeasonTitle{
+  font-size:12px;
+  color:var(--text);
+}
+.survivalPanelStatus{
+  padding:3px 8px;
+  border-radius:999px;
+  font-size:11px;
+  background: color-mix(in srgb, var(--panel) 70%, transparent);
+  color:var(--muted);
+}
+.survivalPanelMeta{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  font-size:12px;
+  color:var(--muted);
+}
+.survivalPanelControls{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:space-between;
+  gap:8px 12px;
+}
+.survivalPanelGroup{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.survivalHistoryLabel{
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  font-size:11px;
+  color:var(--muted);
+}
+.survivalHistoryLabel select{
+  background: color-mix(in srgb, var(--panel) 80%, transparent);
+  border:1px solid var(--border);
+  color:var(--text);
+  border-radius:10px;
+  padding:4px 8px;
+}
+
+.survivalLogFeed{
+  display:none;
+  margin:0 12px 10px;
+  padding:10px 12px;
+  border-radius:14px;
+  border:1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 75%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  max-height:220px;
+  overflow:auto;
+}
+body.survival-room .survivalLogFeed{
+  display:block;
+}
+.survivalLogHeader{
+  font-size:11px;
+  letter-spacing:0.6px;
+  text-transform:uppercase;
+  color:var(--muted);
+  margin-bottom:6px;
+}
+.survivalLogList{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.survivalLogItem{
+  display:grid;
+  grid-template-columns:20px 1fr;
+  gap:8px;
+  align-items:start;
+  font-size:13px;
+}
+.survivalLogIcon{
+  font-size:14px;
+}
+.survivalLogText{
+  color:var(--text);
+}
+.survivalLogDivider{
+  margin:6px 0 4px;
+  font-size:11px;
+  color:var(--muted);
+}
+
+.survivalModal .modalBody{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.survivalPickerModes{
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  font-size:12px;
+  color:var(--muted);
+}
+.survivalParticipantList{
+  max-height:220px;
+  overflow:auto;
+  border-radius:12px;
+  border:1px solid var(--border);
+  padding:8px;
+}
+.survivalParticipantRow{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  padding:6px 4px;
+  font-size:13px;
+}
+.survivalOptions{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  font-size:12px;
+  color:var(--muted);
+}
+.survivalRosterList{
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.survivalRosterRow{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  padding:8px;
+  border-radius:12px;
+  border:1px solid var(--border);
+  background: color-mix(in srgb, var(--panel) 80%, transparent);
+}
+.survivalRosterRow.dead{
+  opacity:0.7;
+}
+.survivalRosterAvatar{
+  width:34px;
+  height:34px;
+  border-radius:50%;
+  background-size:cover;
+  background-position:center;
+}
+.survivalRosterMeta{
+  display:flex;
+  flex-direction:column;
+}
+.survivalRosterName{
+  font-weight:700;
+}
+.survivalRosterStats{
+  font-size:11px;
+  color:var(--muted);
+}
+.survivalRosterStatus.dead{
+  color:#ff9aa2;
+}
+
+.chan[data-room=\"survivalsimulator\"]::before{
+  content:\"🧭 \";
+}
 /* ---- Main chat message grouping (consecutive messages) ---- */
 .msgGroup{ display:flex; gap:10px; align-items:flex-start; max-width:900px; }
 .msgGroup.self{ align-self:flex-end; flex-direction:row-reverse; }

--- a/server.js
+++ b/server.js
@@ -39,6 +39,12 @@ const sessionMetaBySocketId = new Map(); // socket.id -> meta
 const sessionByUserId = new Map(); // userId -> Set(socket.id)
 const DICE_ROLL_MIN_INTERVAL_MS = 1000;
 const diceRollRateByUserId = new Map();
+const SURVIVAL_ROOM_ID = "survivalsimulator";
+const SURVIVAL_ROOM_DB_ID = 1;
+const SURVIVAL_SEASON_COOLDOWN_MS = 2 * 60 * 1000;
+const SURVIVAL_ADVANCE_COOLDOWN_MS = 2000;
+const survivalSeasonCooldownByRoom = new Map();
+const survivalAdvanceCooldownBySeason = new Map();
 const qualifyingMsgWindowByUserId = new Map();
 const rollCadenceWindowByUserId = new Map();
 
@@ -176,6 +182,7 @@ const {
   applyWinCut,
   normalizeLuckMessage,
 } = require("./luck-utils");
+const { SURVIVAL_EVENT_TEMPLATES, SURVIVAL_ITEM_POOL } = require("./survival-events");
 
 // ---- Safety nets (prevents silent crashes in prod) ----
 process.on("unhandledRejection", (err) => {
@@ -851,6 +858,66 @@ try {
     console.warn('[pg-init] friends tables failed:', e?.message || e);
   }
 
+  try {
+    await pgPool.query(`
+      CREATE TABLE IF NOT EXISTS survival_seasons (
+        id SERIAL PRIMARY KEY,
+        room_id INTEGER NOT NULL,
+        created_by_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL,
+        day_index INTEGER NOT NULL DEFAULT 1,
+        phase TEXT NOT NULL DEFAULT 'day',
+        rng_seed TEXT,
+        created_at BIGINT NOT NULL,
+        updated_at BIGINT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS survival_participants (
+        id SERIAL PRIMARY KEY,
+        season_id INTEGER NOT NULL REFERENCES survival_seasons(id) ON DELETE CASCADE,
+        user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+        display_name TEXT NOT NULL,
+        avatar_url TEXT,
+        alive INTEGER NOT NULL DEFAULT 1,
+        hp INTEGER NOT NULL DEFAULT 100,
+        kills INTEGER NOT NULL DEFAULT 0,
+        alliance_id INTEGER,
+        inventory_json TEXT DEFAULT '[]',
+        traits_json TEXT DEFAULT '{}',
+        last_event_at BIGINT,
+        created_at BIGINT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS survival_alliances (
+        id SERIAL PRIMARY KEY,
+        season_id INTEGER NOT NULL REFERENCES survival_seasons(id) ON DELETE CASCADE,
+        name TEXT NOT NULL,
+        created_at BIGINT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS survival_events (
+        id SERIAL PRIMARY KEY,
+        season_id INTEGER NOT NULL REFERENCES survival_seasons(id) ON DELETE CASCADE,
+        day_index INTEGER NOT NULL,
+        phase TEXT NOT NULL,
+        order_index INTEGER NOT NULL,
+        text TEXT NOT NULL,
+        involved_user_ids_json TEXT DEFAULT '[]',
+        outcome_json TEXT DEFAULT '{}',
+        created_at BIGINT NOT NULL
+      );
+    `);
+
+    await pgPool.query(`CREATE INDEX IF NOT EXISTS idx_survival_seasons_room ON survival_seasons(room_id)`);
+    await pgPool.query(`CREATE INDEX IF NOT EXISTS idx_survival_participants_season ON survival_participants(season_id)`);
+    await pgPool.query(`CREATE INDEX IF NOT EXISTS idx_survival_alliances_season ON survival_alliances(season_id)`);
+    await pgPool.query(`CREATE INDEX IF NOT EXISTS idx_survival_events_season ON survival_events(season_id)`);
+    await pgPool.query(`CREATE INDEX IF NOT EXISTS idx_survival_events_day_phase ON survival_events(season_id, day_index, phase)`);
+  } catch (e) {
+    console.warn('[pg-init] survival tables failed:', e?.message || e);
+  }
+
 PG_READY = true;
     PG_INIT_ERROR = null;
     console.log("Postgres tables ready");
@@ -1485,6 +1552,15 @@ const uploadUserLimiter = rateLimit({
 const dmLimiter = rateLimit({
   windowMs: 5 * 60 * 1000,
   limit: Number(process.env.RATE_LIMIT_DM_HTTP || 60),
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+  handler: genericRateLimitHandler,
+  keyGenerator: (req) => String(req.session?.user?.id || getClientIp(req)),
+});
+
+const survivalLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  limit: Number(process.env.RATE_LIMIT_SURVIVAL_HTTP || 40),
   standardHeaders: "draft-7",
   legacyHeaders: false,
   handler: genericRateLimitHandler,
@@ -4044,12 +4120,563 @@ async function fetchUsersByIds(ids) {
   return rows;
 }
 
+async function fetchSurvivalUserSnapshots(userIds) {
+  const cleaned = Array.from(
+    new Set((userIds || [])
+      .map((id) => Number(id))
+      .filter((id) => Number.isInteger(id) && id > 0))
+  );
+  if (!cleaned.length) return [];
+
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT id, username, avatar, avatar_bytes, avatar_mime, avatar_updated FROM users WHERE id = ANY($1::int[])`,
+        [cleaned]
+      );
+      return (rows || []).map((row) => ({
+        id: row.id,
+        username: row.username,
+        avatar: avatarUrlFromRow(row) || null,
+      }));
+    } catch (e) {
+      console.warn("[survival][pg] snapshot failed, falling back to sqlite:", e?.message || e);
+    }
+  }
+
+  const placeholders = cleaned.map(() => "?").join(",");
+  const rows = await dbAllAsync(
+    `SELECT id, username, avatar, avatar_updated FROM users WHERE id IN (${placeholders})`,
+    cleaned
+  );
+  return (rows || []).map((row) => ({
+    id: row.id,
+    username: row.username,
+    avatar: avatarUrlFromRow(row) || null,
+  }));
+}
+
 function sanitizeRoomName(r) {
   r = String(r || "").trim();
   r = r.replace(/^#+/, "");      // drop leading '#'
   r = r.toLowerCase();
   r = r.replace(/[^a-z0-9_-]/g, "");
   return r.slice(0, 24);
+}
+
+function sanitizeDisplayName(name) {
+  return String(name || "").replace(/[<>"'&]/g, "").trim();
+}
+
+function buildSurvivalSeedPayload(seed, options) {
+  return JSON.stringify({
+    seed: String(seed || ""),
+    options: options && typeof options === "object" ? options : {},
+  });
+}
+
+function parseSurvivalSeedPayload(raw) {
+  if (!raw) return { seed: "", options: {} };
+  const parsed = safeJsonParse(raw, null);
+  if (parsed && typeof parsed === "object" && parsed.seed) {
+    return { seed: String(parsed.seed || ""), options: parsed.options || {} };
+  }
+  return { seed: String(raw || ""), options: {} };
+}
+
+function createSeededRng(seedInput) {
+  const seed = String(seedInput || "");
+  const hash = crypto.createHash("sha256").update(seed || "survival").digest("hex").slice(0, 8);
+  let state = parseInt(hash, 16) || 1;
+  return function rng() {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function pickWeighted(items, rng) {
+  const total = items.reduce((sum, item) => sum + (item.weight || 0), 0);
+  if (!total) return null;
+  let roll = rng() * total;
+  for (const item of items) {
+    roll -= item.weight || 0;
+    if (roll <= 0) return item;
+  }
+  return items[items.length - 1] || null;
+}
+
+function pickRandom(items, rng) {
+  if (!items?.length) return null;
+  const idx = Math.floor(rng() * items.length);
+  return items[idx];
+}
+
+const ALLIANCE_ADJECTIVES = [
+  "Spark",
+  "Howling",
+  "Glitch",
+  "Rogue",
+  "Midnight",
+  "Fuzzy",
+  "Solar",
+  "Static",
+  "Storm",
+  "Echo",
+  "Velvet",
+  "Hollow",
+  "Brass",
+  "Crimson",
+  "Silver",
+  "Wild",
+  "Cosmic",
+  "Neon",
+];
+const ALLIANCE_NOUNS = [
+  "Crew",
+  "Squad",
+  "Circle",
+  "Pack",
+  "Alliance",
+  "Cabin",
+  "Cartel",
+  "Band",
+  "Collective",
+  "Guild",
+  "Gang",
+  "Crewmates",
+];
+
+function generateAllianceName(existingNames, rng) {
+  const used = new Set((existingNames || []).map((n) => String(n || "").toLowerCase()));
+  for (let i = 0; i < 12; i += 1) {
+    const name = `The ${pickRandom(ALLIANCE_ADJECTIVES, rng)} ${pickRandom(ALLIANCE_NOUNS, rng)}`;
+    if (!used.has(name.toLowerCase())) return name;
+  }
+  return `The ${pickRandom(ALLIANCE_ADJECTIVES, rng)} ${pickRandom(ALLIANCE_NOUNS, rng)}`;
+}
+
+function clamp(val, min, max) {
+  return Math.max(min, Math.min(max, val));
+}
+
+function getSurvivalEventCount(aliveCount) {
+  const base = Math.min(8, Math.max(3, aliveCount));
+  return Math.min(base, Math.max(1, aliveCount));
+}
+
+function normalizeSurvivalParticipantRow(row) {
+  if (!row) return null;
+  return {
+    id: Number(row.id),
+    season_id: Number(row.season_id),
+    user_id: Number(row.user_id),
+    display_name: row.display_name,
+    avatar_url: row.avatar_url || null,
+    alive: Number(row.alive || 0) === 1,
+    hp: Number(row.hp || 0),
+    kills: Number(row.kills || 0),
+    alliance_id: row.alliance_id == null ? null : Number(row.alliance_id),
+    inventory: Array.isArray(row.inventory) ? row.inventory : safeJsonParse(row.inventory_json || "[]", []),
+    traits: row.traits || safeJsonParse(row.traits_json || "{}", {}),
+    last_event_at: row.last_event_at ? Number(row.last_event_at) : null,
+    created_at: row.created_at ? Number(row.created_at) : null,
+  };
+}
+
+function normalizeSurvivalEventRow(row) {
+  if (!row) return null;
+  return {
+    id: Number(row.id),
+    season_id: Number(row.season_id),
+    day_index: Number(row.day_index),
+    phase: row.phase,
+    order_index: Number(row.order_index),
+    text: row.text,
+    involved_user_ids: safeJsonParse(row.involved_user_ids_json || "[]", []),
+    outcome: safeJsonParse(row.outcome_json || "{}", {}),
+    created_at: row.created_at ? Number(row.created_at) : null,
+  };
+}
+
+async function fetchSurvivalSeasonById(seasonId) {
+  const sid = Number(seasonId);
+  if (!sid) return null;
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(`SELECT * FROM survival_seasons WHERE id = $1 LIMIT 1`, [sid]);
+      return rows[0] || null;
+    } catch (e) {
+      console.warn("[survival][pg] fetch season failed:", e?.message || e);
+    }
+  }
+  return await dbGetAsync(`SELECT * FROM survival_seasons WHERE id = ? LIMIT 1`, [sid]).catch(() => null);
+}
+
+async function fetchSurvivalCurrentSeason() {
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT * FROM survival_seasons WHERE room_id = $1 AND status = 'running' ORDER BY id DESC LIMIT 1`,
+        [SURVIVAL_ROOM_DB_ID]
+      );
+      if (rows[0]) return rows[0];
+      const fallback = await pgPool.query(
+        `SELECT * FROM survival_seasons WHERE room_id = $1 ORDER BY updated_at DESC, id DESC LIMIT 1`,
+        [SURVIVAL_ROOM_DB_ID]
+      );
+      return fallback.rows[0] || null;
+    } catch (e) {
+      console.warn("[survival][pg] fetch current failed:", e?.message || e);
+    }
+  }
+
+  const running = await dbGetAsync(
+    `SELECT * FROM survival_seasons WHERE room_id = ? AND status = 'running' ORDER BY id DESC LIMIT 1`,
+    [SURVIVAL_ROOM_DB_ID]
+  ).catch(() => null);
+  if (running) return running;
+  return await dbGetAsync(
+    `SELECT * FROM survival_seasons WHERE room_id = ? ORDER BY updated_at DESC, id DESC LIMIT 1`,
+    [SURVIVAL_ROOM_DB_ID]
+  ).catch(() => null);
+}
+
+async function fetchSurvivalParticipants(seasonId) {
+  const sid = Number(seasonId);
+  if (!sid) return [];
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT * FROM survival_participants WHERE season_id = $1 ORDER BY id ASC`,
+        [sid]
+      );
+      return rows.map(normalizeSurvivalParticipantRow).filter(Boolean);
+    } catch (e) {
+      console.warn("[survival][pg] fetch participants failed:", e?.message || e);
+    }
+  }
+  const rows = await dbAllAsync(
+    `SELECT * FROM survival_participants WHERE season_id = ? ORDER BY id ASC`,
+    [sid]
+  );
+  return rows.map(normalizeSurvivalParticipantRow).filter(Boolean);
+}
+
+async function fetchSurvivalAlliances(seasonId) {
+  const sid = Number(seasonId);
+  if (!sid) return [];
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT * FROM survival_alliances WHERE season_id = $1 ORDER BY id ASC`,
+        [sid]
+      );
+      return rows || [];
+    } catch (e) {
+      console.warn("[survival][pg] fetch alliances failed:", e?.message || e);
+    }
+  }
+  return await dbAllAsync(
+    `SELECT * FROM survival_alliances WHERE season_id = ? ORDER BY id ASC`,
+    [sid]
+  );
+}
+
+async function fetchSurvivalEvents(seasonId, { limit = 200, beforeId = null } = {}) {
+  const sid = Number(seasonId);
+  const lim = clamp(Number(limit) || 200, 1, 500);
+  const before = beforeId ? Number(beforeId) : null;
+  if (!sid) return [];
+
+  if (await pgUsersEnabled()) {
+    try {
+      if (before) {
+        const { rows } = await pgPool.query(
+          `SELECT * FROM survival_events WHERE season_id = $1 AND id < $2 ORDER BY id DESC LIMIT $3`,
+          [sid, before, lim]
+        );
+        return rows.map(normalizeSurvivalEventRow).filter(Boolean).reverse();
+      }
+      const { rows } = await pgPool.query(
+        `SELECT * FROM survival_events WHERE season_id = $1 ORDER BY id DESC LIMIT $2`,
+        [sid, lim]
+      );
+      return rows.map(normalizeSurvivalEventRow).filter(Boolean).reverse();
+    } catch (e) {
+      console.warn("[survival][pg] fetch events failed:", e?.message || e);
+    }
+  }
+
+  if (before) {
+    const rows = await dbAllAsync(
+      `SELECT * FROM survival_events WHERE season_id = ? AND id < ? ORDER BY id DESC LIMIT ?`,
+      [sid, before, lim]
+    );
+    return rows.map(normalizeSurvivalEventRow).filter(Boolean).reverse();
+  }
+  const rows = await dbAllAsync(
+    `SELECT * FROM survival_events WHERE season_id = ? ORDER BY id DESC LIMIT ?`,
+    [sid, lim]
+  );
+  return rows.map(normalizeSurvivalEventRow).filter(Boolean).reverse();
+}
+
+async function fetchSurvivalHistory(limit = 10) {
+  const lim = clamp(Number(limit) || 10, 1, 25);
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT * FROM survival_seasons WHERE room_id = $1 ORDER BY created_at DESC LIMIT $2`,
+        [SURVIVAL_ROOM_DB_ID, lim]
+      );
+      return rows || [];
+    } catch (e) {
+      console.warn("[survival][pg] fetch history failed:", e?.message || e);
+    }
+  }
+  return await dbAllAsync(
+    `SELECT * FROM survival_seasons WHERE room_id = ? ORDER BY created_at DESC LIMIT ?`,
+    [SURVIVAL_ROOM_DB_ID, lim]
+  );
+}
+
+async function fetchSurvivalWinner(seasonId) {
+  const sid = Number(seasonId);
+  if (!sid) return null;
+  if (await pgUsersEnabled()) {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT display_name FROM survival_participants WHERE season_id = $1 AND alive = 1 LIMIT 1`,
+        [sid]
+      );
+      return rows[0]?.display_name || null;
+    } catch (e) {
+      console.warn("[survival][pg] fetch winner failed:", e?.message || e);
+    }
+  }
+  const row = await dbGetAsync(
+    `SELECT display_name FROM survival_participants WHERE season_id = ? AND alive = 1 LIMIT 1`,
+    [sid]
+  ).catch(() => null);
+  return row?.display_name || null;
+}
+
+function buildSurvivalTraits(rng, chaoticMode) {
+  const bump = chaoticMode ? 0.15 : 0;
+  return {
+    aggression: clamp(rng(), 0, 1),
+    loyalty: clamp(rng() - bump * 0.6, 0, 1),
+    stealth: clamp(rng(), 0, 1),
+    luck: clamp(rng(), 0, 1),
+    chaos: clamp(rng() + bump, 0, 1),
+  };
+}
+
+function hasInventoryTag(participant, tag) {
+  return Array.isArray(participant.inventory) && participant.inventory.includes(tag);
+}
+
+function pickParticipantsForTemplate({
+  template,
+  alive,
+  rng,
+  appearanceCount,
+  couples = [],
+}) {
+  const maxAppearance = 2;
+  const pickWithWeights = (candidates, count) => {
+    const selected = [];
+    const pool = [...candidates];
+    while (selected.length < count && pool.length) {
+      const weighted = pool.map((p) => ({
+        participant: p,
+        weight: 1 / (1 + (appearanceCount.get(p.user_id) || 0)),
+      }));
+      const pick = pickWeighted(weighted.map((w) => ({ ...w.participant, weight: w.weight })), rng);
+      const chosen = pick?.user_id
+        ? pool.find((p) => p.user_id === pick.user_id)
+        : pool[0];
+      if (!chosen) break;
+      selected.push(chosen);
+      const idx = pool.findIndex((p) => p.user_id === chosen.user_id);
+      if (idx >= 0) pool.splice(idx, 1);
+    }
+    return selected;
+  };
+
+  if (template.requiresCouple) {
+    const couplePairs = couples.filter((pair) => pair.length === 2);
+    const available = couplePairs.filter(([a, b]) =>
+      alive.some((p) => p.user_id === a) && alive.some((p) => p.user_id === b)
+    );
+    if (!available.length) return null;
+    const pair = pickRandom(available, rng);
+    return pair
+      ? pair.map((id) => alive.find((p) => p.user_id === id)).filter(Boolean)
+      : null;
+  }
+
+  if (template.requiresAlliance) {
+    const byAlliance = new Map();
+    for (const p of alive) {
+      if (!p.alliance_id) continue;
+      if (!byAlliance.has(p.alliance_id)) byAlliance.set(p.alliance_id, []);
+      byAlliance.get(p.alliance_id).push(p);
+    }
+    const alliances = Array.from(byAlliance.values()).filter((group) => group.length >= template.participants);
+    if (!alliances.length) return null;
+    const group = pickRandom(alliances, rng);
+    return pickWithWeights(group, template.participants);
+  }
+
+  let candidates = alive;
+  if (template.requiresNoAlliance) {
+    candidates = alive.filter((p) => !p.alliance_id);
+  }
+  if (candidates.length < template.participants) return null;
+  return pickWithWeights(candidates, template.participants);
+}
+
+function renderSurvivalEventText(template, participants, rng) {
+  let text = template.text || "";
+  const replace = (token, idx) => {
+    const p = participants[idx];
+    return p ? sanitizeDisplayName(p.display_name) : token;
+  };
+  text = text.replaceAll("{A}", replace("{A}", 0));
+  text = text.replaceAll("{B}", replace("{B}", 1));
+  text = text.replaceAll("{C}", replace("{C}", 2));
+  text = text.replaceAll("{D}", replace("{D}", 3));
+  if (text.includes("{ITEM}") && template.lootTag) {
+    const pool = SURVIVAL_ITEM_POOL[template.lootTag] || ["mystery item"];
+    const item = pickRandom(pool, rng) || "mystery item";
+    text = text.replaceAll("{ITEM}", item);
+  }
+  return text;
+}
+
+function selectSurvivalTemplate({ aliveCount, phase, dayIndex, options }) {
+  const baseDeathFactor = clamp(0.4 + dayIndex * 0.12 + (phase === "night" ? 0.1 : 0), 0.4, 2);
+  const chaosBoost = options?.chaoticMode ? 1.25 : 1;
+  const pool = SURVIVAL_EVENT_TEMPLATES.filter((t) => {
+    if (t.participants > aliveCount) return false;
+    if (t.requiresCouple && !options?.includeCouples) return false;
+    if (Array.isArray(t.phases) && !t.phases.includes(phase)) return false;
+    return true;
+  }).map((t) => {
+    let weight = t.weight || 1;
+    if (t.type === "kill" || t.type === "betray") weight *= baseDeathFactor * chaosBoost;
+    if (t.type === "alliance" && dayIndex < 3) weight *= 1.2;
+    return { ...t, weight };
+  });
+  return pool;
+}
+
+function applySurvivalOutcome({
+  template,
+  participants,
+  rng,
+  pendingAlliances,
+  existingAllianceNames,
+}) {
+  const outcome = { ...(template.outcome || {}) };
+  const resolveTarget = (token) => {
+    const idx = ["A", "B", "C", "D"].indexOf(token);
+    return idx >= 0 ? participants[idx] : null;
+  };
+
+  if (outcome.type === "loot") {
+    const target = resolveTarget(outcome.target || "A");
+    if (target && template.lootTag) {
+      target.inventory = target.inventory || [];
+      if (!target.inventory.includes(template.lootTag)) target.inventory.push(template.lootTag);
+      outcome.itemTag = template.lootTag;
+    }
+  }
+
+  if (outcome.type === "heal") {
+    const target = resolveTarget(outcome.target || "A");
+    const [min, max] = outcome.amount || [10, 25];
+    if (target) {
+      const delta = Math.round(min + rng() * (max - min));
+      target.hp = clamp(target.hp + delta, 1, 100);
+      outcome.deltaHp = delta;
+    }
+  }
+
+  if (outcome.type === "injure") {
+    const target = resolveTarget(outcome.target || "A");
+    const [min, max] = outcome.amount || [10, 25];
+    if (target) {
+      const delta = Math.round(min + rng() * (max - min));
+      target.hp = clamp(target.hp - delta, 1, 100);
+      outcome.deltaHp = -delta;
+    }
+    if (outcome.splashTarget) {
+      const splash = resolveTarget(outcome.splashTarget);
+      const [smin, smax] = outcome.splashAmount || [6, 18];
+      if (splash) {
+        const delta = Math.round(smin + rng() * (smax - smin));
+        splash.hp = clamp(splash.hp - delta, 1, 100);
+      }
+    }
+  }
+
+  if (outcome.type === "protect") {
+    const protectedTarget = resolveTarget(outcome.protected || "B");
+    if (protectedTarget) {
+      protectedTarget.hp = clamp(protectedTarget.hp + 8, 1, 100);
+    }
+  }
+
+  if (outcome.type === "steal") {
+    const thief = resolveTarget(outcome.thief || "A");
+    const victim = resolveTarget(outcome.victim || "B");
+    if (thief && victim && Array.isArray(victim.inventory) && victim.inventory.length) {
+      const stolenTag = pickRandom(victim.inventory, rng);
+      victim.inventory = victim.inventory.filter((tag) => tag !== stolenTag);
+      thief.inventory = thief.inventory || [];
+      thief.inventory.push(stolenTag);
+      outcome.itemTag = stolenTag;
+    } else {
+      outcome.type = "nothing";
+    }
+  }
+
+  if (outcome.type === "kill" || outcome.type === "betray") {
+    const killer = resolveTarget(outcome.killer || "A");
+    const victim = resolveTarget(outcome.victim || "B");
+    if (victim) {
+      victim.alive = false;
+      victim.hp = 0;
+      victim.alliance_id = null;
+    }
+    if (killer) {
+      killer.kills = (killer.kills || 0) + 1;
+      if (outcome.type === "betray") killer.alliance_id = null;
+    }
+  }
+
+  if (outcome.type === "alliance") {
+    const members = (outcome.members || []).map(resolveTarget).filter(Boolean);
+    if (members.length >= 2) {
+      const tempId = -1 * (pendingAlliances.length + 1);
+      const name = generateAllianceName(existingAllianceNames, rng);
+      existingAllianceNames.push(name);
+      pendingAlliances.push({ tempId, name, members });
+      for (const member of members) {
+        member.alliance_id = tempId;
+      }
+      outcome.alliance = { id: tempId, name };
+    } else {
+      outcome.type = "nothing";
+    }
+  }
+
+  return outcome;
 }
 
 const DEFAULT_ROOM_MASTERS = ["Site Rooms", "User Rooms"];
@@ -4472,6 +5099,12 @@ function normalizeReactionKey(reaction){
 function requireOwner(req, res, next) {
   if (!req.session?.user?.id) return res.status(401).send("Not logged in");
   if (!requireMinRole(req.session.user.role, "Owner")) return res.status(403).send("Forbidden");
+  next();
+}
+
+function requireCoOwner(req, res, next) {
+  if (!req.session?.user?.id) return res.status(401).send("Not logged in");
+  if (!requireMinRole(req.session.user.role, "Co-owner")) return res.status(403).send("Forbidden");
   next();
 }
 
@@ -6510,6 +7143,61 @@ app.get("/rooms", requireLogin, async (req, res) => {
   }
 });
 
+async function buildSurvivalHistoryPayload() {
+  const seasons = await fetchSurvivalHistory(10);
+  const result = [];
+  for (const season of seasons || []) {
+    const winner = season.status === "finished" ? await fetchSurvivalWinner(season.id) : null;
+    result.push({
+      id: season.id,
+      title: season.title,
+      status: season.status,
+      created_at: season.created_at,
+      winner,
+    });
+  }
+  return result;
+}
+
+function formatSurvivalSeason(season) {
+  if (!season) return null;
+  const { seed, options } = parseSurvivalSeedPayload(season.rng_seed);
+  return {
+    id: season.id,
+    room_id: season.room_id,
+    created_by_user_id: season.created_by_user_id,
+    title: season.title,
+    status: season.status,
+    day_index: season.day_index,
+    phase: season.phase,
+    rng_seed: seed || null,
+    options: options || {},
+    created_at: season.created_at,
+    updated_at: season.updated_at,
+  };
+}
+
+async function buildSurvivalPayload(season, { beforeId = null, limit = 200 } = {}) {
+  if (!season) {
+    return { season: null, participants: [], alliances: [], events: [], history: await buildSurvivalHistoryPayload() };
+  }
+  const [participants, alliances, events, history, winner] = await Promise.all([
+    fetchSurvivalParticipants(season.id),
+    fetchSurvivalAlliances(season.id),
+    fetchSurvivalEvents(season.id, { limit, beforeId }),
+    buildSurvivalHistoryPayload(),
+    season.status === "finished" ? fetchSurvivalWinner(season.id) : Promise.resolve(null),
+  ]);
+  return {
+    season: formatSurvivalSeason(season),
+    participants,
+    alliances,
+    events,
+    winner,
+    history,
+  };
+}
+
 // Co-owner+ can create rooms
 app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }), async (req, res) => {
   const actor = req.session.user;
@@ -6562,6 +7250,485 @@ app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }),
     console.warn("[rooms] create failed", e?.message || e);
     return res.status(500).send("Failed to create room");
   }
+});
+
+// ---- Survival Simulator API
+app.get("/api/survival/current", requireLogin, async (_req, res) => {
+  try {
+    const season = await fetchSurvivalCurrentSeason();
+    const payload = await buildSurvivalPayload(season);
+    return res.json(payload);
+  } catch (e) {
+    console.warn("[survival] current failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.get("/api/survival/seasons/:id", requireLogin, async (req, res) => {
+  try {
+    const beforeId = req.query?.before ? Number(req.query.before) : null;
+    const season = await fetchSurvivalSeasonById(req.params.id);
+    if (!season) return res.status(404).send("Not found");
+    const payload = await buildSurvivalPayload(season, { beforeId });
+    return res.json(payload);
+  } catch (e) {
+    console.warn("[survival] fetch season failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.post("/api/survival/seasons", survivalLimiter, requireCoOwner, express.json({ limit: "32kb" }), async (req, res) => {
+  const now = Date.now();
+  const lastStart = survivalSeasonCooldownByRoom.get(SURVIVAL_ROOM_DB_ID) || 0;
+  if (now - lastStart < SURVIVAL_SEASON_COOLDOWN_MS) {
+    return res.status(429).json({ message: "Please wait before starting another season." });
+  }
+
+  const running = await fetchSurvivalCurrentSeason();
+  if (running && running.status === "running") {
+    return res.status(409).json({ message: "A season is already running." });
+  }
+
+  const titleRaw = String(req.body?.title || "").trim();
+  const title = titleRaw || `Season — ${new Date(now).toLocaleString()}`;
+  const participantIds = Array.isArray(req.body?.participant_user_ids)
+    ? req.body.participant_user_ids
+    : [];
+  const options = {
+    includeCouples: !!req.body?.options?.includeCouples,
+    chaoticMode: !!req.body?.options?.chaoticMode,
+  };
+  const userSnapshots = await fetchSurvivalUserSnapshots(participantIds);
+  if (userSnapshots.length < 2) {
+    return res.status(400).json({ message: "Select at least two participants." });
+  }
+
+  const seed = crypto.randomBytes(8).toString("hex");
+  const rng = createSeededRng(seed);
+  const seasonPayload = {
+    room_id: SURVIVAL_ROOM_DB_ID,
+    created_by_user_id: req.session.user.id,
+    title: title.slice(0, 120),
+    status: "running",
+    day_index: 1,
+    phase: "day",
+    rng_seed: buildSurvivalSeedPayload(seed, options),
+    created_at: now,
+    updated_at: now,
+  };
+
+  let seasonId = null;
+  try {
+    if (await pgUsersEnabled()) {
+      await pgPool.query("BEGIN");
+      const { rows } = await pgPool.query(
+        `INSERT INTO survival_seasons (room_id, created_by_user_id, title, status, day_index, phase, rng_seed, created_at, updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+         RETURNING id`,
+        [
+          seasonPayload.room_id,
+          seasonPayload.created_by_user_id,
+          seasonPayload.title,
+          seasonPayload.status,
+          seasonPayload.day_index,
+          seasonPayload.phase,
+          seasonPayload.rng_seed,
+          seasonPayload.created_at,
+          seasonPayload.updated_at,
+        ]
+      );
+      seasonId = rows[0]?.id;
+      if (!seasonId) throw new Error("missing season id");
+      for (const user of userSnapshots) {
+        const traits = buildSurvivalTraits(rng, options.chaoticMode);
+        await pgPool.query(
+          `INSERT INTO survival_participants
+           (season_id, user_id, display_name, avatar_url, alive, hp, kills, alliance_id, inventory_json, traits_json, last_event_at, created_at)
+           VALUES ($1,$2,$3,$4,1,100,0,NULL,$5,$6,NULL,$7)`,
+          [
+            seasonId,
+            user.id,
+            user.username,
+            user.avatar || null,
+            JSON.stringify([]),
+            JSON.stringify(traits),
+            now,
+          ]
+        );
+      }
+      await pgPool.query("COMMIT");
+    } else {
+      await dbRunAsync("BEGIN");
+      const result = await dbRunAsync(
+        `INSERT INTO survival_seasons
+         (room_id, created_by_user_id, title, status, day_index, phase, rng_seed, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          seasonPayload.room_id,
+          seasonPayload.created_by_user_id,
+          seasonPayload.title,
+          seasonPayload.status,
+          seasonPayload.day_index,
+          seasonPayload.phase,
+          seasonPayload.rng_seed,
+          seasonPayload.created_at,
+          seasonPayload.updated_at,
+        ]
+      );
+      seasonId = result.lastID;
+      for (const user of userSnapshots) {
+        const traits = buildSurvivalTraits(rng, options.chaoticMode);
+        await dbRunAsync(
+          `INSERT INTO survival_participants
+           (season_id, user_id, display_name, avatar_url, alive, hp, kills, alliance_id, inventory_json, traits_json, last_event_at, created_at)
+           VALUES (?, ?, ?, ?, 1, 100, 0, NULL, ?, ?, NULL, ?)`,
+          [
+            seasonId,
+            user.id,
+            user.username,
+            user.avatar || null,
+            JSON.stringify([]),
+            JSON.stringify(traits),
+            now,
+          ]
+        );
+      }
+      await dbRunAsync("COMMIT");
+    }
+  } catch (e) {
+    try { await dbRunAsync("ROLLBACK"); } catch {}
+    try { if (await pgUsersEnabled()) await pgPool.query("ROLLBACK"); } catch {}
+    console.warn("[survival] create season failed", e?.message || e);
+    return res.status(500).json({ message: "Failed to start season." });
+  }
+
+  survivalSeasonCooldownByRoom.set(SURVIVAL_ROOM_DB_ID, now);
+  const season = await fetchSurvivalSeasonById(seasonId);
+  const payload = await buildSurvivalPayload(season);
+  io.to(SURVIVAL_ROOM_ID).emit("survival:update", payload);
+  return res.json(payload);
+});
+
+app.post("/api/survival/seasons/:id/advance", survivalLimiter, requireCoOwner, express.json({ limit: "16kb" }), async (req, res) => {
+  const seasonId = Number(req.params.id);
+  if (!seasonId) return res.status(400).json({ message: "Invalid season." });
+  const now = Date.now();
+  const lastAdvance = survivalAdvanceCooldownBySeason.get(seasonId) || 0;
+  if (now - lastAdvance < SURVIVAL_ADVANCE_COOLDOWN_MS) {
+    return res.status(429).json({ message: "Slow down." });
+  }
+  survivalAdvanceCooldownBySeason.set(seasonId, now);
+
+  const season = await fetchSurvivalSeasonById(seasonId);
+  if (!season) return res.status(404).json({ message: "Season not found." });
+  if (season.status !== "running") return res.status(400).json({ message: "Season is not running." });
+
+  const participants = await fetchSurvivalParticipants(seasonId);
+  const alliances = await fetchSurvivalAlliances(seasonId);
+  const alive = participants.filter((p) => p.alive);
+  if (alive.length <= 1) {
+    season.status = "finished";
+  }
+
+  const { seed, options } = parseSurvivalSeedPayload(season.rng_seed);
+  const rng = createSeededRng(`${seed || "survival"}:${season.day_index}:${season.phase}`);
+  const couples = options?.includeCouples
+    ? await (async () => {
+      try {
+        if (await pgUsersEnabled()) {
+          const ids = alive.map((p) => p.user_id);
+          const { rows } = await pgPool.query(
+            `SELECT user1_id, user2_id FROM couple_links WHERE user1_id = ANY($1::int[]) OR user2_id = ANY($1::int[])`,
+            [ids]
+          );
+          return (rows || []).map((row) => [Number(row.user1_id), Number(row.user2_id)]);
+        }
+      } catch (e) {
+        console.warn("[survival] couple lookup failed:", e?.message || e);
+      }
+      const rows = await dbAllAsync(
+        `SELECT user1_id, user2_id FROM couple_links`
+      );
+      return (rows || []).map((row) => [Number(row.user1_id), Number(row.user2_id)]);
+    })()
+    : [];
+
+  const eventCount = getSurvivalEventCount(alive.length);
+  const events = [];
+  const pendingAlliances = [];
+  const appearanceCount = new Map();
+  const existingAllianceNames = alliances.map((a) => a.name);
+  const templatePool = selectSurvivalTemplate({
+    aliveCount: alive.length,
+    phase: season.phase,
+    dayIndex: season.day_index,
+    options,
+  });
+
+  let orderIndex = 0;
+  for (let i = 0; i < eventCount; i += 1) {
+    const currentAlive = participants.filter((p) => p.alive);
+    if (currentAlive.length < 1) break;
+    let selectedTemplate = null;
+    let selectedParticipants = null;
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+      const template = pickWeighted(templatePool, rng);
+      if (!template) break;
+      const picked = pickParticipantsForTemplate({
+        template,
+        alive: currentAlive,
+        rng,
+        appearanceCount,
+        couples,
+      });
+      if (!picked || picked.length < template.participants) continue;
+      if (picked.some((p) => (appearanceCount.get(p.user_id) || 0) >= 2)) continue;
+      if (template.type === "steal") {
+        const victim = picked[1];
+        if (!victim || !Array.isArray(victim.inventory) || victim.inventory.length === 0) continue;
+      }
+      selectedTemplate = template;
+      selectedParticipants = picked;
+      break;
+    }
+
+    if (!selectedTemplate || !selectedParticipants) {
+      const fallback = SURVIVAL_EVENT_TEMPLATES.find((t) => t.id.startsWith("solo_neutral_"));
+      if (!fallback) break;
+      selectedTemplate = fallback;
+      selectedParticipants = pickParticipantsForTemplate({
+        template: fallback,
+        alive: currentAlive,
+        rng,
+        appearanceCount,
+        couples,
+      }) || [currentAlive[0]];
+    }
+
+    selectedParticipants.forEach((p) => {
+      appearanceCount.set(p.user_id, (appearanceCount.get(p.user_id) || 0) + 1);
+      p.last_event_at = now;
+    });
+
+    const text = renderSurvivalEventText(selectedTemplate, selectedParticipants, rng);
+    const outcome = applySurvivalOutcome({
+      template: selectedTemplate,
+      participants: selectedParticipants,
+      rng,
+      pendingAlliances,
+      existingAllianceNames,
+    });
+
+    orderIndex += 1;
+    events.push({
+      id: null,
+      season_id: seasonId,
+      day_index: season.day_index,
+      phase: season.phase,
+      order_index: orderIndex,
+      text,
+      involved_user_ids: selectedParticipants.map((p) => p.user_id),
+      outcome,
+      created_at: now,
+    });
+  }
+
+  const aliveAfter = participants.filter((p) => p.alive);
+  if (aliveAfter.length <= 1 && season.status !== "finished") {
+    season.status = "finished";
+    const winner = aliveAfter[0];
+    if (winner) {
+      events.push({
+        id: null,
+        season_id: seasonId,
+        day_index: season.day_index,
+        phase: season.phase,
+        order_index: orderIndex + 1,
+        text: `🏆 ${sanitizeDisplayName(winner.display_name)} wins the season!`,
+        involved_user_ids: [winner.user_id],
+        outcome: { type: "winner" },
+        created_at: now,
+      });
+    } else {
+      events.push({
+        id: null,
+        season_id: seasonId,
+        day_index: season.day_index,
+        phase: season.phase,
+        order_index: orderIndex + 1,
+        text: "No one survived the season. Wild.",
+        involved_user_ids: [],
+        outcome: { type: "draw" },
+        created_at: now,
+      });
+    }
+  }
+
+  if (season.status !== "finished") {
+    if (season.phase === "day") {
+      season.phase = "night";
+    } else {
+      season.phase = "day";
+      season.day_index = Number(season.day_index || 1) + 1;
+    }
+  }
+  season.updated_at = now;
+
+  const pendingMap = new Map();
+  try {
+    if (await pgUsersEnabled()) {
+      await pgPool.query("BEGIN");
+      for (const pending of pendingAlliances) {
+        const { rows } = await pgPool.query(
+          `INSERT INTO survival_alliances (season_id, name, created_at) VALUES ($1,$2,$3) RETURNING id`,
+          [seasonId, pending.name, now]
+        );
+        const actualId = rows[0]?.id;
+        pendingMap.set(pending.tempId, actualId);
+      }
+
+      for (const participant of participants) {
+        const allianceId = pendingMap.get(participant.alliance_id) || participant.alliance_id;
+        participant.alliance_id = allianceId && allianceId < 0 ? null : allianceId;
+        await pgPool.query(
+          `UPDATE survival_participants
+           SET alive=$1, hp=$2, kills=$3, alliance_id=$4, inventory_json=$5, traits_json=$6, last_event_at=$7
+           WHERE id=$8`,
+          [
+            participant.alive ? 1 : 0,
+            participant.hp,
+            participant.kills,
+            participant.alliance_id,
+            JSON.stringify(participant.inventory || []),
+            JSON.stringify(participant.traits || {}),
+            participant.last_event_at,
+            participant.id,
+          ]
+        );
+      }
+
+      for (const event of events) {
+        if (event.outcome?.alliance?.id && pendingMap.has(event.outcome.alliance.id)) {
+          event.outcome.alliance.id = pendingMap.get(event.outcome.alliance.id);
+        }
+        const { rows } = await pgPool.query(
+          `INSERT INTO survival_events
+           (season_id, day_index, phase, order_index, text, involved_user_ids_json, outcome_json, created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           RETURNING id`,
+          [
+            seasonId,
+            event.day_index,
+            event.phase,
+            event.order_index,
+            event.text,
+            JSON.stringify(event.involved_user_ids || []),
+            JSON.stringify(event.outcome || {}),
+            event.created_at,
+          ]
+        );
+        event.id = rows[0]?.id;
+      }
+
+      await pgPool.query(
+        `UPDATE survival_seasons SET status=$1, day_index=$2, phase=$3, updated_at=$4 WHERE id=$5`,
+        [season.status, season.day_index, season.phase, season.updated_at, seasonId]
+      );
+      await pgPool.query("COMMIT");
+    } else {
+      await dbRunAsync("BEGIN");
+      for (const pending of pendingAlliances) {
+        const result = await dbRunAsync(
+          `INSERT INTO survival_alliances (season_id, name, created_at) VALUES (?, ?, ?)`,
+          [seasonId, pending.name, now]
+        );
+        pendingMap.set(pending.tempId, result.lastID);
+      }
+
+      for (const participant of participants) {
+        const allianceId = pendingMap.get(participant.alliance_id) || participant.alliance_id;
+        participant.alliance_id = allianceId && allianceId < 0 ? null : allianceId;
+        await dbRunAsync(
+          `UPDATE survival_participants
+           SET alive=?, hp=?, kills=?, alliance_id=?, inventory_json=?, traits_json=?, last_event_at=?
+           WHERE id=?`,
+          [
+            participant.alive ? 1 : 0,
+            participant.hp,
+            participant.kills,
+            participant.alliance_id,
+            JSON.stringify(participant.inventory || []),
+            JSON.stringify(participant.traits || {}),
+            participant.last_event_at,
+            participant.id,
+          ]
+        );
+      }
+
+      for (const event of events) {
+        if (event.outcome?.alliance?.id && pendingMap.has(event.outcome.alliance.id)) {
+          event.outcome.alliance.id = pendingMap.get(event.outcome.alliance.id);
+        }
+        const result = await dbRunAsync(
+          `INSERT INTO survival_events
+           (season_id, day_index, phase, order_index, text, involved_user_ids_json, outcome_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+          [
+            seasonId,
+            event.day_index,
+            event.phase,
+            event.order_index,
+            event.text,
+            JSON.stringify(event.involved_user_ids || []),
+            JSON.stringify(event.outcome || {}),
+            event.created_at,
+          ]
+        );
+        event.id = result.lastID;
+      }
+
+      await dbRunAsync(
+        `UPDATE survival_seasons SET status=?, day_index=?, phase=?, updated_at=? WHERE id=?`,
+        [season.status, season.day_index, season.phase, season.updated_at, seasonId]
+      );
+      await dbRunAsync("COMMIT");
+    }
+  } catch (e) {
+    try { await dbRunAsync("ROLLBACK"); } catch {}
+    try { if (await pgUsersEnabled()) await pgPool.query("ROLLBACK"); } catch {}
+    console.warn("[survival] advance failed", e?.message || e);
+    return res.status(500).json({ message: "Failed to advance." });
+  }
+
+  const payload = await buildSurvivalPayload(await fetchSurvivalSeasonById(seasonId));
+  io.to(SURVIVAL_ROOM_ID).emit("survival:update", payload);
+  io.to(SURVIVAL_ROOM_ID).emit("survival:events", { seasonId, events });
+  return res.json(payload);
+});
+
+app.post("/api/survival/seasons/:id/end", survivalLimiter, requireCoOwner, express.json({ limit: "8kb" }), async (req, res) => {
+  const seasonId = Number(req.params.id);
+  if (!seasonId) return res.status(400).json({ message: "Invalid season." });
+  const season = await fetchSurvivalSeasonById(seasonId);
+  if (!season) return res.status(404).json({ message: "Season not found." });
+  if (season.status === "finished") {
+    const payload = await buildSurvivalPayload(season);
+    return res.json(payload);
+  }
+  const now = Date.now();
+  try {
+    if (await pgUsersEnabled()) {
+      await pgPool.query(`UPDATE survival_seasons SET status='finished', updated_at=$1 WHERE id=$2`, [now, seasonId]);
+    } else {
+      await dbRunAsync(`UPDATE survival_seasons SET status='finished', updated_at=? WHERE id=?`, [now, seasonId]);
+    }
+  } catch (e) {
+    console.warn("[survival] end failed", e?.message || e);
+    return res.status(500).json({ message: "Failed to end season." });
+  }
+  const payload = await buildSurvivalPayload(await fetchSurvivalSeasonById(seasonId));
+  io.to(SURVIVAL_ROOM_ID).emit("survival:update", payload);
+  return res.json(payload);
 });
 
 // ---- Room structure management (Owner-only)

--- a/survival-events.js
+++ b/survival-events.js
@@ -1,0 +1,332 @@
+"use strict";
+
+const SURVIVAL_ITEM_POOL = {
+  weapon: [
+    "folding chair",
+    "foam bat",
+    "rubber mallet",
+    "camping spatula",
+    "broomstick spear",
+    "staple gun",
+    "plastic sabre",
+    "glitter cannon",
+    "trophy wrench",
+    "umbrella sword",
+  ],
+  food: [
+    "mystery granola",
+    "spicy ramen",
+    "pocket cookies",
+    "trail mix",
+    "moon cheese",
+    "energy gummies",
+    "suspicious sandwich",
+    "marshmallow pack",
+    "midnight noodles",
+    "canned peaches",
+  ],
+  medkit: [
+    "first-aid kit",
+    "bandage roll",
+    "ice pack",
+    "herbal salve",
+    "peppermint balm",
+    "recovery spray",
+  ],
+  trap: [
+    "tripwire",
+    "noise maker",
+    "sticky mat",
+    "smoke popper",
+    "glitter bomb",
+  ],
+  map: [
+    "crumpled map",
+    "glow compass",
+    "scribbled blueprint",
+    "weathered chart",
+    "trail markers",
+  ],
+};
+
+const soloLoot = [
+  { text: "{A} finds a {ITEM} and declares it a legendary artifact.", tag: "weapon" },
+  { text: "{A} uncovers {ITEM} stashed inside a hollow log.", tag: "food" },
+  { text: "{A} fishes out a {ITEM} from a supply crate.", tag: "medkit" },
+  { text: "{A} scores a {ITEM} and refuses to explain how.", tag: "trap" },
+  { text: "{A} pockets a {ITEM} and whispers, 'mine now'.", tag: "map" },
+  { text: "{A} stumbles on a {ITEM} and instantly feels faster.", tag: "weapon" },
+  { text: "{A} grabs a {ITEM} and does a victory lap.", tag: "food" },
+  { text: "{A} discovers a {ITEM} hidden under a rock.", tag: "medkit" },
+  { text: "{A} sets aside a {ITEM} for 'later shenanigans'.", tag: "trap" },
+  { text: "{A} snags a {ITEM} and navigates with swagger.", tag: "map" },
+  { text: "{A} opens a locker and finds {ITEM}.", tag: "weapon" },
+  { text: "{A} raids a cooler for {ITEM}.", tag: "food" },
+  { text: "{A} pulls a {ITEM} from their sock. Why was it there?", tag: "medkit" },
+  { text: "{A} finds a {ITEM} and labels it \"Emergency prank\".", tag: "trap" },
+  { text: "{A} flips a page and reveals a {ITEM}.", tag: "map" },
+  { text: "{A} discovers {ITEM} hanging from a tree branch.", tag: "weapon" },
+  { text: "{A} pockets {ITEM} and munches immediately.", tag: "food" },
+  { text: "{A} salvages {ITEM} from a ruined tent.", tag: "medkit" },
+  { text: "{A} rolls a {ITEM} into their bag like a pro.", tag: "trap" },
+  { text: "{A} finds {ITEM} and marks a route in the dirt.", tag: "map" },
+];
+
+const soloHeal = [
+  "{A} wraps up a scrape and feels brand-new.",
+  "{A} rests by a warm vent and recovers some energy.",
+  "{A} brews a calming tea and steadies their nerves.",
+  "{A} finds a quiet nook and patches up.",
+  "{A} does stretches and heals a stubborn ache.",
+  "{A} meditates under a flickering light and regains focus.",
+  "{A} treats a bruise with surprising professionalism.",
+  "{A} naps for exactly twelve minutes and feels better.",
+  "{A} hums a battle song and shrugs off the pain.",
+  "{A} tightens a bandage and gets back in the game.",
+];
+
+const soloInjure = [
+  "{A} slips on wet leaves and lands badly.",
+  "{A} misjudges a leap and takes a rough tumble.",
+  "{A} gets bonked by a swinging branch.",
+  "{A} steps into a puddle that was deeper than expected.",
+  "{A} bumps into a fence and regrets it.",
+  "{A} trips over their own shoelace. Classic.",
+  "{A} knocks into a crate and bruises a shoulder.",
+  "{A} sprints too hard and pulls something important.",
+  "{A} gets startled by an owl and stumbles.",
+  "{A} faceplants while trying to look cool.",
+];
+
+const soloNeutral = [
+  "{A} scouts the area and keeps moving.",
+  "{A} hides in a bush and listens carefully.",
+  "{A} hums a tune to stay calm.",
+  "{A} takes a cautious shortcut.",
+  "{A} finds a cozy hiding spot and chills.",
+  "{A} builds a tiny fort and feels accomplished.",
+  "{A} practices dramatic monologues. It helps.",
+  "{A} spends the hour reorganizing their bag.",
+  "{A} stares at the horizon like a hero.",
+  "{A} counts clouds and avoids trouble.",
+  "{A} doodles survival notes on a leaf.",
+  "{A} checks the wind and changes course.",
+  "{A} does a silent victory dance.",
+  "{A} strategizes and stays out of sight.",
+  "{A} finds a decent perch and watches the chaos.",
+  "{A} spends time inventing a new handshake.",
+  "{A} chooses caution over chaos.",
+  "{A} reads the vibes and keeps moving.",
+  "{A} listens for footsteps and keeps still.",
+  "{A} quietly snacks and waits.",
+];
+
+const duoAlliance = [
+  "{A} and {B} agree to watch each other's backs... for now.",
+  "{A} and {B} form a truce sealed by a fist bump.",
+  "{A} shares a plan with {B}; it might actually work.",
+  "{A} teams up with {B} after a suspicious nod.",
+  "{A} and {B} create a secret signal and giggle.",
+  "{A} and {B} trade snacks and form an alliance.",
+  "{A} and {B} vow to avoid chaos together.",
+  "{A} and {B} agree to split any loot evenly.",
+  "{A} and {B} decide to go duo mode.",
+  "{A} and {B} share a map and a promise.",
+];
+
+const duoSteal = [
+  "{A} swipes supplies from {B} while whistling innocently.",
+  "{A} borrows {B}'s gear without asking. Bold.",
+  "{A} lifts a pouch from {B} and vanishes.",
+  "{A} pickpockets {B} and pretends to be shocked.",
+  "{A} nabs a snack from {B}'s stash.",
+  "{A} trades {B} a pebble for a real item. {B} is not amused.",
+];
+
+const duoInjure = [
+  "{A} and {B} argue loudly and both get scratched in the mess.",
+  "{A} bumps into {B} during a scramble; both take a hit.",
+  "{A} shoves {B} aside; chaos follows.",
+  "{A} and {B} collide in a narrow passage.",
+  "{A} and {B} get tangled in the same net.",
+  "{A} spooks {B}, and the panic hurts someone.",
+  "{A} tries to sprint past {B} and wipes out.",
+  "{A} and {B} slam into a door at the same time.",
+];
+
+const duoKill = [
+  "{A} wins a tense standoff against {B}.",
+  "{A} outsmarts {B} in a quick duel.",
+  "{A} sets a trap that {B} walks into.",
+  "{A} surprises {B} from the shadows and it's over fast.",
+  "{A} pushes {B} into a pit they never saw.",
+  "{A} lands the final strike on {B}.",
+  "{A} flips the tables and takes out {B}.",
+  "{A} ambushes {B} with a wild plan that works.",
+];
+
+const duoBetrayal = [
+  "{A} betrays {B} when the opportunity appears.",
+  "{A} decides {B} is too risky to keep around.",
+  "{A} breaks the alliance with {B} in dramatic fashion.",
+  "{A} turns on {B} after a tense stare.",
+  "{A} leaves {B} behind when the alarms go off.",
+  "{A} whispers sorry and strikes at {B}.",
+];
+
+const trioAlliance = [
+  "{A}, {B}, and {C} agree to share scouting duties.",
+  "{A}, {B}, and {C} form a pact over a pile of snacks.",
+  "{A}, {B}, and {C} vow to protect each other... mostly.",
+  "{A}, {B}, and {C} link up and look unstoppable.",
+  "{A}, {B}, and {C} agree on a rotating lookout schedule.",
+  "{A}, {B}, and {C} form the most chaotic trio.",
+];
+
+const trioChaos = [
+  "{A}, {B}, and {C} start a loud argument that attracts trouble.",
+  "{A}, {B}, and {C} chase the same supply crate and trip over each other.",
+  "{A}, {B}, and {C} get lost arguing over directions.",
+  "{A}, {B}, and {C} accidentally trigger a noise maker.",
+  "{A}, {B}, and {C} spend the phase debating snack rules.",
+  "{A}, {B}, and {C} sprint away from an imagined threat.",
+];
+
+const quadShowdown = [
+  "{A}, {B}, {C}, and {D} face off and immediately regret it.",
+  "{A}, {B}, {C}, and {D} argue about territory and scatter.",
+  "{A}, {B}, {C}, and {D} collide in a chaotic pileup.",
+  "{A}, {B}, {C}, and {D} make a temporary truce just to breathe.",
+  "{A}, {B}, {C}, and {D} hear a roar and sprint in different directions.",
+  "{A}, {B}, {C}, and {D} throw shade and then bail.",
+];
+
+const coupleSpecial = [
+  "{A} dives in to protect {B} and takes the hit.",
+  "{A} and {B} share supplies and promise to regroup.",
+  "{A} shields {B} from danger with surprising heroics.",
+  "{A} and {B} trade a lucky charm before splitting up.",
+  "{A} distracts the danger so {B} can escape.",
+  "{A} and {B} plan a safe route together.",
+];
+
+function makeTemplates(list, build) {
+  return list.map((entry, idx) => build(entry, idx));
+}
+
+const SURVIVAL_EVENT_TEMPLATES = [
+  ...makeTemplates(soloLoot, (entry, idx) => ({
+    id: `solo_loot_${idx + 1}`,
+    participants: 1,
+    weight: 3,
+    type: "loot",
+    lootTag: entry.tag,
+    text: entry.text,
+    outcome: { type: "loot", target: "A", tag: entry.tag },
+  })),
+  ...makeTemplates(soloHeal, (text, idx) => ({
+    id: `solo_heal_${idx + 1}`,
+    participants: 1,
+    weight: 2,
+    type: "heal",
+    text,
+    outcome: { type: "heal", target: "A", amount: [12, 28] },
+  })),
+  ...makeTemplates(soloInjure, (text, idx) => ({
+    id: `solo_injure_${idx + 1}`,
+    participants: 1,
+    weight: 2,
+    type: "injure",
+    text,
+    outcome: { type: "injure", target: "A", amount: [12, 30] },
+  })),
+  ...makeTemplates(soloNeutral, (text, idx) => ({
+    id: `solo_neutral_${idx + 1}`,
+    participants: 1,
+    weight: 3,
+    type: "neutral",
+    text,
+    outcome: { type: "nothing" },
+  })),
+  ...makeTemplates(duoAlliance, (text, idx) => ({
+    id: `duo_alliance_${idx + 1}`,
+    participants: 2,
+    weight: 3,
+    type: "alliance",
+    text,
+    requiresNoAlliance: true,
+    outcome: { type: "alliance", members: ["A", "B"] },
+  })),
+  ...makeTemplates(duoSteal, (text, idx) => ({
+    id: `duo_steal_${idx + 1}`,
+    participants: 2,
+    weight: 2,
+    type: "steal",
+    text,
+    outcome: { type: "steal", thief: "A", victim: "B" },
+  })),
+  ...makeTemplates(duoInjure, (text, idx) => ({
+    id: `duo_injure_${idx + 1}`,
+    participants: 2,
+    weight: 2,
+    type: "injure",
+    text,
+    outcome: { type: "injure", target: "A", amount: [10, 24], splashTarget: "B", splashAmount: [6, 18] },
+  })),
+  ...makeTemplates(duoKill, (text, idx) => ({
+    id: `duo_kill_${idx + 1}`,
+    participants: 2,
+    weight: 1,
+    type: "kill",
+    text: text + " ☠️",
+    outcome: { type: "kill", killer: "A", victim: "B" },
+  })),
+  ...makeTemplates(duoBetrayal, (text, idx) => ({
+    id: `duo_betray_${idx + 1}`,
+    participants: 2,
+    weight: 1,
+    type: "betray",
+    text: text + " ☠️",
+    requiresAlliance: true,
+    outcome: { type: "betray", killer: "A", victim: "B" },
+  })),
+  ...makeTemplates(trioAlliance, (text, idx) => ({
+    id: `trio_alliance_${idx + 1}`,
+    participants: 3,
+    weight: 2,
+    type: "alliance",
+    text,
+    requiresNoAlliance: true,
+    outcome: { type: "alliance", members: ["A", "B", "C"] },
+  })),
+  ...makeTemplates(trioChaos, (text, idx) => ({
+    id: `trio_chaos_${idx + 1}`,
+    participants: 3,
+    weight: 2,
+    type: "neutral",
+    text,
+    outcome: { type: "nothing" },
+  })),
+  ...makeTemplates(quadShowdown, (text, idx) => ({
+    id: `quad_showdown_${idx + 1}`,
+    participants: 4,
+    weight: 1,
+    type: "neutral",
+    text,
+    outcome: { type: "nothing" },
+  })),
+  ...makeTemplates(coupleSpecial, (text, idx) => ({
+    id: `couple_${idx + 1}`,
+    participants: 2,
+    weight: 2,
+    type: "couple",
+    text,
+    requiresCouple: true,
+    outcome: { type: "protect", protector: "A", protected: "B" },
+  })),
+];
+
+module.exports = {
+  SURVIVAL_EVENT_TEMPLATES,
+  SURVIVAL_ITEM_POOL,
+};


### PR DESCRIPTION
### Motivation
- Add a new built-in site room called `survivalsimulator` that hosts a small built-in survival simulation game with a narrative log and persistent history.
- Provide an owner/Co-owner-controlled flow to start seasons, advance day/night phases, and declare a winner while keeping the system self-contained and deterministic for replays.
- Keep the feature localized to the Survival room UI and ensure it doesn't leak into other rooms or break existing systems (rooms, DMs, dice, profiles, sockets).

### Description
- Database and seeding: seed the site room `survivalsimulator` and add persistent tables for seasons, participants, alliances, and events (SQLite migrations and Postgres init wiring).
- Server-side API & engine: add REST endpoints (`GET /api/survival/current`, `POST /api/survival/seasons`, `POST /api/survival/seasons/:id/advance`, `POST /api/survival/seasons/:id/end`, `GET /api/survival/seasons/:id`), socket emits (`survival:update`, `survival:events`), rate limits and cooldowns, deterministic seedable RNG, a simulation engine applying outcomes (loot/heal/injure/kill/alliance/steal), and safe persistence of events for replay/resume.
- Event pack & templates: add an original event pack and item pool (`survival-events.js`) with 100+ varied templates and constraints so events are sensible and outcomes match narrative lines.
- Client UI: add a pinned Survival Panel visible only in the `survivalsimulator` room (title/status, Day/Night, alive count, owner controls: New Season / Advance / Auto-Run / End, everyone controls: View Roster / View Log), modals for New Season / Roster / Log, a recent log feed, and roster view; client renders only when in the Survival room.
- Safety & hygiene: input/name sanitizer for event text to avoid injection, per-season/per-room cooldowns and HTTP rate limiting, and defensive checks to avoid referencing dead participants.

### Testing
- Ran `npm run check` (which performs `node --check` against key files) and it completed successfully without syntax errors.
- Launched the app with `node server.js` in this environment; the server process started but the configured Postgres host was unreachable (environment DNS error) which produced a non-fatal init warning in logs while the app remained running (SQLite migrations and fallback logic present).
- Attempted an automated Playwright screenshot to confirm UI, but the headless browser crashed in this environment (external to the code changes), so no visual screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696b87ba16a48333afb5948bf02ba822)