### PR TITLE
Fix Iris & Lola ambience and members popover anchoring

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2376,7 +2376,7 @@ function setIrisLolaSkyTintVars(){
 }
 
 function spawnIrisLolaShootingStar(){
-  if (!shouldUseIrisLolaCoupleUi()) return;
+  if (!shouldUseIrisLolaAmbient()) return;
   const field = document.getElementById('irisLolaStarfield');
   if (!field) return;
   if (!shouldAnimateAmbientEffects(PREFERS_REDUCED_MOTION)) return;
@@ -2398,7 +2398,7 @@ function spawnIrisLolaShootingStar(){
 
 function scheduleIrisLolaShootingStar(){
   try{ if (irisLolaShootingStarTimer) clearTimeout(irisLolaShootingStarTimer); }catch{}
-  if (!shouldUseIrisLolaCoupleUi() || !shouldAnimateAmbientEffects(PREFERS_REDUCED_MOTION)) return;
+  if (!shouldUseIrisLolaAmbient() || !shouldAnimateAmbientEffects(PREFERS_REDUCED_MOTION)) return;
   const delay = 2000 + Math.random() * 5200; // 2s-7.2s
   irisLolaShootingStarTimer = setTimeout(()=>{
     spawnIrisLolaShootingStar();
@@ -2407,7 +2407,7 @@ function scheduleIrisLolaShootingStar(){
 }
 
 function spawnIrisLolaConstellationWhisper(){
-  if (!shouldUseIrisLolaCoupleUi()) return;
+  if (!shouldUseIrisLolaAmbient()) return;
   const field = document.getElementById('irisLolaStarfield');
   if (!field) return;
   if (!shouldAnimateAmbientEffects(PREFERS_REDUCED_MOTION)) return;
@@ -2454,7 +2454,7 @@ function spawnIrisLolaConstellationWhisper(){
 
 function ensureIrisLolaAmbientLoops(){
   if (irisLolaAmbientLoopsReady) return;
-  if (!shouldUseIrisLolaCoupleUi()) { clearIrisLolaAmbientLoops(); return; }
+  if (!shouldUseIrisLolaAmbient()) { clearIrisLolaAmbientLoops(); return; }
   ensureIrisLolaStarfield();
 
   // Time-based tint updates.
@@ -2481,7 +2481,7 @@ function updateIrisLolaTogetherClass() {
   document.body?.classList.toggle("irisLolaCoupleActive", !!(themeActive && coupleActive));
   updateIrisLolaAvatarGlows({ themeActive, coupleActive, bothOnline, partnerName });
   // Ambient layer: subtle starfield + shooting stars + rare constellation whispers.
-  if (themeActive && coupleActive) ensureIrisLolaAmbientLoops();
+  if (themeActive) ensureIrisLolaAmbientLoops();
   else clearIrisLolaAmbientLoops();
 }
 function updateIrisLolaAvatarGlows({ themeActive, coupleActive, bothOnline, partnerName } = {}) {
@@ -2518,6 +2518,9 @@ function isPartnerName(username) {
 function shouldUseIrisLolaCoupleUi() {
   return isIrisLolaThemeActive() && isCoupleActiveState(couplesState);
 }
+function shouldUseIrisLolaAmbient() {
+  return isIrisLolaThemeActive();
+}
 const DEFAULT_THEME = "Minimal Dark";
 let currentTheme = document.body?.getAttribute("data-theme") || DEFAULT_THEME;
 let themeActiveFilter = "all";
@@ -2548,6 +2551,8 @@ let dmUploading = false;
 let uploadXhr = null;
 let memberMenuUser = null;
 let memberMenuUsername = "";
+let memberMenuAnchor = null;
+let memberMenuRaf = null;
 let replyTarget = null;
 let dmReplyTarget = null;
 let chatPinned = true;
@@ -2817,6 +2822,11 @@ const memberMenuName = document.getElementById("memberMenuName");
 const memberViewProfileBtn = document.getElementById("memberViewProfileBtn");
 const memberDmBtn = document.getElementById("memberDmBtn");
 const memberReferBtn = document.getElementById("memberReferBtn");
+
+const appRoot = document.getElementById("app");
+if (memberMenu && appRoot && memberMenu.parentElement !== appRoot) {
+  appRoot.appendChild(memberMenu);
+}
 const commandPopup = document.getElementById("commandPopup");
 const commandPopupTitle = document.getElementById("commandPopupTitle");
 const commandPopupBody = document.getElementById("commandPopupBody");
@@ -7673,11 +7683,77 @@ function handleDmMessageDeleted(threadId, messageId){
   if (row) removeMessageWithAnimation(row);
 }
 
+function getSafeInsetPx(varName) {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(varName);
+  const parsed = parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function scheduleMemberMenuPosition() {
+  if (!memberMenu?.classList.contains("open")) return;
+  if (memberMenuRaf) return;
+  memberMenuRaf = requestAnimationFrame(() => {
+    memberMenuRaf = null;
+    positionMemberMenu();
+  });
+}
+
+function positionMemberMenu() {
+  if (!memberMenu || !memberMenuAnchor || !memberMenuAnchor.isConnected) {
+    closeMemberMenu();
+    return;
+  }
+
+  const anchorRect = memberMenuAnchor.getBoundingClientRect();
+  const viewport = window.visualViewport;
+  const viewportWidth = viewport?.width ?? window.innerWidth;
+  const viewportHeight = viewport?.height ?? window.innerHeight;
+  if (anchorRect.bottom < 0 || anchorRect.top > viewportHeight) {
+    closeMemberMenu();
+    return;
+  }
+
+  const appRect = appRoot?.getBoundingClientRect() ?? { left: 0, top: 0 };
+  memberMenu.style.visibility = "hidden";
+  memberMenu.style.left = "0px";
+  memberMenu.style.top = "0px";
+
+  const menuRect = memberMenu.getBoundingClientRect();
+  const menuWidth = menuRect.width;
+  const menuHeight = menuRect.height;
+
+  const safeTop = getSafeInsetPx("--safeT");
+  const safeBottom = getSafeInsetPx("--safeB");
+  const safeLeft = getSafeInsetPx("--safeL");
+  const safeRight = getSafeInsetPx("--safeR");
+
+  const pad = 12;
+  const gap = 8;
+  let left = anchorRect.right + gap;
+  let top = anchorRect.top + (anchorRect.height / 2) - (menuHeight / 2);
+
+  if (left + menuWidth + pad + safeRight > viewportWidth) {
+    left = anchorRect.left - menuWidth - gap;
+  }
+
+  left = Math.min(Math.max(left, pad + safeLeft), viewportWidth - menuWidth - pad - safeRight);
+  top = Math.min(Math.max(top, pad + safeTop), viewportHeight - menuHeight - pad - safeBottom);
+
+  memberMenu.style.left = `${left - appRect.left}px`;
+  memberMenu.style.top = `${top - appRect.top}px`;
+  memberMenu.style.visibility = "";
+}
+
 function closeMemberMenu(){
   if (!memberMenu) return;
   memberMenu.classList.remove("open");
   memberMenuUser = null;
   memberMenuUsername = "";
+  memberMenuAnchor = null;
+  if (memberMenuRaf) {
+    cancelAnimationFrame(memberMenuRaf);
+    memberMenuRaf = null;
+  }
 }
 
 
@@ -7719,8 +7795,15 @@ function openMemberMenu(user, anchor){
     return;
   }
 
+  const anchorEl = anchor?.querySelector(".mName") || anchor;
+  if (memberMenu.classList.contains("open") && memberMenuAnchor === anchorEl) {
+    closeMemberMenu();
+    return;
+  }
+
   memberMenuUser = user;
   memberMenuUsername = user?.username || user?.name || "";
+  memberMenuAnchor = anchorEl;
   // Show "Refer ban" for Moderators (they cannot ban directly)
   if(memberReferBtn){
     const isSelf = (memberMenuUsername && me?.username && memberMenuUsername.toLowerCase()===me.username.toLowerCase());
@@ -7728,13 +7811,7 @@ function openMemberMenu(user, anchor){
   }
   if (memberMenuName) memberMenuName.textContent = `${roleIcon(user.role)} ${user.name}`;
   memberMenu.classList.add("open");
-
-  const paneRect = membersPane.getBoundingClientRect();
-  const rect = anchor.getBoundingClientRect();
-  const top = rect.top - paneRect.top + membersPane.scrollTop + rect.height + 6;
-  const left = rect.left - paneRect.left + 6;
-  memberMenu.style.top = `${top}px`;
-  memberMenu.style.left = `${left}px`;
+  scheduleMemberMenuPosition();
 }
 
 function updateGoldUI(){
@@ -9737,7 +9814,16 @@ document.addEventListener("click", (e) => {
   if (e.target.closest(".mItem")) return;
   closeMemberMenu();
 });
-membersPane?.addEventListener("scroll", closeMemberMenu);
+document.addEventListener("keydown", (e) => {
+  if (e.key !== "Escape") return;
+  if (memberMenu?.classList.contains("open")) closeMemberMenu();
+});
+
+const repositionMemberMenu = () => scheduleMemberMenuPosition();
+membersPane?.addEventListener("scroll", repositionMemberMenu, { passive: true });
+window.addEventListener("resize", repositionMemberMenu, { passive: true });
+window.visualViewport?.addEventListener("resize", repositionMemberMenu, { passive: true });
+window.visualViewport?.addEventListener("scroll", repositionMemberMenu, { passive: true });
 
 mentionDropdown?.addEventListener("click", (e) => {
   const btn = e.target.closest("button[data-name]");

--- a/public/styles.css
+++ b/public/styles.css
@@ -3840,7 +3840,7 @@ body:not(.polish-pack) .tonePicker{
 .mRoll{ font-size:11px; color:var(--accent); font-weight:800; }
 
 .memberMenu{
-  position:absolute;
+  position:fixed;
   top:0;
   left:0;
   background: color-mix(in srgb, var(--panel2) 92%, transparent);
@@ -3851,9 +3851,9 @@ body:not(.polish-pack) .tonePicker{
   display:none;
   flex-direction:column;
   gap:8px;
-  z-index: 8;
+  z-index: 500;
   min-width: 230px;
-  max-width: calc(100% - 20px);
+  max-width: min(320px, calc(100vw - 24px - var(--safeL) - var(--safeR)));
 }
 .memberMenu.open{ display:flex; }
 .memberMenuHeader{ display:flex; flex-direction:column; gap:4px; }
@@ -5931,6 +5931,9 @@ main.chat{ position: relative; }
   --leftDrawerW: 0px;
   --rightDrawerW: 0px;
   --safeB: env(safe-area-inset-bottom, 0px);
+  --safeT: env(safe-area-inset-top, 0px);
+  --safeL: env(safe-area-inset-left, 0px);
+  --safeR: env(safe-area-inset-right, 0px);
 }
 
 body.drawer-left-open  { --leftDrawerW: min(86vw, 340px); }
@@ -10544,6 +10547,20 @@ body[data-theme="Iris & Lola Neon"]{
     radial-gradient(900px 700px at 55% 88%, var(--irisLolaSkyC), transparent 64%),
     linear-gradient(180deg, rgba(0,0,0,.92), rgba(0,0,0,.94)) !important;
   animation: irisLolaBreath 10s ease-in-out infinite;
+}
+
+body[data-theme="Iris & Lola Neon"] .chat{
+  background: rgba(10, 2, 16, 0.42) !important;
+}
+
+body[data-theme="Iris & Lola Neon"] #roomsPanel,
+body[data-theme="Iris & Lola Neon"] #membersPane,
+body[data-theme="Iris & Lola Neon"] .modalCard,
+body[data-theme="Iris & Lola Neon"] .panel,
+body[data-theme="Iris & Lola Neon"] .sidebar,
+body[data-theme="Iris & Lola Neon"] .listPanel{
+  background: rgba(8, 2, 16, 0.78) !important;
+  backdrop-filter: blur(10px);
 }
 
 /* Ensure the starfield sits behind chat content and is clipped to the chat area. */


### PR DESCRIPTION
### Motivation
- Make the “Iris & Lola Neon” theme reliably render its spacey/starry green+purple backdrop across chat, drawers and panels (including iOS Safari / safe-area devices) without heavy assets or performance impact. 
- Ensure the members list quick-actions popover anchors to the clicked row/name and does not appear far down the screen, and never clips outside the viewport or behind other UI. 
- Apply low-risk UX improvements (safe-area handling, z-index, click-outside/Escape close, viewport-aware clamping) while avoiding regressions to existing features.

### Description
- Changed files: `public/styles.css` and `public/app.js`.
- `public/styles.css`: added safe-area CSS vars, raised the `.memberMenu` to `position: fixed` with a higher `z-index` and clamped `max-width` that subtracts safe-area insets, and strengthened Iris & Lola background rules so chat, drawers and panels show the nebula/starfield backdrop and remain readable (subtle glass/backdrop-filter overlays for drawers/panels and chat surface tweaks). 
- `public/app.js`: moved the `#memberMenu` node under `#app` when present, introduced anchor-aware positioning using `getBoundingClientRect()` combined with `visualViewport` sizes and CSS safe insets, used `position: fixed` semantics (via the CSS change) and requestAnimationFrame throttling to recompute and clamp top/left so the popover stays next to the clicked `.mName`/row and never goes off-screen; added handlers to reposition on scroll/resize/visualViewport changes, Escape-to-close, and click-outside toggle behavior. 
- `public/app.js`: simplified Iris & Lola ambient activation so the starfield/constellation/shooting-star loops run whenever the theme is active (new helper `shouldUseIrisLolaAmbient()`), while retaining couple-specific UI/auras; kept ambient effects lightweight (CSS animations + a few DOM spans) and iOS-safe (mounting inside `.chat` to avoid body pseudo issues).

### Testing
- Started the app with `npm start` and confirmed the server served the site at `http://localhost:3000` (server start succeeded; a Postgres env lookup produced a non-fatal init warning in this environment but the web UI was reachable). 
- Ran a Playwright script that set `localStorage.theme = 'Iris & Lola Neon'`, loaded the page, and produced a screenshot `artifacts/iris-lola-login.png` to verify the theme backdrop and layering (Playwright run succeeded and screenshot was produced). 
- No new unit tests were added; `npm test` and other automated unit test scripts were not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e67604f4c83339e48b55d115f75e5)