### PR TITLE
Fix stuck profile modal on boot and restore room modal markup

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -2684,6 +2684,22 @@ const AUDIO_UPLOAD_ALLOWED_MIME = new Set(["audio/mpeg", "audio/mp4"]);
 const AUDIO_UPLOAD_ALLOWED_EXT = new Set(["mp3", "m4a"]);
 
 let modalTargetUsername = null;
+const DEBUG_PROFILE_MODAL = false;
+let profileModalTraceEmitted = false;
+const logProfileModal = (...args) => {
+  if (!DEBUG_PROFILE_MODAL) return;
+  console.log("[profile-modal]", ...args);
+};
+const traceProfileModalOnce = (label) => {
+  if (!DEBUG_PROFILE_MODAL || profileModalTraceEmitted) return;
+  profileModalTraceEmitted = true;
+  console.trace(`[profile-modal] ${label}`);
+};
+const setModalTargetUsername = (username, source) => {
+  modalTargetUsername = username;
+  if (!DEBUG_PROFILE_MODAL) return;
+  console.log("[profile-modal] modalTargetUsername set", { username, source });
+};
 let modalTargetUserId = null;
 let pendingFile = null;
 let roomPendingAttachment = null;
@@ -11016,31 +11032,39 @@ tabActions?.addEventListener("click", async ()=>{
 function hardHideProfileModal(){
   try{
     if(!modal) return;
+    logProfileModal("hardHideProfileModal");
     modal.classList.remove("modal-visible");
     modal.classList.remove("modal-closing");
     modal.style.display="none";
   }catch{}
-  modalTargetUsername=null;
+  setModalTargetUsername(null, "hardHideProfileModal");
   modalTargetUserId=null;
 }
 // modal open/close
 function openModal(){
   if (!modal) return;
+  logProfileModal("openModal");
   modal.style.display="flex";
   modal.classList.remove("modal-closing");
+  logProfileModal("openModal display set", { display: modal.style.display });
   if (PREFERS_REDUCED_MOTION) {
     modal.classList.add("modal-visible");
+    logProfileModal("openModal visible (reduced motion)");
+    traceProfileModalOnce("modal visible (reduced motion)");
     return;
   }
   requestAnimationFrame(() => {
     modal.classList.add("modal-visible");
+    logProfileModal("openModal visible (animated)");
+    traceProfileModalOnce("modal visible (animated)");
   });
 }
 function closeModal(){
   if (!modal) return;
+  logProfileModal("closeModal");
   modal.classList.remove("modal-visible");
   modal.classList.add("modal-closing");
-  modalTargetUsername=null;
+  setModalTargetUsername(null, "closeModal");
   modalTargetUserId=null;
   setProfileEditMode(false);
   setCustomizePage(null);
@@ -16454,20 +16478,44 @@ async function toggleMemoryPin(memory){
   }
 }
 
+function notifyProfileOpenError(message){
+  const msg = message || "Could not load profile.";
+  if (typeof showToast === "function") {
+    showToast(msg);
+  } else {
+    toast?.(msg);
+  }
+}
+
 async function openMyProfile(){
+  logProfileModal("openMyProfile");
   closeDrawers();
   clearAvatarPreview();
 
   // Try the self profile endpoint first (includes edit fields)
-  let res = await fetch("/profile");
+  let res;
+  try {
+    res = await fetch("/profile");
+  } catch (err) {
+    console.error("Failed to load profile", err);
+    notifyProfileOpenError("Could not load your profile.");
+    hardHideProfileModal();
+    return false;
+  }
   if (!res.ok && me?.username){
     // Fallback to member profile route if /profile fails for any reason
-    try { await openMemberProfile(me.username); return; } catch {}
+    const opened = await openMemberProfile(me.username);
+    if (opened) return true;
   }
-  if(!res.ok){ hardHideProfileModal(); return; }
+  if(!res.ok){
+    const t = await res.text().catch(()=> "");
+    notifyProfileOpenError(t || "Could not load your profile.");
+    hardHideProfileModal();
+    return false;
+  }
   const p = await res.json();
   updateRoleCache(p.username, p.role);
-  modalTargetUsername = p.username;
+  setModalTargetUsername(p.username, "openMyProfile");
   applyProgressionPayload(p);
 
   modalTitle.textContent="My Profile";
@@ -16507,6 +16555,7 @@ async function openMyProfile(){
   updateProfileActions({ isSelf: true, canModerate: canMod });
   setTab("profile");
   openModal();
+  return true;
 }
 profileBtn?.addEventListener("click", openMyProfile);
 
@@ -16592,12 +16641,33 @@ memoryEnabledToggle?.addEventListener("change", async () => {
 });
 
 async function openMemberProfile(username){
-  modalTargetUsername = username;
+  const cleanUsername = String(username || "").trim();
+  logProfileModal("openMemberProfile", cleanUsername);
+  if (!cleanUsername) {
+    notifyProfileOpenError("Profile not found.");
+    hardHideProfileModal();
+    return false;
+  }
+  setModalTargetUsername(cleanUsername, "openMemberProfile");
   closeDrawers();
 
-  const res=await fetch("/profile/" + encodeURIComponent(username));
-  if(!res.ok){ hardHideProfileModal(); return; }
+  let res;
+  try {
+    res = await fetch("/profile/" + encodeURIComponent(cleanUsername));
+  } catch (err) {
+    console.error("Failed to load member profile", err);
+    notifyProfileOpenError("Could not load profile.");
+    hardHideProfileModal();
+    return false;
+  }
+  if(!res.ok){
+    const t = await res.text().catch(()=> "");
+    notifyProfileOpenError(t || "Profile not found.");
+    hardHideProfileModal();
+    return false;
+  }
   const p=await res.json();
+  setModalTargetUsername(p.username || cleanUsername, "openMemberProfile:resolved");
   modalTargetUserId = Number(p?.id) || null;
   const isSelf = isSelfProfile(p);
   if (isSelf) applyProgressionPayload(p);
@@ -16641,6 +16711,7 @@ async function openMemberProfile(username){
   setCustomizePage(null);
   setTab("profile");
   openModal();
+  return true;
 }
 
 let likeToggleInFlight = false;
@@ -17907,10 +17978,15 @@ socket.on("dm history", (payload = {}) => {
   // hash profile links (clear hash after handling to avoid "stuck" profile overlays on reload)
   const handleProfileHash = async () => {
     if(location.hash.startsWith("#profile:")){
-      const u = decodeURIComponent(location.hash.slice("#profile:".length));
-      if(u){
-        try{ await openMemberProfile(u); }catch{ hardHideProfileModal(); }
-      }else{
+      const raw = decodeURIComponent(location.hash.slice("#profile:".length));
+      const u = raw.trim();
+      if(!u){
+        hardHideProfileModal();
+        try{ history.replaceState(null, "", location.pathname + location.search); }catch{}
+        return;
+      }
+      const opened = await openMemberProfile(u);
+      if (!opened) {
         hardHideProfileModal();
       }
       try{ history.replaceState(null, "", location.pathname + location.search); }catch{}
@@ -17918,6 +17994,10 @@ socket.on("dm history", (payload = {}) => {
   };
   handleProfileHash();
   window.addEventListener("hashchange", ()=>{ handleProfileHash(); });
+  if (modal?.classList.contains("modal-visible") && !modalTargetUsername) {
+    logProfileModal("initChatApp cleanup: modal visible without target");
+    hardHideProfileModal();
+  }
 
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -758,116 +758,8 @@
 </button>
 </div>
 </div>
-
-
-
-<div class="roomManageList" id="roomMasterList"></div>
-</div>
-<div class="roomManageSection" data-room-manage-section="categories">
-<div class="field">
-<label for="roomCategoryMasterSelect">Master</label>
-<select id="roomCategoryMasterSelect"></select>
-</div>
-<div class="field">
-<label for="roomCategoryCreateInput">New subcategory</label>
-<div class="row" style="gap:8px; flex-wrap:wrap;">
-<input id="roomCategoryCreateInput" maxlength="40" placeholder="Subcategory name"/>
-<button class="btn" id="roomCategoryCreateBtn" type="button">Create</button>
-</div>
-<div class="msgline" id="roomCategoryMsg"></div>
-</div>
-<div class="roomManageList" id="roomCategoryList"></div>
-</div>
-<div class="roomManageSection" data-room-manage-section="rooms">
-<div class="field">
-<label for="roomManageMasterSelect">Master</label>
-<select id="roomManageMasterSelect"></select>
-</div>
-<div class="field">
-<label for="roomManageCategorySelect">Subcategory</label>
-<select id="roomManageCategorySelect"></select>
-</div>
-<div class="roomManageList" id="roomManageRoomList"></div>
-<div class="msgline" id="roomManageMsg"></div>
-</div>
-<div class="roomManageSection" data-room-manage-section="create" id="roomManageTab_create">
-  <form id="roomCreateForm">
-    <div class="field">
-      <label for="roomCreateName">Room name</label>
-      <input id="roomCreateName" maxlength="24" placeholder="room-name"/>
-    </div>
-    <div class="field">
-      <label for="roomCreateMaster">Master group</label>
-      <select id="roomCreateMaster"></select>
-    </div>
-    <div class="field">
-      <label for="roomCreateCategory">Subcategory</label>
-      <select id="roomCreateCategory"></select>
-    </div>
-
-    <div class="roomManageSettingsGrid" data-admin-only>
-      <label class="chk"><input type="checkbox" id="roomCreateVipOnly"> VIP only</label>
-      <label class="chk"><input type="checkbox" id="roomCreateStaffOnly"> Staff only</label>
-      <label class="chk"><input type="checkbox" id="roomCreateLocked"> Locked</label>
-      <label class="chk"><input type="checkbox" id="roomCreateMaintenance"> Maintenance</label>
-      <label class="chk"><input type="checkbox" id="roomCreateEventsEnabled" checked> Events enabled</label>
-      <label class="mini">Min level <input type="number" id="roomCreateMinLevel" min="0" max="999" value="0"></label>
-    </div>
-
-    <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
-      <button class="btn" type="submit">Create</button>
-    </div>
-  </form>
-</div>
-
-<div class="roomManageSection" data-room-manage-section="events" id="roomManageTab_events">
-  <div class="field">
-    <label for="roomEventsRoomSelect">Room</label>
-    <select id="roomEventsRoomSelect"></select>
-  </div>
-  <div class="field">
-    <label for="roomEventsType">Event type</label>
-    <select id="roomEventsType">
-      <option value="announcement">Announcement</option>
-      <option value="prompt">Prompt</option>
-      <option value="boost">XP Boost</option>
-    </select>
-  </div>
-  <div class="field">
-    <label for="roomEventsText">Text</label>
-    <textarea id="roomEventsText" rows="3" placeholder="What should appear as a system message?"></textarea>
-  </div>
-  <div class="row" style="gap:8px; flex-wrap:wrap;">
-    <div class="field" style="flex:1; min-width:160px;">
-      <label for="roomEventsDuration">Duration (seconds, 0 = no end)</label>
-      <input id="roomEventsDuration" type="number" min="0" max="86400" value="600"/>
-    </div>
-    <div class="field" style="flex:1; min-width:160px;">
-      <label for="roomEventsXpMult">XP multiplier (boost only)</label>
-      <input id="roomEventsXpMult" type="number" min="1" max="10" value="2"/>
-    </div>
-  </div>
-  <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
-    <button class="btn" id="roomEventsStartBtn" type="button">Start event</button>
-  </div>
-
-  <div class="roomEventsActive">
-    <div class="muted" style="margin:10px 0 6px;">Active events</div>
-    <div id="roomEventsActiveList" class="roomEventsList"></div>
-  </div>
-</div>
-</div>
-</div>
-</div>
-</div
-
-
-
-</div>
-</div>
 </div>
 <span aria-hidden="true" class="profilePresenceDot" id="profilePresenceDot"></span>
-</div>
 <div class="profileSheetMeta">
 <span class="srOnly" id="modalTitle">Profile</span>
 <div class="profileSheetNameRow">
@@ -2415,52 +2307,152 @@
 
 <!-- ROOM MANAGEMENT MODALS (moved out of profile modal to prevent stuck overlay) -->
 <div id="roomManageModal" class="roomModal" hidden="">
-<div class="modalCard roomModalCard">
-<div class="modalTop">
-<strong>Manage Rooms</strong>
-<button class="iconBtn smallIcon" id="roomManageCloseBtn" title="Close" type="button">✕</button>
-</div>
-<div class="modalBody roomModalBody">
-<div class="tabs roomManageTabs">
-<button class="tab active" data-room-manage-tab="masters" type="button">Masters</button>
-<button class="tab" data-room-manage-tab="categories" type="button">Subcategories</button>
-<button class="tab" data-room-manage-tab="rooms" type="button">Rooms</button>
-<button class="tab" data-room-manage-tab="create" type="button">Create</button>
-<button class="tab" data-room-manage-tab="events" type="button">Room Events</button>
-</div>
-<div class="roomManageSection active" data-room-manage-section="masters">
-<div class="field">
-<label for="roomMasterCreateInput">New master</label>
-<div class="row" style="gap:8px; flex-wrap:wrap;">
-<input id="roomMasterCreateInput" maxlength="40" placeholder="Master name"/>
-<button class="btn" id="roomMasterCreateBtn" type="button">Create</button>
-</div>
-<div class="msgline" id="roomMasterMsg"></div>
+  <div class="modalCard roomModalCard">
+    <div class="modalTop">
+      <strong>Manage Rooms</strong>
+      <button class="iconBtn smallIcon" id="roomManageCloseBtn" title="Close" type="button">✕</button>
+    </div>
+    <div class="modalBody roomModalBody">
+      <div class="tabs roomManageTabs">
+        <button class="tab active" data-room-manage-tab="masters" type="button">Masters</button>
+        <button class="tab" data-room-manage-tab="categories" type="button">Subcategories</button>
+        <button class="tab" data-room-manage-tab="rooms" type="button">Rooms</button>
+        <button class="tab" data-room-manage-tab="create" type="button">Create</button>
+        <button class="tab" data-room-manage-tab="events" type="button">Room Events</button>
+      </div>
+      <div class="roomManageSection active" data-room-manage-section="masters">
+        <div class="field">
+          <label for="roomMasterCreateInput">New master</label>
+          <div class="row" style="gap:8px; flex-wrap:wrap;">
+            <input id="roomMasterCreateInput" maxlength="40" placeholder="Master name"/>
+            <button class="btn" id="roomMasterCreateBtn" type="button">Create</button>
+          </div>
+          <div class="msgline" id="roomMasterMsg"></div>
+        </div>
+        <div class="roomManageList" id="roomMasterList"></div>
+      </div>
+      <div class="roomManageSection" data-room-manage-section="categories">
+        <div class="field">
+          <label for="roomCategoryMasterSelect">Master</label>
+          <select id="roomCategoryMasterSelect"></select>
+        </div>
+        <div class="field">
+          <label for="roomCategoryCreateInput">New subcategory</label>
+          <div class="row" style="gap:8px; flex-wrap:wrap;">
+            <input id="roomCategoryCreateInput" maxlength="40" placeholder="Subcategory name"/>
+            <button class="btn" id="roomCategoryCreateBtn" type="button">Create</button>
+          </div>
+          <div class="msgline" id="roomCategoryMsg"></div>
+        </div>
+        <div class="roomManageList" id="roomCategoryList"></div>
+      </div>
+      <div class="roomManageSection" data-room-manage-section="rooms">
+        <div class="field">
+          <label for="roomManageMasterSelect">Master</label>
+          <select id="roomManageMasterSelect"></select>
+        </div>
+        <div class="field">
+          <label for="roomManageCategorySelect">Subcategory</label>
+          <select id="roomManageCategorySelect"></select>
+        </div>
+        <div class="roomManageList" id="roomManageRoomList"></div>
+        <div class="msgline" id="roomManageMsg"></div>
+      </div>
+      <div class="roomManageSection" data-room-manage-section="create" id="roomManageTab_create">
+        <form id="roomCreateForm">
+          <div class="field">
+            <label for="roomCreateName">Room name</label>
+            <input id="roomCreateName" maxlength="24" placeholder="room-name"/>
+          </div>
+          <div class="field">
+            <label for="roomCreateMaster">Master group</label>
+            <select id="roomCreateMaster"></select>
+          </div>
+          <div class="field">
+            <label for="roomCreateCategory">Subcategory</label>
+            <select id="roomCreateCategory"></select>
+          </div>
+
+          <div class="roomManageSettingsGrid" data-admin-only>
+            <label class="chk"><input type="checkbox" id="roomCreateVipOnly"> VIP only</label>
+            <label class="chk"><input type="checkbox" id="roomCreateStaffOnly"> Staff only</label>
+            <label class="chk"><input type="checkbox" id="roomCreateLocked"> Locked</label>
+            <label class="chk"><input type="checkbox" id="roomCreateMaintenance"> Maintenance</label>
+            <label class="chk"><input type="checkbox" id="roomCreateEventsEnabled" checked> Events enabled</label>
+            <label class="mini">Min level <input type="number" id="roomCreateMinLevel" min="0" max="999" value="0"></label>
+          </div>
+
+          <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
+            <button class="btn" type="submit">Create</button>
+          </div>
+        </form>
+      </div>
+      <div class="roomManageSection" data-room-manage-section="events" id="roomManageTab_events">
+        <div class="field">
+          <label for="roomEventsRoomSelect">Room</label>
+          <select id="roomEventsRoomSelect"></select>
+        </div>
+        <div class="field">
+          <label for="roomEventsType">Event type</label>
+          <select id="roomEventsType">
+            <option value="announcement">Announcement</option>
+            <option value="prompt">Prompt</option>
+            <option value="boost">XP Boost</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="roomEventsText">Text</label>
+          <textarea id="roomEventsText" rows="3" placeholder="What should appear as a system message?"></textarea>
+        </div>
+        <div class="row" style="gap:8px; flex-wrap:wrap;">
+          <div class="field" style="flex:1; min-width:160px;">
+            <label for="roomEventsDuration">Duration (seconds, 0 = no end)</label>
+            <input id="roomEventsDuration" type="number" min="0" max="86400" value="600"/>
+          </div>
+          <div class="field" style="flex:1; min-width:160px;">
+            <label for="roomEventsXpMult">XP multiplier (boost only)</label>
+            <input id="roomEventsXpMult" type="number" min="1" max="10" value="2"/>
+          </div>
+        </div>
+        <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
+          <button class="btn" id="roomEventsStartBtn" type="button">Start event</button>
+        </div>
+
+        <div class="roomEventsActive">
+          <div class="muted" style="margin:10px 0 6px;">Active events</div>
+          <div id="roomEventsActiveList" class="roomEventsList"></div>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div id="roomCreateModal" class="roomModal" hidden="">
-<div class="modalCard roomModalCard">
-<div class="modalTop">
-<strong>Create Room</strong>
-<button class="iconBtn smallIcon" id="roomCreateCloseBtn" title="Close" type="button">✕</button>
-</div>
-<div class="modalBody roomModalBody">
-<div class="field">
-<label for="roomCreateNameInput">Room name</label>
-<input id="roomCreateNameInput" maxlength="24" placeholder="room-name"/>
-</div>
-<div class="field">
-<label for="roomCreateMasterSelect">Master group</label>
-<select id="roomCreateMasterSelect"></select>
-</div>
-<div class="field">
-<label for="roomCreateCategorySelect">Subcategory</label>
-<select id="roomCreateCategorySelect"></select>
-</div>
-<div class="row" style="gap:8px; flex-wrap:wrap;">
-<button class="btn" id="roomCreateSubmitBtn" type="button">Create</button>
-<button class="btn secondary" id="roomCreateCancelBtn" type="button">Cancel</button>
-<div class="msgline" id="roomCreateMsg"></div>
+  <div class="modalCard roomModalCard">
+    <div class="modalTop">
+      <strong>Create Room</strong>
+      <button class="iconBtn smallIcon" id="roomCreateCloseBtn" title="Close" type="button">✕</button>
+    </div>
+    <div class="modalBody roomModalBody">
+      <div class="field">
+        <label for="roomCreateNameInput">Room name</label>
+        <input id="roomCreateNameInput" maxlength="24" placeholder="room-name"/>
+      </div>
+      <div class="field">
+        <label for="roomCreateMasterSelect">Master group</label>
+        <select id="roomCreateMasterSelect"></select>
+      </div>
+      <div class="field">
+        <label for="roomCreateCategorySelect">Subcategory</label>
+        <select id="roomCreateCategorySelect"></select>
+      </div>
+      <div class="row" style="gap:8px; flex-wrap:wrap;">
+        <button class="btn" id="roomCreateSubmitBtn" type="button">Create</button>
+        <button class="btn secondary" id="roomCreateCancelBtn" type="button">Cancel</button>
+        <div class="msgline" id="roomCreateMsg"></div>
+      </div>
+    </div>
+  </div>
 </div>
 
 </body>


### PR DESCRIPTION
### Motivation

- Remove a persistent, empty "Profile" overlay that was appearing on load and blocking the chat UI, and fix a client JS issue that broke login/boot flow.
- Ensure profile modals only open from explicit actions or valid deep-links and that failed profile fetches do not leave the UI blocked.
- Prevent DOM nesting of room management UI inside the profile modal which can cause overlay stacking issues.

### Description

- Repaired profile modal and room management markup by restoring `roomManageModal`/`roomCreateModal` as standalone overlays outside the main `#modal` profile container in `public/index.html` so room modals no longer depend on the profile DOM tree.
- Added guarded debug helpers (`DEBUG_PROFILE_MODAL = false`, `logProfileModal`, `traceProfileModalOnce`) and a small `setModalTargetUsername` wrapper to centralize state updates for `modalTargetUsername` in `public/app.js` without changing runtime behavior when the flag is off.
- Hardened profile open/close logic by adding safe `fetch` try/catch paths and explicit failure handling in `openMyProfile` and `openMemberProfile` so a failed request calls `hardHideProfileModal()` and shows a non-blocking toast via `showToast`/`toast` instead of leaving an empty modal visible.
- Improved deep-link handling by parsing and validating `#profile:<user>` hash usage, only opening the modal when a valid profile is resolved, clearing the hash with `history.replaceState`, and adding a startup fail-safe that cleans up a visible modal with no valid `modalTargetUsername`.

### Testing

- Ran `node --check public/app.js` which passed with no syntax errors.
- Ran `node --check server.js` which passed with no syntax errors.
- Produced a ZIP of changed files at `changes.zip` containing the modified `public/app.js` and `public/index.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972c9f818f883339e37234bf513e12b)