### PR TITLE
Deterministic DM threads + Inbox/Conversation UI separation

### DIFF
--- a/database.js
+++ b/database.js
@@ -626,6 +626,8 @@ await run(`CREATE INDEX IF NOT EXISTS idx_appeal_messages_appeal ON appeal_messa
     ["user_high", "user_high INTEGER"],
     ["last_message_id", "last_message_id INTEGER"],
     ["last_message_at", "last_message_at INTEGER"],
+    ["participants_key", "participants_key TEXT"],
+    ["participants_json", "participants_json TEXT"],
   ]);
 
   await ensureColumns("dm_participants", [
@@ -641,6 +643,11 @@ await run(`CREATE INDEX IF NOT EXISTS idx_appeal_messages_appeal ON appeal_messa
     `CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_threads_pair
        ON dm_threads(user_low, user_high)
        WHERE is_group = 0 AND user_low IS NOT NULL AND user_high IS NOT NULL`
+  );
+  await run(
+    `CREATE UNIQUE INDEX IF NOT EXISTS idx_dm_threads_group_key
+       ON dm_threads(participants_key)
+       WHERE is_group = 1 AND participants_key IS NOT NULL`
   );
 
 

--- a/public/app.js
+++ b/public/app.js
@@ -8477,10 +8477,63 @@ function formatDmTime(ts){
   return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
+function formatRelativeTime(ts){
+  if (!ts) return "";
+  const delta = Math.floor((Date.now() - ts) / 1000);
+  if (delta < 60) return "just now";
+  const mins = Math.floor(delta / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  return new Date(ts).toLocaleDateString();
+}
+
 function threadAvatarNode(t){
   const wrap = document.createElement("div");
   wrap.className = "dmAvatar";
-  wrap.appendChild(avatarNode(null, threadLabel(t), "member"));
+  if (!t?.is_group) {
+    const other = otherParty(t) || threadLabel(t);
+    const meta = getUserMeta(other);
+    const fromDetail = Array.isArray(t.participantsDetail)
+      ? (t.participantsDetail.find(p => normKey(p?.username) === normKey(other)) || null)
+      : null;
+    const avatarUrl = t.otherUser?.avatar || fromDetail?.avatar || avatarCache?.[other] || null;
+    const av = makeAvatarEl({
+      username: meta.username || other || "?",
+      role: meta.role || "member",
+      avatarUrl: meta.avatarUrl || avatarUrl || null,
+      size: 40
+    });
+    wrap.appendChild(av);
+    return wrap;
+  }
+
+  const stack = document.createElement("div");
+  stack.className = "dmGroupStack";
+  const namesFromParticipants = Array.isArray(t.participants) ? t.participants : [];
+  const namesFromDetail = Array.isArray(t.participantsDetail) ? t.participantsDetail.map(p => p?.username).filter(Boolean) : [];
+  const names = [...namesFromParticipants, ...namesFromDetail].filter(Boolean);
+  const others = names.filter(n => normKey(n) !== normKey(me?.username));
+  const picks = (others.length ? others : names).slice(0, 4);
+
+  picks.forEach((name, idx) => {
+    const meta = getUserMeta(name);
+    const fromDetail = Array.isArray(t.participantsDetail)
+      ? (t.participantsDetail.find(p => normKey(p?.username) === normKey(name)) || null)
+      : null;
+    const avatarUrl = fromDetail?.avatar || avatarCache?.[name] || null;
+    const av = makeAvatarEl({
+      username: meta.username || name || "?",
+      role: meta.role || "member",
+      avatarUrl: meta.avatarUrl || avatarUrl || null,
+      size: 20
+    });
+    av.classList.add("dmGroupAvatar", `dmGroupAvatar${idx + 1}`);
+    stack.appendChild(av);
+  });
+  wrap.appendChild(stack);
   return wrap;
 }
 
@@ -8552,6 +8605,16 @@ async function dmFetch(url, options){
   return lastRes;
 }
 
+function getThreadUnreadCount(t){
+  const base = Number(t?.unreadCount || 0);
+  if (base > 0) return base;
+  if (dmUnreadThreads.has(t.id)) return 1;
+  const lastTs = Number(t?.last_ts || 0);
+  const lastRead = Number(dmLastRead?.[t.id] || 0);
+  if (lastTs && lastTs > lastRead) return 1;
+  return 0;
+}
+
 function renderThreadItem(t){
   const div = document.createElement("div");
   div.className = "dmItem" + (t.id === activeDmId ? " active" : "");
@@ -8583,7 +8646,8 @@ function renderThreadItem(t){
   } catch {}
   const time = document.createElement("div");
   time.className = "dmItemTime";
-  time.textContent = formatDmTime(t.last_ts);
+  const lastTs = Number(t.last_ts || t.created_at || 0);
+  time.textContent = formatRelativeTime(lastTs);
   top.appendChild(title);
   top.appendChild(time);
 
@@ -8594,10 +8658,11 @@ function renderThreadItem(t){
   prev.textContent = preview;
   bottom.appendChild(prev);
 
-  if (dmUnreadThreads.has(t.id)) {
+  const unreadCount = getThreadUnreadCount(t);
+  if (unreadCount > 0) {
     const unread = document.createElement("div");
     unread.className = "dmUnread";
-    unread.textContent = "New";
+    unread.textContent = String(Math.min(99, unreadCount));
     bottom.appendChild(unread);
   }
 
@@ -8783,12 +8848,17 @@ function renderDmThreadList(){
   dmThreadList.innerHTML = "";
   const direct = (dmThreads || []).filter(isDirectThread);
   const groups = (dmThreads || []).filter((t)=>!!t.is_group);
-  const sortByRecent = (a, b) => Number(b.last_ts || 0) - Number(a.last_ts || 0);
+  const sortByInbox = (a, b) => {
+    const aUnread = getThreadUnreadCount(a) > 0;
+    const bUnread = getThreadUnreadCount(b) > 0;
+    if (aUnread !== bUnread) return aUnread ? -1 : 1;
+    return Number(b.last_ts || b.created_at || 0) - Number(a.last_ts || a.created_at || 0);
+  };
 
   if (!direct.length && !groups.length) {
     const empty = document.createElement("div");
     empty.className = "dmEmpty";
-    empty.textContent = "No DM threads yet.";
+    empty.textContent = "No conversations yet.";
     dmThreadList.appendChild(empty);
     return;
   }
@@ -8798,7 +8868,7 @@ function renderDmThreadList(){
     title.className = "dmSectionTitle";
     title.textContent = "Direct messages";
     dmThreadList.appendChild(title);
-    direct.sort(sortByRecent).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
+    direct.sort(sortByInbox).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
   }
 
   if (groups.length) {
@@ -8806,7 +8876,7 @@ function renderDmThreadList(){
     title.className = "dmSectionTitle";
     title.textContent = "Group chats";
     dmThreadList.appendChild(title);
-    groups.sort(sortByRecent).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
+    groups.sort(sortByInbox).forEach((t) => dmThreadList.appendChild(renderThreadItem(t)));
   }
 }
 
@@ -8948,16 +9018,30 @@ async function startDirectMessage(username, targetId){
   }
 }
 
-function openDmPanel(){
+function openDmPanel({ view } = {}){
   dmPanel.classList.add("open");
   setDmNotice("");
-  setDmViewMode("inbox");
+  if (view) setDmViewMode(view);
   // Do not clear badges on open; only clear when a thread is actually read.
   syncDmTabUi();
 
   // load threads if we haven't yet
   if (!dmThreads.length) loadDmThreads();
   else renderDmThreads();
+}
+
+function showDmInbox({ tab } = {}){
+  saveDmDraft();
+  if (activeDmId) {
+    try { socket?.emit("dm leave", { threadId: activeDmId }); } catch {}
+  }
+  activeDmId = null;
+  setDmViewMode("inbox");
+  setDmMeta(null);
+  setDmReplyTarget(null);
+  if (dmMessagesEl) dmMessagesEl.innerHTML = "";
+  if (tab) setDmTab(tab);
+  renderDmThreads();
 }
 
 function closeDmPanel(){
@@ -9763,8 +9847,7 @@ async function toggleDmQuickBar(kind){
   else renderDirectThreads();
 }
 
-// DM button should open the full DM panel (mobile-friendly). The quick avatar strip
-// is a nice extra, but it must not be the only way to access DMs.
+// DM buttons open the inbox strip only; threads open the conversation panel.
 dmToggleBtn?.addEventListener("click", () => {
   try { hideAllDmQuickBars(); } catch {}
   if (!dmPanel) return;
@@ -9773,11 +9856,21 @@ dmToggleBtn?.addEventListener("click", () => {
   if (dmPanel.classList.contains("open")) {
     closeDmPanel();
   } else {
-    setDmTab("direct");
     openDmPanel();
+    showDmInbox({ tab: "direct" });
   }
 });
-groupDmToggleBtn?.addEventListener("click", () => { toggleDmQuickBar("group"); });
+groupDmToggleBtn?.addEventListener("click", () => {
+  try { hideAllDmQuickBars(); } catch {}
+  if (!dmPanel) return;
+
+  if (dmPanel.classList.contains("open")) {
+    closeDmPanel();
+  } else {
+    openDmPanel();
+    showDmInbox({ tab: "group" });
+  }
+});
 
 groupQuickStartBtn?.addEventListener("click", (e) => {
   e.stopPropagation();
@@ -9808,7 +9901,7 @@ document.addEventListener("touchstart", closeQuickBarsOnOutside, { capture: true
 // The DM panel is entered only after selecting a thread from the quick strip.
 dmCreateGroupBtn?.addEventListener("click", () => openDmPicker("create"));
 dmCloseBtn?.addEventListener("click", closeDmPanel);
-dmBackBtn?.addEventListener("click", () => setDmViewMode("inbox"));
+dmBackBtn?.addEventListener("click", () => showDmInbox());
 dmSendBtn?.addEventListener("click", sendDmMessage);
 dmInfoBtn?.addEventListener("click", () => openDmInfo());
 dmSettingsBtn?.addEventListener("click", (e) => {

--- a/public/styles.css
+++ b/public/styles.css
@@ -4856,6 +4856,8 @@ body.lockScroll{ overflow:hidden; }
   background: color-mix(in srgb, var(--panel2) 72%, transparent);
   -webkit-backdrop-filter: blur(12px);
   backdrop-filter: blur(12px);
+  border-color: transparent;
+  box-shadow: 0 22px 60px rgba(0,0,0,.5);
 }
 .dmPanel.dmTranslucent .dmHeader,
 .dmPanel.dmTranslucent .dmThreadsHeader,
@@ -5091,6 +5093,24 @@ body.lockScroll{ overflow:hidden; }
 .groupVenn .vennAvatar.v1{ left:0; top:8px; }
 .groupVenn .vennAvatar.v2{ right:0; top:8px; }
 .groupVenn .vennAvatar.v3{ left:6px; top:0; }
+
+.dmGroupStack{
+  position:relative;
+  width:40px;
+  height:40px;
+}
+.dmGroupAvatar{
+  position:absolute;
+  width:20px;
+  height:20px;
+  border-radius:999px;
+  border:2px solid rgba(0,0,0,0.35);
+  box-sizing:border-box;
+}
+.dmGroupAvatar1{ left:0; top:0; }
+.dmGroupAvatar2{ right:0; top:0; }
+.dmGroupAvatar3{ left:0; bottom:0; }
+.dmGroupAvatar4{ right:0; bottom:0; }
 
 .dmTabs{
   display:flex;

--- a/server.js
+++ b/server.js
@@ -4852,6 +4852,16 @@ function normalizeDmPair(a, b) {
   return { low: Math.min(aId, bId), high: Math.max(aId, bId) };
 }
 
+function normalizeDmParticipants(ids = []) {
+  return Array.from(
+    new Set(
+      (ids || [])
+        .map((v) => Number(v))
+        .filter((n) => Number.isInteger(n) && n > 0)
+    )
+  ).sort((a, b) => a - b);
+}
+
 function ensureDmParticipants(threadId, userIds, addedBy, joinedAt, cb) {
   let pending = userIds.length;
   if (!pending) return cb && cb();
@@ -4867,45 +4877,113 @@ function ensureDmParticipants(threadId, userIds, addedBy, joinedAt, cb) {
   }
 }
 
-function getOrCreateDirectThread({ userA, userB, createdBy }, cb) {
-  const pair = normalizeDmPair(userA, userB);
-  if (!pair) return cb(new Error("invalid participants"));
+function resolveOrCreateThread({ participantIds, isGroup, title, createdBy }, cb) {
+  const ids = normalizeDmParticipants(participantIds);
   const now = Date.now();
 
+  if (!isGroup) {
+    if (ids.length !== 2) return cb(new Error("invalid participants"));
+    const pair = normalizeDmPair(ids[0], ids[1]);
+    if (!pair) return cb(new Error("invalid participants"));
+
+    const finish = (row, created) => {
+      ensureDmParticipants(row.id, [pair.low, pair.high], createdBy, now, () => {
+        cb(null, { id: row.id, created: !!created, user_low: pair.low, user_high: pair.high });
+      });
+    };
+
+    const lookup = () => {
+      db.get(
+        `SELECT id, user_low, user_high FROM dm_threads WHERE is_group=0 AND user_low=? AND user_high=?`,
+        [pair.low, pair.high],
+        (err, row) => {
+          if (row && row.id) {
+            if (!row.user_low || !row.user_high) {
+              db.run(`UPDATE dm_threads SET user_low=?, user_high=? WHERE id=?`, [pair.low, pair.high, row.id]);
+            }
+            return finish(row, false);
+          }
+
+          if (err) return cb(err);
+
+          // Fallback: legacy rows without user_low/user_high but with both participants.
+          db.get(
+            `SELECT t.id FROM dm_threads t
+               JOIN dm_participants p1 ON p1.thread_id=t.id AND p1.user_id=?
+               JOIN dm_participants p2 ON p2.thread_id=t.id AND p2.user_id=?
+             WHERE t.is_group=0
+             ORDER BY t.id DESC LIMIT 1`,
+            [pair.low, pair.high],
+            (legacyErr, legacyRow) => {
+              if (legacyRow && legacyRow.id) {
+                db.run(`UPDATE dm_threads SET user_low=?, user_high=? WHERE id=?`, [pair.low, pair.high, legacyRow.id]);
+                return finish({ ...legacyRow, user_low: pair.low, user_high: pair.high }, false);
+              }
+              if (legacyErr) return cb(legacyErr);
+              return insert();
+            }
+          );
+        }
+      );
+    };
+
+    const insert = () => {
+      db.run(
+        `INSERT INTO dm_threads (title, is_group, created_by, created_at, user_low, user_high) VALUES (?, 0, ?, ?, ?, ?)`,
+        [null, createdBy, now, pair.low, pair.high],
+        function (insertErr) {
+          if (insertErr) {
+            // Unique constraint race: try lookup again.
+            if (String(insertErr.message || "").toLowerCase().includes("unique")) return lookup();
+            return cb(insertErr);
+          }
+          console.log(`[dm:create] thread ${this.lastID} created for users ${pair.low}/${pair.high}`);
+          finish({ id: this.lastID, user_low: pair.low, user_high: pair.high }, true);
+        }
+      );
+    };
+
+    return lookup();
+  }
+
+  if (ids.length < 2) return cb(new Error("invalid participants"));
+  const participantsKey = ids.join(",");
+  const participantsJson = JSON.stringify(ids);
+
   const finish = (row, created) => {
-    ensureDmParticipants(row.id, [pair.low, pair.high], createdBy, now, () => {
-      cb(null, { id: row.id, created: !!created, user_low: pair.low, user_high: pair.high });
+    ensureDmParticipants(row.id, ids, createdBy, now, () => {
+      cb(null, { id: row.id, created: !!created, participants_key: participantsKey });
     });
   };
 
   const lookup = () => {
     db.get(
-      `SELECT id, user_low, user_high FROM dm_threads WHERE is_group=0 AND user_low=? AND user_high=?`,
-      [pair.low, pair.high],
+      `SELECT id FROM dm_threads WHERE is_group=1 AND participants_key=?`,
+      [participantsKey],
       (err, row) => {
-        if (row && row.id) {
-          if (!row.user_low || !row.user_high) {
-            db.run(`UPDATE dm_threads SET user_low=?, user_high=? WHERE id=?`, [pair.low, pair.high, row.id]);
-          }
-          return finish(row, false);
-        }
-
+        if (row && row.id) return finish(row, false);
         if (err) return cb(err);
 
-        // Fallback: legacy rows without user_low/user_high but with both participants.
+        const placeholders = ids.map(() => "?").join(",");
+        if (!placeholders) return insert();
         db.get(
           `SELECT t.id FROM dm_threads t
-             JOIN dm_participants p1 ON p1.thread_id=t.id AND p1.user_id=?
-             JOIN dm_participants p2 ON p2.thread_id=t.id AND p2.user_id=?
-           WHERE t.is_group=0
-           ORDER BY t.id DESC LIMIT 1`,
-          [pair.low, pair.high],
+             JOIN dm_participants dp ON dp.thread_id=t.id
+            WHERE t.is_group=1 AND dp.user_id IN (${placeholders})
+            GROUP BY t.id
+            HAVING COUNT(DISTINCT dp.user_id)=? AND (SELECT COUNT(*) FROM dm_participants WHERE thread_id=t.id)=?
+            ORDER BY t.id DESC LIMIT 1`,
+          [...ids, ids.length, ids.length],
           (legacyErr, legacyRow) => {
-            if (legacyRow && legacyRow.id) {
-              db.run(`UPDATE dm_threads SET user_low=?, user_high=? WHERE id=?`, [pair.low, pair.high, legacyRow.id]);
-              return finish({ ...legacyRow, user_low: pair.low, user_high: pair.high }, false);
-            }
             if (legacyErr) return cb(legacyErr);
+            if (legacyRow && legacyRow.id) {
+              db.run(
+                `UPDATE dm_threads SET participants_key=?, participants_json=? WHERE id=?`,
+                [participantsKey, participantsJson, legacyRow.id],
+                () => finish({ id: legacyRow.id }, false)
+              );
+              return;
+            }
             return insert();
           }
         );
@@ -4915,16 +4993,15 @@ function getOrCreateDirectThread({ userA, userB, createdBy }, cb) {
 
   const insert = () => {
     db.run(
-      `INSERT INTO dm_threads (title, is_group, created_by, created_at, user_low, user_high) VALUES (?, 0, ?, ?, ?, ?)`,
-      [null, createdBy, now, pair.low, pair.high],
+      `INSERT INTO dm_threads (title, is_group, created_by, created_at, participants_key, participants_json)
+       VALUES (?, 1, ?, ?, ?, ?)`,
+      [title || null, createdBy, now, participantsKey, participantsJson],
       function (insertErr) {
         if (insertErr) {
-          // Unique constraint race: try lookup again.
           if (String(insertErr.message || "").toLowerCase().includes("unique")) return lookup();
           return cb(insertErr);
         }
-        console.log(`[dm:create] thread ${this.lastID} created for users ${pair.low}/${pair.high}`);
-        finish({ id: this.lastID, user_low: pair.low, user_high: pair.high }, true);
+        finish({ id: this.lastID }, true);
       }
     );
   };
@@ -10324,7 +10401,6 @@ app.get("/api/dm/thread/:id", requireLogin, (req, res) => {
 
       const myId = req.session.user.id;
       const myName = req.session.user.username;
-      const now = Date.now();
 
       const usersById = await fetchUsersByIds(participantIds);
       if (usersById.length !== participantIds.length) {
@@ -10366,29 +10442,20 @@ app.get("/api/dm/thread/:id", requireLogin, (req, res) => {
         return res.json({ ok: true, threadId, reused, isGroup: isGroupThread, participants: allParticipantNames });
       };
 
-      if (!isGroup) {
-        const otherId = recipientIds[0];
-        return getOrCreateDirectThread({ userA: myId, userB: otherId, createdBy: myId }, (err3, info) => {
+      const threadParticipants = allParticipantIds;
+      return resolveOrCreateThread(
+        {
+          participantIds: threadParticipants,
+          isGroup,
+          title,
+          createdBy: myId,
+        },
+        (err3, info) => {
           if (err3) {
-            console.error("[dm:create] direct helper failed", err3);
+            console.error("[dm:create] resolve failed", err3);
             return res.status(500).send("Failed to create thread");
           }
-          notifyParticipants(info.id, !info.created, false, null);
-        });
-      }
-
-      db.run(
-        `INSERT INTO dm_threads (title, is_group, created_by, created_at) VALUES (?, ?, ?, ?)`,
-        [title || null, 1, myId, now],
-        function (insertErr) {
-          if (insertErr) {
-            console.error("[dm:create] failed to insert group", insertErr);
-            return res.status(500).send("Failed to create thread");
-          }
-          const threadId = this.lastID;
-          ensureDmParticipants(threadId, allParticipantIds, myId, now, () =>
-            notifyParticipants(threadId, false, true, title || null)
-          );
+          notifyParticipants(info.id, !info.created, isGroup, title || null);
         }
       );
     } catch (err) {


### PR DESCRIPTION
### Motivation
- Prevent duplicate DM threads and make thread creation deterministic for both 1-to-1 and group DMs. 
- Ensure DM / Group DM buttons open only the Inbox strip and that a conversation panel opens only after selecting a thread (with Members List DM still opening the conversation immediately). 
- Improve inbox rendering (empty state, unread counts, avatars, relative timestamps) and keep DM UI stable on mobile.

### Description
- Database: added `participants_key` and `participants_json` columns to `dm_threads` and created a unique index `idx_dm_threads_group_key` to enforce one group thread per participant set. 
- Server: introduced `normalizeDmParticipants` and `resolveOrCreateThread` which canonicalize participant ID lists, lookup existing direct/group threads, fallback to legacy participant scans, and avoid race duplicates by rechecking on unique constraint errors; replaced ad-hoc direct thread helper usage with `resolveOrCreateThread` in the `/dm/thread` creation flow. 
- Client (public/app.js): separated inbox vs conversation state with `showDmInbox` and updated `openDmPanel` behavior so DM and Group DM buttons open the inbox only; `openDmThread` still opens a conversation panel when a thread is selected; added `formatRelativeTime`, `getThreadUnreadCount`, improved sorting (unread first, then recent), avatar stack rendering for groups, updated empty text to `No conversations yet.`, and made the back button clear active thread without closing the inbox. 
- Styles: added stacked group-avatar CSS (`.dmGroupStack`, `.dmGroupAvatar*`) and refined translucent DM panel styling to remove double outline. 
- Kept changes narrowly scoped to DM-related DB, server, client, and CSS files to preserve other app behavior.

### Testing
- Started the server locally with `node server.js`; the process logged a Postgres init DNS error for the configured PG host but continued to run and reported `Server running on http://localhost:3000` (startup completed with DB warning). (succeeded with warning) 
- Ran an automated Playwright script that navigated to the running app, clicked the DM toggle, and captured a screenshot of the DM panel state (succeeded and produced a screenshot). 
- No unit test suite was modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ed9af00988333950d236a83d37139)