### PR TITLE
Revamp DM UI (mobile-first) + DM neon backing + reliable thread creation

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1244,9 +1244,10 @@ const badgeDefaults = { direct: "#ed4245", group: "#5865f2" };
 let badgePrefs = { ...badgeDefaults };
 let directBadgePending = false;
 let groupBadgePending = false;
-const dmThemeDefaults = { background: "#1e1f22" };
-let dmThemePrefs = { ...dmThemeDefaults };
+const dmNeonDefaults = { color: "#5865f2" };
+let dmNeonColor = dmNeonDefaults.color;
 let dmTab = "direct";
+let dmViewMode = "inbox";
 const dmUnreadThreads = new Set();
 let chatFxPrefs = { ...CHAT_FX_DEFAULTS };
 let chatFxDraft = null;
@@ -3774,6 +3775,7 @@ function updateDmThreadPlaceholderVisibility(){
 }
 
 const dmCloseBtn = document.getElementById("dmCloseBtn");
+const dmBackBtn = document.getElementById("dmBackBtn");
 const dmTabs = document.getElementById("dmTabs");
 const dmCreateGroupBtn = document.getElementById("dmCreateGroupBtn");
 const dmThreadList = document.getElementById("dmThreadList");
@@ -3862,8 +3864,8 @@ const dmReplyPreview = document.getElementById("dmReplyPreview");
 const dmReplyPreviewText = document.getElementById("dmReplyPreviewText");
 const dmReplyClose = document.getElementById("dmReplyClose");
 const dmMentionDropdown = document.getElementById("dmMentionDropdown");
-const dmBgColor = document.getElementById("dmBgColor");
-const dmBgColorText = document.getElementById("dmBgColorText");
+const dmNeonColorInput = document.getElementById("dmNeonColor");
+const dmNeonColorText = document.getElementById("dmNeonColorText");
 const dmPickerModal = document.getElementById("dmPickerModal");
 const dmModalCloseBtn = document.getElementById("dmModalCloseBtn");
 const dmModalCancelBtn = document.getElementById("dmModalCancelBtn");
@@ -5781,26 +5783,37 @@ function applyProfileHeaderGradient(colorA, colorB, role){
   }
   applyProfileHeaderOverlay(role || currentProfileHeaderRole);
 }
-function loadDmThemePrefsFromStorage(){
+function loadDmNeonColorFromStorage(){
   try {
-    const raw = localStorage.getItem("dmThemePrefs");
-    const parsed = raw ? JSON.parse(raw) : {};
-    return { ...dmThemeDefaults, ...parsed };
-  } catch {
-    return { ...dmThemeDefaults };
-  }
+    const raw = localStorage.getItem("dmNeonColor");
+    if (raw) return raw;
+  } catch {}
+
+  // One-time migration from legacy DM background preference.
+  try {
+    const legacyRaw = localStorage.getItem("dmThemePrefs");
+    const parsed = safeJsonParse(legacyRaw, {});
+    const legacyColor = parsed?.background;
+    if (legacyColor) {
+      localStorage.setItem("dmNeonColor", legacyColor);
+      localStorage.removeItem("dmThemePrefs");
+      return legacyColor;
+    }
+  } catch {}
+
+  return dmNeonDefaults.color;
 }
-function saveDmThemePrefsToStorage(){
-  try { localStorage.setItem("dmThemePrefs", JSON.stringify(dmThemePrefs)); }
+function saveDmNeonColorToStorage(){
+  try { localStorage.setItem("dmNeonColor", dmNeonColor); }
   catch{}
-  queuePersistPrefs({ dmThemePrefs });
+  queuePersistPrefs({ dmNeonColor });
 }
-function applyDmThemePrefs(){
-  const bg = sanitizeColor(dmThemePrefs.background, dmThemeDefaults.background, dmThemeDefaults.background);
-  dmThemePrefs.background = bg;
-  document.documentElement.style.setProperty("--dm-bg", bg);
-  if(dmBgColor) dmBgColor.value = normalizeColorForInput(bg, dmThemeDefaults.background);
-  if(dmBgColorText) dmBgColorText.value = bg;
+function applyDmNeonPrefs(){
+  const color = sanitizeColor(dmNeonColor, dmNeonDefaults.color, dmNeonDefaults.color);
+  dmNeonColor = color;
+  document.documentElement.style.setProperty("--dm-neon", color);
+  if(dmNeonColorInput) dmNeonColorInput.value = normalizeColorForInput(color, dmNeonDefaults.color);
+  if(dmNeonColorText) dmNeonColorText.value = color;
 }
 
 function sanitizeThemeName(name){
@@ -5994,10 +6007,15 @@ async function loadUserPrefs(){
       saveBadgePrefsToStorage();
   queuePersistPrefs({ dmBadgePrefs: badgePrefs });
     }
-    if(prefs.dmThemePrefs && typeof prefs.dmThemePrefs === "object"){
-      dmThemePrefs = { ...dmThemeDefaults, ...prefs.dmThemePrefs };
-      applyDmThemePrefs();
-      saveDmThemePrefsToStorage();
+    if (typeof prefs.dmNeonColor === "string") {
+      dmNeonColor = prefs.dmNeonColor;
+      applyDmNeonPrefs();
+      saveDmNeonColorToStorage();
+    } else if (prefs.dmThemePrefs && typeof prefs.dmThemePrefs === "object" && typeof prefs.dmThemePrefs.background === "string") {
+      dmNeonColor = prefs.dmThemePrefs.background;
+      applyDmNeonPrefs();
+      saveDmNeonColorToStorage();
+      queuePersistPrefs({ dmNeonColor });
     }
     if (Array.isArray(prefs.pinnedThemeIds)) {
       themePinnedIds = normalizeThemeIdList(prefs.pinnedThemeIds);
@@ -6559,8 +6577,8 @@ function markDmNotification(threadId, isGroupHint){
 }
 badgePrefs = loadBadgePrefsFromStorage();
 applyBadgePrefs();
-dmThemePrefs = loadDmThemePrefsFromStorage();
-applyDmThemePrefs();
+dmNeonColor = loadDmNeonColorFromStorage();
+applyDmNeonPrefs();
 initCustomizationUi();
 const EMOJI_CHOICES = ["😀","😁","😂","🙂","😉","😍","😘","🤔","😤","😭","😡","🥹","😈","💀","🔥","👀","🖕","♥️","💯","👍","👎","🎉","📸","🫦",];
 
@@ -7537,7 +7555,7 @@ memberReferBtn?.addEventListener("click", ()=>{
   closeMemberMenu();
 });
 
-  if (uname) startDirectMessage(uname);
+  if (uname) startDirectMessage(uname, memberMenuUser?.id ?? memberMenuUser?.userId ?? memberMenuUser?.user_id);
   closeMemberMenu();
 });
 
@@ -8199,11 +8217,21 @@ function syncDmTabUi(){
   if (dmCreateGroupBtn) dmCreateGroupBtn.style.display = dmTab === "group" ? "block" : "none";
 }
 
+function setDmViewMode(mode){
+  const next = mode === "thread" ? "thread" : "inbox";
+  dmViewMode = next;
+  if (!dmPanel) return;
+  dmPanel.classList.toggle("dmModeInbox", next === "inbox");
+  dmPanel.classList.toggle("dmModeThread", next === "thread");
+}
+
 function setDmTab(tab){
   dmTab = tab === "group" ? "group" : "direct";
   syncDmTabUi();
   renderDmThreads();
 }
+
+setDmViewMode("inbox");
 
 // Some deployments mount DM routes under /api (e.g. /api/dm/thread) while others use
 // /dm directly. Try the likely variant first and fall back on 404.
@@ -8464,10 +8492,43 @@ function renderGroupThreads(){
   updateDmThreadPlaceholderVisibility();
 }
 
+function renderDmThreadList(){
+  if (!dmThreadList) return;
+  dmThreadList.innerHTML = "";
+  const direct = (dmThreads || []).filter(isDirectThread);
+  const groups = (dmThreads || []).filter((t)=>!!t.is_group);
+  const sortByRecent = (a, b) => Number(b.last_ts || 0) - Number(a.last_ts || 0);
+
+  if (!direct.length && !groups.length) {
+    const empty = document.createElement("div");
+    empty.className = "dmEmpty";
+    empty.textContent = "No DM threads yet.";
+    dmThreadList.appendChild(empty);
+    return;
+  }
+
+  if (direct.length) {
+    const title = document.createElement("div");
+    title.className = "dmSectionTitle";
+    title.textContent = "Direct messages";
+    dmThreadList.appendChild(title);
+    direct.sort(sortByRecent).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
+  }
+
+  if (groups.length) {
+    const title = document.createElement("div");
+    title.className = "dmSectionTitle";
+    title.textContent = "Group chats";
+    dmThreadList.appendChild(title);
+    groups.sort(sortByRecent).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
+  }
+}
+
 function renderDmThreads(){
   // Backwards-compatible entrypoint.
   renderDirectThreads();
   renderGroupThreads();
+  renderDmThreadList();
 }
 
 
@@ -8508,6 +8569,17 @@ try{
   }
 }
 
+function resolveParticipantIdsByNames(names = []){
+  const ids = new Set();
+  for (const name of names) {
+    const key = normKey(name);
+    const hit = (lastUsers || []).find((u) => normKey(u?.name || u?.username) === key);
+    const id = Number(hit?.id ?? hit?.userId ?? hit?.user_id);
+    if (Number.isInteger(id) && id > 0) ids.add(id);
+  }
+  return Array.from(ids);
+}
+
 async function startDirectMessage(username, targetId){
   if (!username) return;
   const target = String(username).trim();
@@ -8541,25 +8613,25 @@ async function startDirectMessage(username, targetId){
 
   setDmNotice("Preparing chat...");
   try {
-    const res = await dmFetch("/api/dm/thread", {
+    const resolvedId = Number(targetId);
+    const participantIds = Number.isInteger(resolvedId) && resolvedId > 0
+      ? [resolvedId]
+      : resolveParticipantIdsByNames([target]);
+
+    const res = await dmFetch("/dm/thread", {
       method: "POST",
       headers: {"Content-Type":"application/json"},
-      // Send multiple keys for backwards/forwards compatibility across server builds.
       body: JSON.stringify({
         kind: "direct",
         participants: [target],
-        participant: target,
-        user: target,
-        to: target,
-        username: target,
-        participantId: (Number.isInteger(Number(targetId)) && Number(targetId) > 0) ? Number(targetId) : undefined,
-        targetId: (Number.isInteger(Number(targetId)) && Number(targetId) > 0) ? Number(targetId) : undefined,
+        participantIds,
       })
     });
 
     if (!res.ok) {
       const text = await res.text();
       setDmNotice(text || "Could not start DM.");
+      toast?.(text || "Could not start DM.");
       return;
     }
 
@@ -8569,16 +8641,19 @@ async function startDirectMessage(username, targetId){
 
     if (data.threadId) {
       upsertThreadMeta(data.threadId, { participants: [target, meName].filter(Boolean), is_group: false });
+      await loadDmThreads();
       openDmThread(data.threadId);
     }
   } catch {
     setDmNotice("Could not start DM.");
+    toast?.("Could not start DM.");
   }
 }
 
 function openDmPanel(){
   dmPanel.classList.add("open");
   setDmNotice("");
+  setDmViewMode("inbox");
   // Do not clear badges on open; only clear when a thread is actually read.
   syncDmTabUi();
 
@@ -9066,6 +9141,7 @@ function openDmThread(threadId){
 
   const meta = dmThreads.find(t => String(t.id) === String(threadId));
   if (meta) setDmTab(meta.is_group ? "group" : "direct");
+  setDmViewMode("thread");
   dmUnreadThreads.delete(threadId);
   renderDmThreads();
   setDmMeta(meta);
@@ -9250,12 +9326,14 @@ async function submitDmPicker(){
 
   try {
     dmModalPrimaryBtn.disabled = true;
-    const res = await dmFetch("/api/dm/thread", {
+    const participantIds = resolveParticipantIdsByNames(names);
+    const res = await dmFetch("/dm/thread", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         kind: "group",
         participants: names,
+        participantIds,
         // Compatibility keys
         users: names.join(","),
       }),
@@ -9264,6 +9342,7 @@ async function submitDmPicker(){
     if (!res.ok) {
       const txt = await res.text();
       setDmNotice(txt || "Could not create group.");
+      toast?.(txt || "Could not create group.");
       return;
     }
     const data = await res.json();
@@ -9272,6 +9351,7 @@ async function submitDmPicker(){
     if (data.threadId) openDmThread(data.threadId);
   } catch {
     setDmNotice("Could not create group.");
+    toast?.("Could not create group.");
   }
 }
 
@@ -9417,6 +9497,7 @@ document.addEventListener("touchstart", closeQuickBarsOnOutside, { capture: true
 // The DM panel is entered only after selecting a thread from the quick strip.
 dmCreateGroupBtn?.addEventListener("click", () => openDmPicker("create"));
 dmCloseBtn?.addEventListener("click", closeDmPanel);
+dmBackBtn?.addEventListener("click", () => setDmViewMode("inbox"));
 dmSendBtn?.addEventListener("click", sendDmMessage);
 dmInfoBtn?.addEventListener("click", () => openDmInfo());
 dmSettingsBtn?.addEventListener("click", (e) => {
@@ -9450,17 +9531,17 @@ document.addEventListener("click", (e) => {
   closeDmSettingsMenu();
 });
 
-dmBgColor?.addEventListener("input", () => {
-  dmThemePrefs.background = dmBgColor.value;
-  if(dmBgColorText) dmBgColorText.value = dmBgColor.value;
-  applyDmThemePrefs();
-  saveDmThemePrefsToStorage();
+dmNeonColorInput?.addEventListener("input", () => {
+  dmNeonColor = dmNeonColorInput.value;
+  if(dmNeonColorText) dmNeonColorText.value = dmNeonColorInput.value;
+  applyDmNeonPrefs();
+  saveDmNeonColorToStorage();
 });
-dmBgColorText?.addEventListener("input", () => {
-  const safe = sanitizeColor(dmBgColorText.value, dmThemePrefs.background, dmThemeDefaults.background);
-  dmThemePrefs.background = safe;
-  applyDmThemePrefs();
-  saveDmThemePrefsToStorage();
+dmNeonColorText?.addEventListener("input", () => {
+  const safe = sanitizeColor(dmNeonColorText.value, dmNeonColor, dmNeonDefaults.color);
+  dmNeonColor = safe;
+  applyDmNeonPrefs();
+  saveDmNeonColorToStorage();
 });
 
 memberViewProfileBtn?.addEventListener("click", () => {
@@ -9470,7 +9551,7 @@ memberViewProfileBtn?.addEventListener("click", () => {
 });
 
 memberDmBtn?.addEventListener("click", () => {
-  if (memberMenuUser) startDirectMessage(memberMenuUser.name);
+  if (memberMenuUser) startDirectMessage(memberMenuUser.name, memberMenuUser?.id ?? memberMenuUser?.userId ?? memberMenuUser?.user_id);
 });
 
 document.addEventListener("click", (e) => {
@@ -14667,9 +14748,9 @@ resetAdvancedBtn?.addEventListener("click", () => {
   syncSoundPrefsUI(true);
   queuePersistPrefs({ sound: Sound.exportPrefs() });
 
-  dmThemePrefs = { ...dmThemeDefaults };
-  applyDmThemePrefs();
-  saveDmThemePrefsToStorage();
+  dmNeonColor = dmNeonDefaults.color;
+  applyDmNeonPrefs();
+  saveDmNeonColorToStorage();
 
   badgePrefs = { ...badgeDefaults };
   applyBadgePrefs();

--- a/public/index.html
+++ b/public/index.html
@@ -620,13 +620,25 @@
 <!-- DM PANEL -->
 <div class="dmPanel" id="dmPanel">
 <div class="dmHeader">
+<div class="dmHeaderMain">
+<button class="iconBtn secondary dmBackBtn" id="dmBackBtn" title="Back to inbox" type="button">←</button>
 <div>
 <div class="title">Direct Messages</div>
 <div class="small">Start a DM from the members list.</div>
 </div>
+</div>
 <button class="iconBtn" id="dmCloseBtn" title="Close" type="button">✕</button>
 </div>
 <div class="dmContent">
+<div class="dmThreads">
+<div class="dmThreadsHeader">
+<div>
+<div class="title">Inbox</div>
+<div class="small">Direct and group chats</div>
+</div>
+</div>
+<div class="dmThreadList" id="dmThreadList"></div>
+</div>
 <div class="dmConversation">
 <div class="dmMeta">
 <div class="dmMetaText">
@@ -1675,13 +1687,13 @@
 <details class="customizeSection" data-section="advanced-extra">
 <summary>Advanced</summary>
 <div class="panelBox" id="advancedAdvanced">
-<div class="field" data-customize-item="" data-search="dm background">
-<div class="small">DM background</div>
+<div class="field" data-customize-item="" data-search="dm neon backing">
+<div class="small">DM neon backing</div>
 <div class="colorInputRow tight">
-<input aria-label="DM background color" id="dmBgColor" type="color"/>
-<input aria-label="DM background color text" id="dmBgColorText" placeholder="#1e1f22 or blue" type="text"/>
+<input aria-label="DM neon backing color" id="dmNeonColor" type="color"/>
+<input aria-label="DM neon backing color text" id="dmNeonColorText" placeholder="#5865f2 or blue" type="text"/>
 </div>
-<div class="small">Change the backdrop behind your DM threads and conversation.</div>
+<div class="small">Adds a subtle neon outline around your DM panel. DM background follows your current theme.</div>
 </div>
 <div class="field" data-customize-item="" data-search="dm badge color">
 <label>Direct message badge color</label>

--- a/public/styles.css
+++ b/public/styles.css
@@ -47,7 +47,8 @@
   /* legacy aliases so existing rules consume theme tokens */
   --soft: rgba(0, 0, 0, 0.13);
   --avatar-bg: #444444;
-  --dm-bg: #1e1f22;
+  --dm-bg: var(--panel2);
+  --dm-neon: var(--accent);
   --overlay-scrim: rgba(0, 0, 0, 0.6);
   --bubble: var(--messageOtherBg);
   --bubbleSelf: var(--messageSelfBg);
@@ -4848,10 +4849,13 @@ body.lockScroll{ overflow:hidden; }
   width:min(640px, 48vw);
   height:auto;
   max-height: calc(var(--vvhPx) - 16px - var(--dmPanelBottom));
-  background:linear-gradient(135deg, rgba(255,255,255,.02), rgba(255,255,255,.04)), var(--panel2);
-  border:1px solid var(--line);
+  background: var(--panel2);
+  border:1px solid color-mix(in srgb, var(--dm-neon) 18%, var(--line));
   border-radius:20px;
-  box-shadow: 0 22px 60px rgba(0,0,0,.5);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--dm-neon) 18%, transparent),
+    0 0 22px color-mix(in srgb, var(--dm-neon) 18%, transparent),
+    0 22px 60px rgba(0,0,0,.5);
   display:flex;
   flex-direction:column;
   /* Pop-out animation (shown when .open is toggled) */
@@ -4873,13 +4877,21 @@ body.lockScroll{ overflow:hidden; }
  }
 .dmHeader{
   /* Keep the DM panel header compact (closer to desktop DM header style). */
-  padding:6px 10px;
+  padding:8px 12px;
   display:flex;
   align-items:center;
   gap:12px;
   justify-content:space-between;
   border-bottom:1px solid var(--line);
+  background: var(--panel2);
 }
+.dmHeaderMain{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  min-width:0;
+}
+.dmBackBtn{ display:none; }
 .dmHeader .title{ font-weight:900; letter-spacing:.01em; }
 .dmHeader .small{ font-size:11px; }
 .dmHeader .iconBtn{ width:32px; height:32px; }
@@ -4898,22 +4910,51 @@ body.lockScroll{ overflow:hidden; }
 .dmNoticeText{ display:none; }
 .dmNotice.hasNotice .dmNoticeText{ display:block; }
 .dmContent{
-  /* Single-pane DM layout.
-     A previous 2-column grid left an unused/black column on desktop.
-     Keep this as a flex column so the conversation fills the whole panel. */
   flex:1;
+  display:flex;
+  flex-direction:row;
+  min-height:0;
+  background:var(--dm-bg);
+}
+.dmThreads{
+  width: min(320px, 38%);
+  border-right:1px solid var(--line);
+  overflow:auto;
   display:flex;
   flex-direction:column;
   min-height:0;
-  backdrop-filter: blur(4px);
-  background:var(--dm-bg);
+  gap:10px;
+  padding:10px;
+  background: var(--panel);
 }
-.dmThreads{ border-right:1px solid var(--line); overflow:auto; display:flex; flex-direction:column; min-height:0; gap:8px; padding:8px 10px 10px; }
+.dmThreadsHeader{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:10px;
+  padding:4px 4px 0;
+}
+.dmThreadList{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  min-height:0;
+}
 /* Remove the large "boxed" panel look so the left list doesn't waste vertical space (mobile) */
 .dmThreadList{ border:0; border-radius:0; overflow:auto; background:transparent; flex:1; min-height:0; }
-.dmItem{ padding:12px; border-bottom:1px solid var(--line); cursor:pointer; display:flex; gap:10px; align-items:center; transition: background .12s ease, border-color .12s ease; }
+.dmItem{
+  padding:12px;
+  border:1px solid transparent;
+  border-radius:14px;
+  cursor:pointer;
+  display:flex;
+  gap:10px;
+  align-items:center;
+  transition: background .12s ease, border-color .12s ease, transform .12s ease;
+  min-height:48px;
+}
 .dmItem:hover{ background:var(--panel); }
-.dmItem.active{ background:var(--bubble); }
+.dmItem.active{ background:color-mix(in srgb, var(--panel2) 70%, transparent); border-color:color-mix(in srgb, var(--dm-neon) 18%, transparent); }
 .dmItem:last-child{ border-bottom:0; }
 .dmItem,
 .dmThreadRow{
@@ -4954,7 +4995,7 @@ body.lockScroll{ overflow:hidden; }
 .dmItemBottom{ display:flex; align-items:center; gap:6px; justify-content:space-between; }
 .dmItemTime{ font-size:11px; color:var(--muted); white-space:nowrap; }
 .dmUnread{ min-width:22px; height:22px; padding:0 8px; border-radius:999px; background:var(--accent); color:white; font-size:11px; display:flex; align-items:center; justify-content:center; }
-.dmAvatar{ width:42px; height:42px; border-radius:12px; overflow:hidden; background:var(--avatar-bg); flex-shrink:0; display:flex; align-items:center; justify-content:center; }
+.dmAvatar{ width:44px; height:44px; border-radius:14px; overflow:hidden; background:var(--avatar-bg); flex-shrink:0; display:flex; align-items:center; justify-content:center; }
 .dmConversation{
   display:flex;
   flex-direction:column;
@@ -5333,7 +5374,21 @@ body.polish-pack.polish-animations .msg-new .dmMsgAvatar{
 .dmThreadActions .btn.full{ width:100%; justify-content:center; }
 .dmModal{ position:fixed; inset:0; background:var(--overlay-scrim); display:none; align-items:center; justify-content:center; padding:14px; z-index:380; }
 .dmModal.show{ display:flex; }
-.dmModalCard{ background:var(--panel2); border:1px solid var(--line); border-radius:18px; width:min(560px, 96vw); max-height:90vh; display:flex; flex-direction:column; gap:12px; padding:14px; overflow:hidden; }
+.dmModalCard{
+  background:var(--panel2);
+  border:1px solid color-mix(in srgb, var(--dm-neon) 18%, var(--line));
+  border-radius:18px;
+  width:min(560px, 96vw);
+  max-height:90vh;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:14px;
+  overflow:hidden;
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--dm-neon) 16%, transparent),
+    0 12px 32px rgba(0,0,0,0.45);
+}
 .dmModalHeader{ display:flex; align-items:flex-start; justify-content:space-between; gap:10px; }
 .dmPickerList{ flex:1; min-height:200px; border:1px solid var(--line); border-radius:12px; overflow:auto; background:var(--panel); }
 .dmPickerRow{ display:flex; align-items:center; gap:10px; padding:10px 12px; border-bottom:1px solid var(--line); }
@@ -5393,14 +5448,23 @@ body.polish-pack.polish-animations .msg-new .dmMsgAvatar{
     box-shadow:none;
   }
   .dmHeader{ position:sticky; top:0; background:var(--panel2); z-index:2; }
+  .dmBackBtn{ display:inline-flex; }
   .dmInput{
     position: static;
     bottom: auto;
     padding-bottom: calc(10px + env(safe-area-inset-bottom));
   }
-  /* DM is single-pane on mobile as well; keep full-height conversation */
   .dmContent{ display:flex; flex-direction:column; }
-  .dmThreads{ display:none; }
+  .dmThreads{
+    width:100%;
+    border-right:0;
+    border-bottom:1px solid var(--line);
+    background: var(--panel2);
+  }
+  .dmPanel.dmModeInbox .dmConversation{ display:none; }
+  .dmPanel.dmModeThread .dmThreads{ display:none; }
+  .dmPanel.dmModeThread .dmBackBtn{ display:inline-flex; }
+  .dmPanel.dmModeInbox .dmBackBtn{ display:none; }
   .dmMessages{ padding-bottom: 12px; }
 
   .channels{

--- a/server.js
+++ b/server.js
@@ -6973,6 +6973,7 @@ function safeNumber(value, fallback = 0) {
 }
 const PREFS_DEFAULTS = Object.freeze({
   dmBadgePrefs: { direct: "#ed4245", group: "#5865f2" },
+  dmNeonColor: "#5865f2",
   dmThemePrefs: { background: "#1e1f22" },
   pinnedThemeIds: [],
   favoriteThemeIds: [],
@@ -7019,6 +7020,9 @@ function normalizePrefs(raw) {
     if (typeof prefs.dmBadgePrefs.direct === "string") dmBadgePrefs.direct = prefs.dmBadgePrefs.direct;
     if (typeof prefs.dmBadgePrefs.group === "string") dmBadgePrefs.group = prefs.dmBadgePrefs.group;
   }
+  const dmNeonColor = typeof prefs.dmNeonColor === "string"
+    ? prefs.dmNeonColor
+    : (typeof prefs.dmThemePrefs?.background === "string" ? prefs.dmThemePrefs.background : PREFS_DEFAULTS.dmNeonColor);
   const dmThemePrefs = { ...PREFS_DEFAULTS.dmThemePrefs };
   if (prefs.dmThemePrefs && typeof prefs.dmThemePrefs === "object") {
     if (typeof prefs.dmThemePrefs.background === "string") dmThemePrefs.background = prefs.dmThemePrefs.background;
@@ -7029,6 +7033,7 @@ function normalizePrefs(raw) {
     favoriteThemeIds: normalizeThemeIdList(prefs.favoriteThemeIds),
     ownedThemeIds: normalizeThemeIdList(prefs.ownedThemeIds),
     dmBadgePrefs,
+    dmNeonColor,
     dmThemePrefs,
     sound: normalizeSoundPrefs(prefs.sound),
     chatFx: sanitizeChatFx(prefs.chatFx),
@@ -7038,6 +7043,7 @@ function sanitizePrefsInput(p) {
   const out = {};
   if (p && typeof p === "object") {
     if (p.dmBadgePrefs && typeof p.dmBadgePrefs === "object") out.dmBadgePrefs = p.dmBadgePrefs;
+    if (typeof p.dmNeonColor === "string") out.dmNeonColor = p.dmNeonColor;
     if (p.dmThemePrefs && typeof p.dmThemePrefs === "object") out.dmThemePrefs = p.dmThemePrefs;
     if (Array.isArray(p.pinnedThemeIds)) out.pinnedThemeIds = normalizeThemeIdList(p.pinnedThemeIds);
     if (Array.isArray(p.favoriteThemeIds)) out.favoriteThemeIds = normalizeThemeIdList(p.favoriteThemeIds);


### PR DESCRIPTION
### Motivation
- Modernize the Direct Message experience with a mobile-first, app-like layout and cleaner visuals. 
- Replace the confusing per-DM background fill with a theme-following DM neon outline/backing control. 
- Fix unreliable DM thread creation so starting a DM always creates/reuses and opens the thread immediately.

### Description
- UI/layout: restructured the DM panel into an inbox/thread two-pane layout and added mobile modes with a top-left Back button and `dmViewMode` state (`inbox` | `thread`) to toggle `.dmModeInbox` / `.dmModeThread` on the DM root; added an inbox thread list DOM node and rendering (`renderDmThreadList`). (files: `public/index.html`, `public/app.js`, `public/styles.css`)
- Styling: removed custom DM background fill and introduced CSS variable `--dm-neon` used for a subtle outline/glow (borders, box-shadows) around DM panel/modal; DM surfaces keep theme-driven `--panel/--panel2`; improved spacing, touch targets, thread rows and composer safe-area handling. (file: `public/styles.css`)
- Preference change & migration: replaced old “DM background” controls with “DM neon backing” inputs (`dmNeonColor` / `dmNeonColorText`), added client-side storage, server-side preference key `dmNeonColor`, and a one-time migration from legacy `dmThemePrefs.background` to the new neon color. The client sets `--dm-neon` on apply. (files: `public/index.html`, `public/app.js`, `server.js`)
- Thread creation robustness: standardized client thread creation to call the server DM route consistently (`/dm/thread`) and send participant IDs when available; implemented `resolveParticipantIdsByNames` helper to map names -> ids via `lastUsers`; after creation the client reloads threads and opens the new thread immediately; group creation similarly posts `participantIds`. Added immediate toast notices on errors. (file: `public/app.js`)
- Small wiring: back button handler, view-mode setters, DM picker updates, and minor avatar/list improvements to integrate the new layout. (files: `public/app.js`, `public/index.html`, `public/styles.css`)

### Testing
- Ran `npm run check` (JS syntax checks) — succeeded. 
- Performed a local smoke attempt with `npm start`; the server process launched but the environment lacked reachable Postgres (DNS lookup error from the external PG host), so full end-to-end tests against DB-backed endpoints could not complete in this environment (this is an external infra issue, not a code regression).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dba6904188333b4292f9c5cfeb2bf)