### PR TITLE
Restore core rooms and add room management + room-scoped events (safe, gated)

### DIFF
--- a/database.js
+++ b/database.js
@@ -188,6 +188,11 @@ async function runSqliteMigrations() {
     ["is_locked", "is_locked INTEGER NOT NULL DEFAULT 0"],
     ["pinned_message_ids", "pinned_message_ids TEXT"],
     ["maintenance_mode", "maintenance_mode INTEGER NOT NULL DEFAULT 0"],
+    ["vip_only", "vip_only INTEGER NOT NULL DEFAULT 0"],
+    ["staff_only", "staff_only INTEGER NOT NULL DEFAULT 0"],
+    ["min_level", "min_level INTEGER NOT NULL DEFAULT 0"],
+    ["events_enabled", "events_enabled INTEGER NOT NULL DEFAULT 1"],
+    ["archived", "archived INTEGER NOT NULL DEFAULT 0"],
   ]);
 
   await ensureRoomHierarchySqlite();

--- a/public/app.js
+++ b/public/app.js
@@ -860,6 +860,7 @@ let roomCollapseState = { master: {}, category: {} };
 const memoryCacheByFilter = new Map();
 const DICE_ROOM_ID = "diceroom";
 const SURVIVAL_ROOM_ID = "survivalsimulator";
+const CORE_ROOMS = new Set(["main", "music", "nsfw", "diceroom", "survivalsimulator"]);
 function isDiceRoom(activeRoom){
   const roomName = typeof activeRoom === "string"
     ? activeRoom
@@ -2793,6 +2794,7 @@ const appealsUnlockBtn = document.getElementById("appealsUnlockBtn");
 const app = document.getElementById("app");
 const addRoomBtn = document.getElementById("addRoomBtn");
 const manageRoomsBtn = document.getElementById("manageRoomsBtn");
+const roomActionsMenu = document.getElementById("roomActionsMenu");
 const menuToggleBtn = document.getElementById("menuToggleBtn");
 const chanHeaderTitle = document.getElementById("chanHeaderTitle");
 const roomsPanel = document.getElementById("roomsPanel");
@@ -2819,8 +2821,20 @@ const roomCategoryList = document.getElementById("roomCategoryList");
 const roomCategoryMsg = document.getElementById("roomCategoryMsg");
 const roomManageMasterSelect = document.getElementById("roomManageMasterSelect");
 const roomManageCategorySelect = document.getElementById("roomManageCategorySelect");
+const roomManageShowArchived = document.getElementById("roomManageShowArchived");
 const roomManageRoomList = document.getElementById("roomManageRoomList");
 const roomManageMsg = document.getElementById("roomManageMsg");
+const roomManageCreateForm = document.getElementById("roomCreateForm");
+const roomManageCreateNameInput = document.getElementById("roomCreateName");
+const roomManageCreateMasterSelect = document.getElementById("roomCreateMaster");
+const roomManageCreateCategorySelect = document.getElementById("roomCreateCategory");
+const roomManageCreateVipOnly = document.getElementById("roomCreateVipOnly");
+const roomManageCreateStaffOnly = document.getElementById("roomCreateStaffOnly");
+const roomManageCreateLocked = document.getElementById("roomCreateLocked");
+const roomManageCreateMaintenance = document.getElementById("roomCreateMaintenance");
+const roomManageCreateEventsEnabled = document.getElementById("roomCreateEventsEnabled");
+const roomManageCreateMinLevel = document.getElementById("roomCreateMinLevel");
+const roomManageCreateMsg = document.getElementById("roomManageCreateMsg");
 const roomCreateModal = document.getElementById("roomCreateModal");
 const roomCreateCloseBtn = document.getElementById("roomCreateCloseBtn");
 const roomCreateNameInput = document.getElementById("roomCreateNameInput");
@@ -2829,6 +2843,13 @@ const roomCreateCategorySelect = document.getElementById("roomCreateCategorySele
 const roomCreateSubmitBtn = document.getElementById("roomCreateSubmitBtn");
 const roomCreateCancelBtn = document.getElementById("roomCreateCancelBtn");
 const roomCreateMsg = document.getElementById("roomCreateMsg");
+const roomEventsRoomSelect = document.getElementById("roomEventsRoomSelect");
+const roomEventsType = document.getElementById("roomEventsType");
+const roomEventsText = document.getElementById("roomEventsText");
+const roomEventsDuration = document.getElementById("roomEventsDuration");
+const roomEventsStartBtn = document.getElementById("roomEventsStartBtn");
+const roomEventsActiveList = document.getElementById("roomEventsActiveList");
+const roomEventsMsg = document.getElementById("roomEventsMsg");
 
 // Shared date formatter for Changelog + FAQ.
 // IMPORTANT: keep this at top-level so it is in scope everywhere.
@@ -11167,6 +11188,9 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && couplesModal && couplesModal.style.display !== "none") {
     closeCouplesModal();
   }
+  if (e.key === "Escape" && roomActionsMenu && !roomActionsMenu.hidden) {
+    closeRoomActionsMenu();
+  }
   if (e.key === "Escape" && roomManageModal && roomManageModal.style.display !== "none") {
     closeRoomManageModal();
   }
@@ -11257,6 +11281,7 @@ function setActiveRoom(room){
   const wasDiceRoom = isDiceRoom(currentRoom);
   const wasSurvivalRoom = isSurvivalRoom(currentRoom);
   currentRoom = room;
+  setRoomEvent(null);
   const nowDiceRoom = isDiceRoom(room);
   const nowSurvivalRoom = isSurvivalRoom(room);
   document.body.classList.toggle("dice-room", nowDiceRoom);
@@ -11327,28 +11352,35 @@ let roomEventTimer = null;
 
 function updateRoomEventBanner(){
   if(!roomEventBanner) return;
-  if(!getFeatureFlag("roomEvents", true) || !activeRoomEvent || !activeRoomEvent.endsAt){
+  if(!getFeatureFlag("roomEvents", true) || !activeRoomEvent){
     roomEventBanner.hidden = true;
     roomEventBanner.innerHTML = "";
     if(roomEventTimer){ clearInterval(roomEventTimer); roomEventTimer=null; }
     return;
   }
   roomEventBanner.hidden = false;
-  const leftMs = Math.max(0, Number(activeRoomEvent.endsAt) - Date.now());
-  const leftSec = Math.ceil(leftMs/1000);
+  const hasEnds = activeRoomEvent.endsAt && Number.isFinite(Number(activeRoomEvent.endsAt));
+  const leftMs = hasEnds ? Math.max(0, Number(activeRoomEvent.endsAt) - Date.now()) : 0;
+  if(hasEnds && leftMs <= 0){
+    setRoomEvent(null);
+    return;
+  }
+  const leftSec = hasEnds ? Math.ceil(leftMs/1000) : 0;
   const mm = Math.floor(leftSec/60);
   const ss = String(leftSec%60).padStart(2,"0");
   roomEventBanner.innerHTML = `
     <div class="meta">
       <span class="tag">${escapeHtml(String(activeRoomEvent.type||"event"))}</span>
       <span>${escapeHtml(String(activeRoomEvent.title||"Room Event"))}</span>
-      <span class="count">• ${mm}:${ss}</span>
+      ${hasEnds ? `<span class="count">• ${mm}:${ss}</span>` : ""}
     </div>
   `;
 }
 
 function setRoomEvent(ev){
   activeRoomEvent = ev || null;
+  const isFlair = activeRoomEvent && String(activeRoomEvent.type || "") === "flair";
+  document.body.classList.toggle("event-active", Boolean(isFlair));
   updateRoomEventBanner();
   if(roomEventTimer){ clearInterval(roomEventTimer); roomEventTimer=null; }
   if(activeRoomEvent && activeRoomEvent.endsAt){
@@ -11437,6 +11469,8 @@ function setRoomStructure(payload, { updateCollapse = true } = {}){
   renderRoomsList(roomStructure);
   if(roomManageModal && roomManageModal.style.display !== "none" && !roomManageModal.hidden){
     refreshRoomManageUi();
+    const activeTab = document.querySelector("[data-room-manage-tab].active")?.dataset?.roomManageTab;
+    if(activeTab === "events") refreshRoomEventsUi();
   }
   return true;
 }
@@ -11490,7 +11524,7 @@ function renderRoomsList(structureOrRooms){
   const payload = normalizeRoomStructurePayload(structureOrRooms) || { masters: [], categories: [], rooms: [] };
   const masters = ensureDefaultMasters(payload.masters || []);
   const categories = payload.categories || [];
-  const rooms = payload.rooms || [];
+  const rooms = (payload.rooms || []).filter((room) => !room?.archived);
   const categoriesByMaster = new Map();
   const categoryById = new Map();
   for(const cat of categories){
@@ -11689,6 +11723,46 @@ async function submitCreateRoom(){
   joinRoom(name);
 }
 
+async function submitRoomManageCreate(e){
+  e?.preventDefault?.();
+  if(roomManageCreateMsg) roomManageCreateMsg.textContent = "";
+  const raw = String(roomManageCreateNameInput?.value || "");
+  const name = sanitizeRoomClient(raw);
+  if(!name){
+    if(roomManageCreateMsg) roomManageCreateMsg.textContent = "Invalid room name.";
+    return;
+  }
+  const masterId = roomManageCreateMasterSelect?.value || "";
+  const categoryId = roomManageCreateCategorySelect?.value || "";
+  const vipOnly = roomManageCreateVipOnly?.checked ? 1 : 0;
+  const staffOnly = roomManageCreateStaffOnly?.checked ? 1 : 0;
+  const minLevel = vipOnly ? Math.max(0, Math.min(999, Number(roomManageCreateMinLevel?.value || 0))) : 0;
+  const payload = {
+    name,
+    vip_only: vipOnly,
+    staff_only: staffOnly,
+    min_level: minLevel,
+    is_locked: roomManageCreateLocked?.checked ? 1 : 0,
+    maintenance_mode: roomManageCreateMaintenance?.checked ? 1 : 0,
+    events_enabled: roomManageCreateEventsEnabled?.checked ? 1 : 0,
+  };
+  if(categoryId) payload.category_id = Number(categoryId) || categoryId;
+  if(masterId) payload.master_id = Number(masterId) || masterId;
+
+  const {res, text} = await api("/rooms", {
+    method:"POST",
+    headers: {"Content-Type":"application/json"},
+    body: JSON.stringify(payload),
+  });
+  if(!res.ok){
+    if(roomManageCreateMsg) roomManageCreateMsg.textContent = text || "Failed to create room.";
+    return;
+  }
+  if(roomManageCreateNameInput) roomManageCreateNameInput.value = "";
+  await loadRooms();
+  joinRoom(name);
+}
+
 async function createRoomFlow(){
   if(roomCreateModal){
     openRoomCreateModal();
@@ -11730,9 +11804,10 @@ function getSortedCategories(masterId, { includeTemporary = true } = {}){
   return list.filter((c) => !c.temporary && !String(c.id || "").startsWith("temp-"));
 }
 
-function getSortedRoomsForCategory(categoryId){
+function getSortedRoomsForCategory(categoryId, { includeArchived = true } = {}){
   const rooms = (roomStructure.rooms || []).filter((r) => String(r.category_id) === String(categoryId));
-  return [...rooms].sort((a, b) => sortByOrderThenName(a, b, "room_sort_order"));
+  const filtered = includeArchived ? rooms : rooms.filter((r) => Number(r.archived || 0) !== 1);
+  return [...filtered].sort((a, b) => sortByOrderThenName(a, b, "room_sort_order"));
 }
 
 function populateSelect(el, options, selectedValue){
@@ -11747,22 +11822,28 @@ function populateSelect(el, options, selectedValue){
   }
 }
 
-function populateRoomCreateSelects(){
+function populateRoomCreateSelectsFor(masterSelect, categorySelect){
+  if(!masterSelect || !categorySelect) return;
   const masters = getSortedMasters();
   const defaultMaster = masters.find((m) => m.name === "Site Rooms") || masters[0];
-  const masterId = roomCreateMasterSelect?.value || defaultMaster?.id || "";
+  const masterId = masterSelect.value || defaultMaster?.id || "";
   populateSelect(
-    roomCreateMasterSelect,
+    masterSelect,
     masters.map((m) => ({ value: m.id, label: m.name })),
     masterId
   );
   const categories = masterId ? getSortedCategories(masterId) : [];
   const defaultCategory = categories.find((c) => c.name === "Uncategorized") || categories[0];
   populateSelect(
-    roomCreateCategorySelect,
+    categorySelect,
     categories.map((c) => ({ value: c.id, label: c.name })),
     defaultCategory?.id || ""
   );
+}
+
+function populateRoomCreateSelects(){
+  populateRoomCreateSelectsFor(roomCreateMasterSelect, roomCreateCategorySelect);
+  populateRoomCreateSelectsFor(roomManageCreateMasterSelect, roomManageCreateCategorySelect);
 }
 
 function populateManageMasterSelects(){
@@ -11924,8 +12005,9 @@ function renderRoomManageRoomsList(){
   if(!roomManageRoomList) return;
   const masterId = roomManageMasterSelect?.value || "";
   const categoryId = roomManageCategorySelect?.value || "";
+  const showArchived = roomManageShowArchived?.checked;
   const categories = masterId ? getSortedCategories(masterId) : [];
-  const rooms = categoryId ? getSortedRoomsForCategory(categoryId) : [];
+  const rooms = categoryId ? getSortedRoomsForCategory(categoryId, { includeArchived: Boolean(showArchived) }) : [];
   const masterOptions = getSortedMasters().map((m) => ({
     master: m,
     categories: getSortedCategories(m.id),
@@ -11936,34 +12018,61 @@ function renderRoomManageRoomsList(){
       label: `${entry.master.name} / ${c.name}`,
     })));
   roomManageRoomList.innerHTML = "";
+  const isOwner = roleRank(me?.role || "User") >= roleRank("Owner");
   for(const room of rooms){
+    const isArchived = Number(room?.archived || 0) === 1;
+    const isCore = CORE_ROOMS.has(String(room?.name || ""));
+    const isProtected = isCore && !isOwner;
     const row = document.createElement("div");
     row.className = "roomManageRow";
     const optionsMarkup = moveOptions.map((opt) => `<option value="${opt.value}">${escapeHtml(opt.label)}</option>`).join("");
     row.innerHTML = `
-      <div class="label">${escapeHtml(displayRoomName(room.name))}</div>
+      <div class="label">${escapeHtml(displayRoomName(room.name))} ${isArchived ? "<span class='tag'>Archived</span>" : ""}</div>
       <select class="roomManageMoveSelect">${optionsMarkup}</select>
       <div class="actions">
+        <button class="btn secondary" data-action="rename">Rename</button>
         <button class="btn secondary" data-action="up">Up</button>
         <button class="btn secondary" data-action="down">Down</button>
         <button class="btn secondary" data-action="move">Move</button>
+        <button class="btn ${isArchived ? "secondary" : "danger"}" data-action="${isArchived ? "restore" : "archive"}">${isArchived ? "Restore" : "Archive"}</button>
       </div>
     `;
     const moveSelect = row.querySelector(".roomManageMoveSelect");
     if(moveSelect) moveSelect.value = categoryId;
+    if(isProtected){
+      row.querySelectorAll("[data-action='rename'], [data-action='archive'], [data-action='restore']").forEach((btn) => { btn.disabled = true; });
+    }
     const actions = row.querySelector(".actions");
     actions?.addEventListener("click", async (e) => {
       const btn = e.target.closest("button");
       if(!btn) return;
       const action = btn.dataset.action;
+      if(roomManageMsg) roomManageMsg.textContent = "";
+      if(action === "rename"){
+        const next = prompt("Rename room:", room.name);
+        if(!next) return;
+        const {res, text} = await api(`/api/rooms/${encodeURIComponent(room.name)}`, {
+          method:"PATCH",
+          headers: { "Content-Type":"application/json" },
+          body: JSON.stringify({ name: next }),
+        });
+        if(!res.ok){
+          if(roomManageMsg) roomManageMsg.textContent = text || "Failed to rename room.";
+          return;
+        }
+      }
       if(action === "move"){
         const target = moveSelect?.value || "";
         if(!target || target === String(categoryId)) return;
-        await api(`/api/rooms/${encodeURIComponent(room.name)}/move`, {
+        const {res, text} = await api(`/api/rooms/${encodeURIComponent(room.name)}/move`, {
           method:"PATCH",
           headers: { "Content-Type":"application/json" },
           body: JSON.stringify({ category_id: Number(target) || target })
         });
+        if(!res.ok){
+          if(roomManageMsg) roomManageMsg.textContent = text || "Failed to move room.";
+          return;
+        }
       }
       if(action === "up" || action === "down"){
         const index = rooms.findIndex((r) => r.name === room.name);
@@ -11971,11 +12080,30 @@ function renderRoomManageRoomsList(){
         if(swapWith < 0 || swapWith >= rooms.length) return;
         const orderedIds = [...rooms].map((r) => r.name);
         [orderedIds[index], orderedIds[swapWith]] = [orderedIds[swapWith], orderedIds[index]];
-        await api("/api/rooms/reorder", {
+        const {res, text} = await api("/api/rooms/reorder", {
           method:"PATCH",
           headers: { "Content-Type":"application/json" },
           body: JSON.stringify({ category_id: Number(categoryId) || categoryId, orderedIds })
         });
+        if(!res.ok){
+          if(roomManageMsg) roomManageMsg.textContent = text || "Failed to reorder rooms.";
+          return;
+        }
+      }
+      if(action === "archive"){
+        if(!confirm(`Archive room "${displayRoomName(room.name)}"?`)) return;
+        const {res, text} = await api(`/api/rooms/${encodeURIComponent(room.name)}/archive`, { method:"PATCH" });
+        if(!res.ok){
+          if(roomManageMsg) roomManageMsg.textContent = text || "Failed to archive room.";
+          return;
+        }
+      }
+      if(action === "restore"){
+        const {res, text} = await api(`/api/rooms/${encodeURIComponent(room.name)}/restore`, { method:"PATCH" });
+        if(!res.ok){
+          if(roomManageMsg) roomManageMsg.textContent = text || "Failed to restore room.";
+          return;
+        }
       }
       await loadRooms();
     });
@@ -11984,32 +12112,118 @@ function renderRoomManageRoomsList(){
 }
 
 function refreshRoomManageUi(){
+  populateRoomCreateSelects();
   populateManageMasterSelects();
   renderRoomMasterList();
   renderRoomCategoryList();
   renderRoomManageRoomsList();
 }
 
-function openRoomManageModal(){
+function populateRoomEventsRoomSelect(){
+  if(!roomEventsRoomSelect) return;
+  const rooms = (roomStructure.rooms || []).filter((r) => Number(r?.archived || 0) !== 1);
+  const sorted = [...rooms].sort((a, b) => String(a?.name || "").localeCompare(String(b?.name || ""), undefined, { sensitivity: "base" }));
+  if(!sorted.length){
+    roomEventsRoomSelect.innerHTML = "<option value=''>No rooms available</option>";
+    return;
+  }
+  const selected = roomEventsRoomSelect.value || sorted[0]?.name || "";
+  populateSelect(
+    roomEventsRoomSelect,
+    sorted.map((r) => ({ value: r.name, label: displayRoomName(r.name) })),
+    selected
+  );
+}
+
+function updateRoomEventsTypeHint(){
+  if(!roomEventsType || !roomEventsText) return;
+  const type = String(roomEventsType.value || "");
+  const isFlair = type === "flair";
+  roomEventsText.disabled = isFlair;
+  if(isFlair){
+    roomEventsText.placeholder = "Flair events apply a temporary visual highlight.";
+  }else if(type === "announcement"){
+    roomEventsText.placeholder = "Announcement text (required).";
+  }else{
+    roomEventsText.placeholder = "Prompt text (optional, leave blank for random).";
+  }
+}
+
+async function refreshRoomEventsActiveList(){
+  if(!roomEventsRoomSelect || !roomEventsActiveList) return;
+  const roomName = roomEventsRoomSelect.value || "";
+  if(!roomName){
+    roomEventsActiveList.innerHTML = "<div class='muted'>Select a room.</div>";
+    return;
+  }
+  if(roomEventsMsg) roomEventsMsg.textContent = "";
+  const {res, text} = await api(`/api/rooms/${encodeURIComponent(roomName)}/events`, { method:"GET" });
+  if(!res.ok){
+    if(roomEventsMsg) roomEventsMsg.textContent = text || "Failed to load events.";
+    return;
+  }
+  let data = {};
+  try {
+    data = JSON.parse(text || "{}");
+  } catch {}
+  const events = Array.isArray(data.events) ? data.events : [];
+  if(!events.length){
+    roomEventsActiveList.innerHTML = "<div class='muted'>No active events.</div>";
+    return;
+  }
+  roomEventsActiveList.innerHTML = "";
+  for(const ev of events){
+    const row = document.createElement("div");
+    row.className = "roomManageRow";
+    const endsAt = ev?.endsAt ? new Date(Number(ev.endsAt)).toLocaleTimeString() : "No end";
+    row.innerHTML = `
+      <div class="label">${escapeHtml(String(ev?.title || ev?.type || "Event"))}</div>
+      <div class="tag">${escapeHtml(String(ev?.type || "event"))}</div>
+      <div class="muted" style="font-size:12px;">${escapeHtml(endsAt)}</div>
+      <div class="actions">
+        <button class="btn danger" data-action="stop">Stop</button>
+      </div>
+    `;
+    row.querySelector("[data-action='stop']")?.addEventListener("click", async () => {
+      const {res: stopRes, text: stopText} = await api(`/api/room-events/${encodeURIComponent(ev.id)}/stop`, { method:"POST" });
+      if(!stopRes.ok){
+        if(roomEventsMsg) roomEventsMsg.textContent = stopText || "Failed to stop event.";
+        return;
+      }
+      await refreshRoomEventsActiveList();
+    });
+    roomEventsActiveList.appendChild(row);
+  }
+}
+
+function refreshRoomEventsUi(){
+  populateRoomEventsRoomSelect();
+  updateRoomEventsTypeHint();
+  refreshRoomEventsActiveList();
+}
+
+function openRoomManageModal(options = {}){
   // Prevent overlay stacking: close drawers / other modals before opening room modals
   try{ closeDrawers(); }catch{}
   try{ if(typeof closeMemberMenu==="function") closeMemberMenu(); }catch{}
   try{ if(typeof closeActionMenu==="function") closeActionMenu(); }catch{}
   try{ if(typeof closeModal==="function" && modal && modal.style && modal.style.display !== "none") closeModal(); }catch{}
   try{ if(typeof closeCouplesModal==="function") closeCouplesModal(); }catch{}
+  closeRoomActionsMenu();
   if(!roomManageModal) return;
   if(!me){
     toast("Loading your profile — try again in a second.");
     return;
   }
-  if(roleRank(me.role) < roleRank("Owner")){
-    toast("Room management is Owner-only.");
+  if(roleRank(me.role) < roleRank("Admin")){
+    toast("Room management is Admin-only.");
     return;
   }
   if(roomMasterMsg) roomMasterMsg.textContent = "";
   if(roomCategoryMsg) roomCategoryMsg.textContent = "";
   if(roomManageMsg) roomManageMsg.textContent = "";
-  const activeTab = document.querySelector("[data-room-manage-tab].active")?.dataset?.roomManageTab || "masters";
+  if(roomManageCreateMsg) roomManageCreateMsg.textContent = "";
+  const activeTab = options.tab || document.querySelector("[data-room-manage-tab].active")?.dataset?.roomManageTab || "masters";
   setRoomManageTab(activeTab);
   roomManageModal.hidden = false;
   roomManageModal.style.display = "flex";
@@ -12018,6 +12232,9 @@ function openRoomManageModal(){
     roomManageModal.classList.add("modal-visible");
   }else{
     requestAnimationFrame(()=> roomManageModal.classList.add("modal-visible"));
+  }
+  if(options.focusEl){
+    requestAnimationFrame(()=> options.focusEl?.focus?.());
   }
 }
 
@@ -12037,6 +12254,18 @@ function closeRoomManageModal(){
   }, 140);
 }
 
+function openRoomManageModalAtTab(tab, options = {}){
+  openRoomManageModal({ ...options, tab });
+}
+
+function applyRoomCreatePreset({ vipOnly = false, minLevel = 0, staffOnly = false } = {}){
+  if(roomManageCreateVipOnly) roomManageCreateVipOnly.checked = Boolean(vipOnly);
+  if(roomManageCreateStaffOnly) roomManageCreateStaffOnly.checked = Boolean(staffOnly);
+  if(roomManageCreateMinLevel){
+    roomManageCreateMinLevel.value = String(vipOnly ? Math.max(Number(minLevel) || 0, 0) : 0);
+  }
+}
+
 function setRoomManageTab(tab){
   const next = tab || "masters";
   document.querySelectorAll("[data-room-manage-tab]").forEach((btn) => {
@@ -12046,6 +12275,7 @@ function setRoomManageTab(tab){
     section.classList.toggle("active", section.dataset.roomManageSection === next);
   });
   refreshRoomManageUi();
+  if(next === "events") refreshRoomEventsUi();
 }
 
 async function persistRoomMasterCollapse(masterId, collapsed){
@@ -12068,14 +12298,42 @@ async function persistRoomCategoryCollapse(categoryId, collapsed){
 
 function updateRoomControlsVisibility(){
   if(addRoomBtn){
-    const canCreate = me && roleRank(me.role) >= roleRank("Co-owner");
+    const canCreate = me && roleRank(me.role) >= roleRank("Admin");
     addRoomBtn.style.display = rightPanelMode === "rooms" && canCreate ? "inline-flex" : "none";
   }
   if(manageRoomsBtn){
-    const isOwner = me && roleRank(me.role) >= roleRank("Owner");
-    manageRoomsBtn.style.display = rightPanelMode === "rooms" && isOwner ? "inline-flex" : "none";
-    if(!isOwner) closeRoomManageModal();
+    const isAdmin = me && roleRank(me.role) >= roleRank("Admin");
+    const isVipEligible = me && roleRank(me.role) >= roleRank("VIP") && Number(me.level || 0) >= 25;
+    const shouldShow = rightPanelMode === "rooms" && (isAdmin || isVipEligible);
+    manageRoomsBtn.style.display = shouldShow ? "inline-flex" : "none";
+    if(!isAdmin) closeRoomManageModal();
+    if(!shouldShow) closeRoomActionsMenu();
   }
+  updateRoomActionsMenu();
+}
+
+function updateRoomActionsMenu(){
+  if(!roomActionsMenu) return;
+  const isAdmin = me && roleRank(me.role) >= roleRank("Admin");
+  const isVipEligible = me && roleRank(me.role) >= roleRank("VIP") && Number(me.level || 0) >= 25;
+  roomActionsMenu.querySelectorAll("[data-room-action]").forEach((btn) => {
+    const action = btn.dataset.roomAction;
+    if(action === "add-vip-room"){
+      btn.hidden = !isVipEligible;
+      return;
+    }
+    btn.hidden = !isAdmin;
+  });
+}
+
+function closeRoomActionsMenu(){
+  if(roomActionsMenu) roomActionsMenu.hidden = true;
+}
+
+function toggleRoomActionsMenu(){
+  if(!roomActionsMenu) return;
+  updateRoomActionsMenu();
+  roomActionsMenu.hidden = !roomActionsMenu.hidden;
 }
 
 function ensureChangelogLoaded(force = false){
@@ -17376,13 +17634,51 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   ensureRoomModeSwitch();
   await loadDmThreads();
 
-  // show Create Room button only for Co-owner+
+  // show Create Room button only for Admin+
   if(addRoomBtn){
     addRoomBtn.addEventListener("click", createRoomFlow);
   }
   if(manageRoomsBtn){
-    manageRoomsBtn.addEventListener("click", openRoomManageModal);
+    manageRoomsBtn.addEventListener("click", (e) => {
+      e.stopPropagation();
+      toggleRoomActionsMenu();
+    });
   }
+  roomActionsMenu?.addEventListener("click", (e) => {
+    const btn = e.target.closest("button[data-room-action]");
+    if(!btn) return;
+    const action = btn.dataset.roomAction;
+    const isAdmin = me && roleRank(me.role) >= roleRank("Admin");
+    const isVipEligible = me && roleRank(me.role) >= roleRank("VIP") && Number(me.level || 0) >= 25;
+    closeRoomActionsMenu();
+    if(action === "add-category"){
+      if(!isAdmin) return toast("Admin+ required.");
+      openRoomManageModalAtTab("categories", { focusEl: roomCategoryCreateInput });
+      return;
+    }
+    if(action === "add-room"){
+      if(!isAdmin) return toast("Admin+ required.");
+      applyRoomCreatePreset({ vipOnly: false, minLevel: 0 });
+      openRoomManageModalAtTab("create", { focusEl: roomManageCreateNameInput });
+      return;
+    }
+    if(action === "add-vip-room"){
+      if(!isVipEligible) return;
+      if(!isAdmin) return toast("Admin+ required to create VIP rooms.");
+      applyRoomCreatePreset({ vipOnly: true, minLevel: 25 });
+      openRoomManageModalAtTab("create", { focusEl: roomManageCreateNameInput });
+      return;
+    }
+    if(action === "manage-rooms"){
+      if(!isAdmin) return toast("Admin+ required.");
+      openRoomManageModalAtTab("rooms");
+    }
+  });
+  document.addEventListener("click", (e) => {
+    if(!roomActionsMenu || roomActionsMenu.hidden) return;
+    if(roomActionsMenu.contains(e.target) || manageRoomsBtn?.contains(e.target)) return;
+    closeRoomActionsMenu();
+  });
   roomManageCloseBtn?.addEventListener("click", closeRoomManageModal);
   roomManageModal?.addEventListener("click", (e)=>{ if(e.target === roomManageModal) closeRoomManageModal(); });
   roomCreateCloseBtn?.addEventListener("click", closeRoomCreateModal);
@@ -17390,12 +17686,23 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   roomCreateModal?.addEventListener("click", (e)=>{ if(e.target === roomCreateModal) closeRoomCreateModal(); });
   roomCreateSubmitBtn?.addEventListener("click", submitCreateRoom);
   roomCreateMasterSelect?.addEventListener("change", populateRoomCreateSelects);
+  roomManageCreateForm?.addEventListener("submit", submitRoomManageCreate);
+  roomManageCreateMasterSelect?.addEventListener("change", () => {
+    populateRoomCreateSelectsFor(roomManageCreateMasterSelect, roomManageCreateCategorySelect);
+  });
+  roomManageCreateVipOnly?.addEventListener("change", () => {
+    if(roomManageCreateVipOnly.checked && roomManageCreateMinLevel){
+      const next = Math.max(25, Number(roomManageCreateMinLevel.value || 0));
+      roomManageCreateMinLevel.value = String(next);
+    }
+  });
   roomCategoryMasterSelect?.addEventListener("change", renderRoomCategoryList);
   roomManageMasterSelect?.addEventListener("change", () => {
     populateManageCategorySelects();
     renderRoomManageRoomsList();
   });
   roomManageCategorySelect?.addEventListener("change", renderRoomManageRoomsList);
+  roomManageShowArchived?.addEventListener("change", renderRoomManageRoomsList);
   document.querySelectorAll("[data-room-manage-tab]").forEach((btn)=>{
     btn.addEventListener("click", ()=> setRoomManageTab(btn.dataset.roomManageTab));
   });
@@ -17429,6 +17736,32 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
     });
     if(roomCategoryCreateInput) roomCategoryCreateInput.value = "";
     await loadRooms();
+  });
+  roomEventsRoomSelect?.addEventListener("change", refreshRoomEventsActiveList);
+  roomEventsType?.addEventListener("change", updateRoomEventsTypeHint);
+  roomEventsStartBtn?.addEventListener("click", async () => {
+    if(!roomEventsRoomSelect) return;
+    if(roomEventsMsg) roomEventsMsg.textContent = "";
+    const roomName = roomEventsRoomSelect.value || "";
+    if(!roomName){
+      if(roomEventsMsg) roomEventsMsg.textContent = "Select a room.";
+      return;
+    }
+    const type = String(roomEventsType?.value || "");
+    const duration = Math.max(0, Math.min(86400, Number(roomEventsDuration?.value || 0)));
+    const text = type === "flair" ? "" : String(roomEventsText?.value || "").trim();
+    const payload = { text };
+    const {res, text: resText} = await api(`/api/rooms/${encodeURIComponent(roomName)}/events`, {
+      method:"POST",
+      headers: { "Content-Type":"application/json" },
+      body: JSON.stringify({ type, duration_seconds: duration, payload }),
+    });
+    if(!res.ok){
+      if(roomEventsMsg) roomEventsMsg.textContent = resText || "Failed to start event.";
+      return;
+    }
+    if(roomEventsText) roomEventsText.value = "";
+    await refreshRoomEventsActiveList();
   });
   updateRoomControlsVisibility();
 

--- a/public/index.html
+++ b/public/index.html
@@ -150,7 +150,15 @@
 <div class="row" style="gap:6px;">
 <button class="iconBtn smallIcon" id="channelsCloseBtn" title="Close" type="button">✕</button>
 <button class="iconBtn smallIcon" id="menuToggleBtn" title="Menu" type="button">☰</button>
+<div class="roomActionsWrap">
 <button class="iconBtn smallIcon" id="manageRoomsBtn" title="Manage rooms" type="button">⋯</button>
+<div class="roomActionsMenu" id="roomActionsMenu" hidden="">
+<button type="button" data-room-action="add-category">Add category</button>
+<button type="button" data-room-action="add-room">Add room</button>
+<button type="button" data-room-action="add-vip-room">Add VIP room</button>
+<button type="button" data-room-action="manage-rooms">Manage rooms</button>
+</div>
+</div>
 </div>
 </div>
 <div class="roomsPanel" id="roomsPanel">
@@ -2355,6 +2363,7 @@
           <label for="roomManageCategorySelect">Subcategory</label>
           <select id="roomManageCategorySelect"></select>
         </div>
+        <label class="chk"><input type="checkbox" id="roomManageShowArchived"> Show archived rooms</label>
         <div class="roomManageList" id="roomManageRoomList"></div>
         <div class="msgline" id="roomManageMsg"></div>
       </div>
@@ -2384,6 +2393,7 @@
 
           <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
             <button class="btn" type="submit">Create</button>
+            <div class="msgline" id="roomManageCreateMsg"></div>
           </div>
         </form>
       </div>
@@ -2397,25 +2407,22 @@
           <select id="roomEventsType">
             <option value="announcement">Announcement</option>
             <option value="prompt">Prompt</option>
-            <option value="boost">XP Boost</option>
+            <option value="flair">Visual Flair</option>
           </select>
         </div>
         <div class="field">
           <label for="roomEventsText">Text</label>
-          <textarea id="roomEventsText" rows="3" placeholder="What should appear as a system message?"></textarea>
+          <textarea id="roomEventsText" rows="3" placeholder="Announcement or prompt text (optional for prompts)."></textarea>
         </div>
         <div class="row" style="gap:8px; flex-wrap:wrap;">
           <div class="field" style="flex:1; min-width:160px;">
             <label for="roomEventsDuration">Duration (seconds, 0 = no end)</label>
             <input id="roomEventsDuration" type="number" min="0" max="86400" value="600"/>
           </div>
-          <div class="field" style="flex:1; min-width:160px;">
-            <label for="roomEventsXpMult">XP multiplier (boost only)</label>
-            <input id="roomEventsXpMult" type="number" min="1" max="10" value="2"/>
-          </div>
         </div>
         <div class="row" style="gap:8px; flex-wrap:wrap; margin-top:10px;">
           <button class="btn" id="roomEventsStartBtn" type="button">Start event</button>
+          <div class="msgline" id="roomEventsMsg"></div>
         </div>
 
         <div class="roomEventsActive">

--- a/public/styles.css
+++ b/public/styles.css
@@ -1922,6 +1922,12 @@ main.chat{
   min-height:0;
   height:100%;
 }
+body.event-active main.chat{
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 40%, transparent);
+}
+body.event-active .roomTitle{
+  color: var(--accent);
+}
 
 .msgs{
   flex:1 1 auto;
@@ -2419,6 +2425,14 @@ body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + e
   font-weight:800;
   flex:1;
   min-width:120px;
+}
+.roomManageRow .tag{
+  font-size:11px;
+  padding:2px 6px;
+  border-radius:999px;
+  background:color-mix(in srgb, var(--panel) 75%, transparent);
+  border:1px solid var(--border);
+  color:var(--muted);
 }
 .roomManageRow .actions{
   display:flex;
@@ -5680,6 +5694,40 @@ body.polish-pack.polish-animations .msg-new .dmMsgAvatar{
   padding:10px 12px;
   border-top:1px solid var(--line);
   border-bottom:1px solid var(--line);
+  position:relative;
+}
+.roomActionsWrap{ position:relative; display:inline-flex; align-items:center; }
+.roomActionsMenu{
+  position:absolute;
+  top:calc(100% + 6px);
+  right:0;
+  min-width:180px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  padding:8px;
+  background:var(--panel2);
+  border:1px solid var(--border);
+  border-radius:12px;
+  box-shadow: var(--shadowMd);
+  z-index:200;
+}
+.roomActionsMenu[hidden]{ display:none; }
+.roomActionsMenu button{
+  width:100%;
+  text-align:left;
+  background:transparent;
+  border:1px solid transparent;
+  color:var(--text);
+  padding:8px 10px;
+  border-radius:10px;
+  cursor:pointer;
+  font-weight:600;
+}
+.roomActionsMenu button:hover{ background:var(--panel); }
+.roomActionsMenu button:disabled{
+  opacity:0.5;
+  cursor:not-allowed;
 }
 .smallIcon{
   width:32px;

--- a/server.js
+++ b/server.js
@@ -41,6 +41,14 @@ const DICE_ROLL_MIN_INTERVAL_MS = 1000;
 const diceRollRateByUserId = new Map();
 const SURVIVAL_ROOM_ID = "survivalsimulator";
 const SURVIVAL_ROOM_DB_ID = 1;
+const CORE_ROOMS = [
+  { name: "main", sortOrder: 0 },
+  { name: "music", sortOrder: 1 },
+  { name: "nsfw", sortOrder: 2 },
+  { name: "diceroom", sortOrder: 3 },
+  { name: "survivalsimulator", sortOrder: 4 },
+];
+const CORE_ROOM_NAMES = new Set(CORE_ROOMS.map((room) => room.name));
 const SURVIVAL_SEASON_COOLDOWN_MS = 2 * 60 * 1000;
 const SURVIVAL_ADVANCE_COOLDOWN_MS = 2000;
 const CHESS_DEFAULT_ELO = 1200;
@@ -85,6 +93,16 @@ const lastReactionByUserId = new Map(); // userId -> ts
 
 // --- Room events (in-memory, roomName -> {type,title,endsAt,startedBy})
 const ACTIVE_ROOM_EVENTS = new Map();
+let ROOM_EVENT_SEQ = 1;
+const ROOM_PROMPT_TEMPLATES = [
+  "What’s a small win you had this week?",
+  "Share a comfort movie or show you love.",
+  "What song do you have on repeat right now?",
+  "What’s a simple joy you want more of lately?",
+  "Drop a cozy weekend plan in one sentence.",
+  "What’s something new you want to try this month?",
+  "Describe today in three words.",
+];
 
 function pruneWindowTimestamps(list, now, windowMs) {
   const cutoff = now - windowMs;
@@ -490,6 +508,7 @@ const pgInitPromise = (async () => {
         staff_only INTEGER NOT NULL DEFAULT 0,
         min_level INTEGER NOT NULL DEFAULT 0,
         events_enabled INTEGER NOT NULL DEFAULT 1,
+        archived INTEGER NOT NULL DEFAULT 0,
         category_id INTEGER REFERENCES room_categories(id) ON DELETE SET NULL,
         room_sort_order INTEGER NOT NULL DEFAULT 0,
         created_by_user_id INTEGER,
@@ -506,10 +525,11 @@ const pgInitPromise = (async () => {
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS room_sort_order INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS created_by_user_id INTEGER`,
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS is_user_room INTEGER NOT NULL DEFAULT 0`,
-          `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS vip_only INTEGER NOT NULL DEFAULT 0`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS vip_only INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS staff_only INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS min_level INTEGER NOT NULL DEFAULT 0`,
       `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS events_enabled INTEGER NOT NULL DEFAULT 1`,
+      `ALTER TABLE rooms ADD COLUMN IF NOT EXISTS archived INTEGER NOT NULL DEFAULT 0`,
     ];
     for (const q of roomCols) {
       try { await pgPool.query(q); } catch (_) {}
@@ -2539,11 +2559,15 @@ db.get(`SELECT value FROM config WHERE key='maintenance'`, [], (_e, row) => {
 db.get(`SELECT value FROM config WHERE key='active_room_events'`, [], (_e, row) => {
   try {
     const obj = safeJsonParse(row?.value || "{}", {});
+    let maxId = 0;
     for (const [room, ev] of Object.entries(obj || {})) {
       if (!ev || typeof ev !== "object") continue;
       if (ev.endsAt && Number(ev.endsAt) < Date.now()) continue;
       ACTIVE_ROOM_EVENTS.set(room, ev);
+      const evId = Number(ev.id);
+      if (Number.isFinite(evId) && evId > maxId) maxId = evId;
     }
+    ROOM_EVENT_SEQ = Math.max(ROOM_EVENT_SEQ, maxId + 1);
   } catch {}
 });
 
@@ -2613,6 +2637,53 @@ async function setConfigJson(key, obj) {
   const raw = JSON.stringify(obj ?? {});
   await setConfigValue(key, raw);
   return obj;
+}
+
+function selectPromptText() {
+  const pool = ROOM_PROMPT_TEMPLATES.filter(Boolean);
+  if (!pool.length) return "💬 Prompt event started.";
+  return pool[Math.floor(Math.random() * pool.length)];
+}
+
+function pruneExpiredRoomEvent(roomName) {
+  const existing = ACTIVE_ROOM_EVENTS.get(roomName);
+  if (!existing) return null;
+  if (existing.endsAt && Number(existing.endsAt) < Date.now()) {
+    ACTIVE_ROOM_EVENTS.delete(roomName);
+    return null;
+  }
+  return existing;
+}
+
+function getActiveEventsForRoom(roomName) {
+  const key = String(roomName || "");
+  const existing = pruneExpiredRoomEvent(key);
+  if (!existing) return [];
+  return [existing];
+}
+
+async function syncActiveRoomEvents() {
+  await setConfigJson("active_room_events", Object.fromEntries(ACTIVE_ROOM_EVENTS.entries()));
+}
+
+async function addRoomEvent(roomName, ev) {
+  const room = String(roomName || "");
+  const payload = ev && typeof ev === "object" ? ev : {};
+  const next = { ...payload, room };
+  ACTIVE_ROOM_EVENTS.set(room, next);
+  await syncActiveRoomEvents();
+  return next;
+}
+
+async function stopRoomEventById(id) {
+  for (const [room, ev] of ACTIVE_ROOM_EVENTS.entries()) {
+    if (Number(ev?.id) === Number(id)) {
+      ACTIVE_ROOM_EVENTS.delete(room);
+      await syncActiveRoomEvents();
+      return { ...ev, room };
+    }
+  }
+  return null;
 }
 
 function createChessInstance(fen) {
@@ -4112,37 +4183,48 @@ const commandRegistry = {
     },
   },
   event: {
-    minRole: "Moderator",
-    description: "Start/stop a room event banner (mods+)",
-    usage: "/event start <type> <minutes> <title...> | /event stop",
-    example: "/event start trivia 10 Quick Trivia",
+    minRole: "Admin",
+    description: "Start/stop a room event (admin+)",
+    usage: "/event start <announcement|prompt|flair> <minutes> <text...> | /event stop",
+    example: "/event start prompt 10 Quick Trivia",
     handler: async ({ args, actor }) => {
       const sub = String(args[0] || "").toLowerCase();
       if (!room) return { ok: false, message: "Join a room first." };
 
       if (sub === "stop") {
+        const existing = ACTIVE_ROOM_EVENTS.get(room);
+        if (!existing) return { ok: false, message: "No active room event." };
         ACTIVE_ROOM_EVENTS.delete(room);
-        await setConfigJson("active_room_events", Object.fromEntries(ACTIVE_ROOM_EVENTS.entries()));
+        await syncActiveRoomEvents();
         io.to(room).emit("room:event", { room, active: null, at: Date.now() });
         return { ok: true, message: "Room event cleared." };
       }
 
       if (sub !== "start") return { ok: false, message: "Use /event start ... or /event stop" };
 
-      const type = String(args[1] || "event").slice(0, 24);
+      const type = String(args[1] || "").toLowerCase();
+      const allowed = new Set(["announcement", "prompt", "flair"]);
+      if (!allowed.has(type)) return { ok: false, message: "Type must be announcement, prompt, or flair." };
       const mins = Math.max(1, Math.min(120, Math.floor(Number(args[2]) || 10)));
-      const title = String(args.slice(3).join(" ") || "").slice(0, 80) || "Room Event";
+      const rawText = String(args.slice(3).join(" ") || "").trim();
+      if (type === "announcement" && !rawText) return { ok: false, message: "Announcement text required." };
+      const resolvedText = type === "prompt" ? (rawText || selectPromptText()) : rawText;
+      const title = resolvedText ? resolvedText.slice(0, 80) : type === "flair" ? "Visual Flair" : "Room Event";
       const ev = {
+        id: ROOM_EVENT_SEQ++,
         type,
         title,
+        payload: { text: resolvedText },
         startedBy: actor?.username || "",
         startedAt: Date.now(),
         endsAt: Date.now() + mins * 60_000,
       };
-      ACTIVE_ROOM_EVENTS.set(room, ev);
-      await setConfigJson("active_room_events", Object.fromEntries(ACTIVE_ROOM_EVENTS.entries()));
+      await addRoomEvent(room, ev);
       io.to(room).emit("room:event", { room, active: ev, at: Date.now() });
-      return { ok: true, message: `Event started for ${mins} min.` };
+      if (type === "announcement" || type === "prompt") {
+        io.to(room).emit("system", { room, text: resolvedText || "💬 Prompt event started." });
+      }
+      return { ok: true, message: `Room event '${title}' started.` };
     },
   },
 
@@ -4306,6 +4388,10 @@ function canAccessRoomBySettings(user, roomRow) {
   if (vipOnly && !isVipPlus(role)) return false;
   if (minLevel > 0 && level < minLevel) return false;
   return true;
+}
+
+function isCoreRoomName(name) {
+  return CORE_ROOM_NAMES.has(String(name || "").toLowerCase());
 }
 
 
@@ -4570,16 +4656,6 @@ async function awardMessageXp(userId, roleHint, roomName) {
 
   const role = roleHint || row.role || "User";
   let delta = xpRatesForRole(role).message;
-  try {
-    if (roomName) {
-      const events = getActiveEventsForRoom(roomName);
-      const boost = (events || []).find((e) => e.type === 'boost' && (e.payload?.xp_multiplier || e.payload?.xpMultiplier));
-      if (boost) {
-        const mult = Number(boost.payload?.xp_multiplier ?? boost.payload?.xpMultiplier ?? 1);
-        if (Number.isFinite(mult) && mult > 1 && mult <= 10) delta = Math.round(delta * mult);
-      }
-    }
-  } catch (_) {}
   const result = await applyXpGain(userId, delta, {
     baseRow: row,
     lastMessageXpAt: now,
@@ -5747,7 +5823,7 @@ async function buildRoomStructure() {
     `SELECT id, master_id, name, sort_order FROM room_categories ORDER BY sort_order ASC, name ASC`
   );
   const rooms = await dbAllAsync(
-    `SELECT name, category_id, room_sort_order, slowmode_seconds, is_locked, maintenance_mode, vip_only, staff_only, min_level, events_enabled,
+    `SELECT name, category_id, room_sort_order, slowmode_seconds, is_locked, maintenance_mode, vip_only, staff_only, min_level, events_enabled, archived,
             created_by, created_by_user_id, is_user_room
        FROM rooms
       ORDER BY room_sort_order ASC, name ASC`
@@ -5767,6 +5843,7 @@ async function buildRoomStructure() {
       staff_only: Number(r.staff_only || 0),
       min_level: Number(r.min_level || 0),
       events_enabled: Number(r.events_enabled ?? 1),
+      archived: Number(r.archived || 0),
       created_by: r.created_by ?? null,
       created_by_user_id: r.created_by_user_id ?? null,
       is_user_room: Number(r.is_user_room || 0),
@@ -5780,8 +5857,10 @@ async function buildRoomStructurePayload(userId) {
   try {
     if (userId) user = await dbGetAsync(`SELECT id, role, level FROM users WHERE id = ?`, [userId]);
   } catch (_) {}
+  const isAdmin = user && roleRankServer(user.role) >= roleRankServer("Admin");
   const filteredRooms = (base.rooms || []).filter((room) => {
     if (!room) return false;
+    if (Number(room.archived || 0) === 1 && !isAdmin) return false;
     // Legacy VIP prefix gate remains, but new settings gate applies too.
     const isVipPrefix = /^vip[_-]/i.test(room.name || "");
     if (isVipPrefix) {
@@ -5811,6 +5890,87 @@ async function getDefaultMasterIds() {
     site: map.get("Site Rooms") || null,
     user: map.get("User Rooms") || null,
   };
+}
+
+async function resolveSiteUncategorizedCategoryId() {
+  try {
+    const ids = await getDefaultMasterIds();
+    if (!ids.site) return null;
+    const row = await dbGetAsync(
+      `SELECT id FROM room_categories WHERE master_id = ? AND lower(name) = lower('Uncategorized') LIMIT 1`,
+      [ids.site]
+    );
+    return row?.id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function ensureCoreRoomsExist() {
+  const now = Date.now();
+  const categoryId = await resolveSiteUncategorizedCategoryId();
+  for (const room of CORE_ROOMS) {
+    const existing = await dbGetAsync(`SELECT name, category_id FROM rooms WHERE name = ?`, [room.name]).catch(() => null);
+    if (!existing) {
+      await dbRunAsync(
+        `INSERT OR IGNORE INTO rooms
+          (name, created_by, created_at, category_id, room_sort_order, is_user_room, vip_only, staff_only, min_level, is_locked, maintenance_mode, events_enabled, slowmode_seconds, archived)
+         VALUES (?, NULL, ?, ?, ?, 0, 0, 0, 0, 0, 0, 1, 0, 0)`,
+        [room.name, now, categoryId, room.sortOrder ?? 0]
+      );
+    } else {
+      await dbRunAsync(
+        `UPDATE rooms
+            SET category_id = COALESCE(category_id, ?),
+                room_sort_order = COALESCE(room_sort_order, ?),
+                archived = 0
+          WHERE name = ?`,
+        [categoryId, room.sortOrder ?? 0, room.name]
+      ).catch(() => {});
+    }
+  }
+
+  if (!PG_READY) return;
+  const pgCategoryId = await (async () => {
+    try {
+      const { rows } = await pgPool.query(
+        `SELECT c.id
+           FROM room_categories c
+           JOIN room_master_categories m ON m.id = c.master_id
+          WHERE m.name = 'Site Rooms' AND lower(c.name) = lower('Uncategorized')
+          LIMIT 1`
+      );
+      return rows?.[0]?.id ?? null;
+    } catch {
+      return null;
+    }
+  })();
+  for (const room of CORE_ROOMS) {
+    try {
+      const { rows } = await pgPool.query(`SELECT name, category_id FROM rooms WHERE name = $1 LIMIT 1`, [room.name]);
+      const existing = rows?.[0] || null;
+      if (!existing) {
+        await pgPool.query(
+          `INSERT INTO rooms
+            (name, created_by, created_at, category_id, room_sort_order, is_user_room, vip_only, staff_only, min_level, is_locked, maintenance_mode, events_enabled, slowmode_seconds, archived)
+           VALUES ($1, NULL, $2, $3, $4, 0, 0, 0, 0, 0, 0, 1, 0, 0)
+           ON CONFLICT (name) DO NOTHING`,
+          [room.name, now, pgCategoryId, room.sortOrder ?? 0]
+        );
+      } else {
+        await pgPool.query(
+          `UPDATE rooms
+              SET category_id = COALESCE(category_id, $1),
+                  room_sort_order = COALESCE(room_sort_order, $2),
+                  archived = 0
+            WHERE name = $3`,
+          [pgCategoryId, room.sortOrder ?? 0, room.name]
+        );
+      }
+    } catch (e) {
+      console.warn("[rooms] core room seed failed:", e?.message || e);
+    }
+  }
 }
 
 async function getUncategorizedCategoryId(masterId) {
@@ -8531,10 +8691,10 @@ async function buildSurvivalPayload(season, { beforeId = null, limit = 200 } = {
   };
 }
 
-// Co-owner+ can create rooms
-app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }), async (req, res) => {
+// Admin+ can create rooms
+app.post("/rooms", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
   const actor = req.session.user;
-  if (!requireMinRole(actor.role, "Co-owner")) return res.status(403).send("Forbidden");
+  if (!requireMinRole(actor.role, "Admin")) return res.status(403).send("Forbidden");
 
   const name = sanitizeRoomName(req.body?.name || req.body?.room || "");
   if (!name) return res.status(400).send("Invalid room name");
@@ -8570,8 +8730,8 @@ app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }),
     const sortOrder = Number(nextSort?.maxSort || 0) + 1;
 
     await dbRunAsync(
-      `INSERT INTO rooms (name, created_by, created_at, category_id, room_sort_order, created_by_user_id, is_user_room, vip_only, staff_only, min_level, is_locked, maintenance_mode, events_enabled, slowmode_seconds)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO rooms (name, created_by, created_at, category_id, room_sort_order, created_by_user_id, is_user_room, vip_only, staff_only, min_level, is_locked, maintenance_mode, events_enabled, slowmode_seconds, archived)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [name, actor.id, Date.now(), categoryId, sortOrder, actor.id, isUserRoom,
        Number(req.body?.vip_only)||0,
        Number(req.body?.staff_only)||0,
@@ -8579,7 +8739,8 @@ app.post("/rooms", strictLimiter, requireLogin, express.json({ limit: "16kb" }),
        Number(req.body?.is_locked)||0,
        Number(req.body?.maintenance_mode)||0,
        (req.body?.events_enabled === 0 || req.body?.events_enabled === "0") ? 0 : 1,
-       Math.max(0, Math.min(3600, Number(req.body?.slowmode_seconds)||0))]
+       Math.max(0, Math.min(3600, Number(req.body?.slowmode_seconds)||0)),
+       0]
     );
 
     logModAction({ actor, action: "room.create", room: name, details: null });
@@ -9541,7 +9702,7 @@ app.patch("/api/room-categories/:id", strictLimiter, requireAdminPlus, express.j
   }
 });
 
-app.delete("/api/room-categories/:id", strictLimiter, requireOwner, async (req, res) => {
+app.delete("/api/room-categories/:id", strictLimiter, requireAdminPlus, async (req, res) => {
   const id = Number(req.params.id);
   if (!id) return res.status(400).send("Invalid category");
   try {
@@ -9550,10 +9711,8 @@ app.delete("/api/room-categories/:id", strictLimiter, requireOwner, async (req, 
     if (normalizeRoomGroupName(row.name) === normalizeRoomGroupName(DEFAULT_ROOM_CATEGORY)) {
       return res.status(400).send("Cannot delete Uncategorized");
     }
-    const fallbackCategoryId = await getUncategorizedCategoryId(row.master_id);
-    if (fallbackCategoryId) {
-      await dbRunAsync(`UPDATE rooms SET category_id = ? WHERE category_id = ?`, [fallbackCategoryId, id]);
-    }
+    const rooms = await dbAllAsync(`SELECT name FROM rooms WHERE category_id = ?`, [id]);
+    if (rooms?.length) return res.status(409).send("Category must be empty to delete");
     await dbRunAsync(`DELETE FROM room_categories WHERE id = ?`, [id]);
     await emitRoomStructureUpdate();
     return res.json({ ok: true });
@@ -9571,83 +9730,6 @@ app.patch("/api/rooms/:id/move", strictLimiter, requireAdminPlus, express.json({
     if (!roomRow) return res.status(404).send("Not found");
     const requestedCategoryId = Number(req.body?.category_id) || null;
     const resolved = await resolveRoomCategoryId({ categoryId: requestedCategoryId, isUserRoom: false });
-
-app.patch("/api/rooms/:id/settings", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
-  const roomName = sanitizeRoomName(req.params.id || "");
-  if (!roomName) return res.status(400).send("Invalid room");
-  const slowmode = Number(req.body?.slowmode_seconds ?? req.body?.slowmode ?? 0);
-  const isLocked = Number(req.body?.is_locked ?? 0) ? 1 : 0;
-  const maintenance = Number(req.body?.maintenance_mode ?? 0) ? 1 : 0;
-  const vipOnly = Number(req.body?.vip_only ?? 0) ? 1 : 0;
-  const staffOnly = Number(req.body?.staff_only ?? 0) ? 1 : 0;
-  const minLevel = Math.max(0, Math.min(999, Number(req.body?.min_level ?? 0) || 0));
-  const eventsEnabled = Number(req.body?.events_enabled ?? 1) ? 1 : 0;
-
-  if (!Number.isFinite(slowmode) || slowmode < 0 || slowmode > 3600) {
-    return res.status(400).send("Invalid slowmode");
-  }
-  try {
-    const roomRow = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [roomName]);
-    if (!roomRow) return res.status(404).send("Not found");
-    await dbRunAsync(
-      `UPDATE rooms
-          SET slowmode_seconds = ?,
-              is_locked = ?,
-              maintenance_mode = ?,
-              vip_only = ?,
-              staff_only = ?,
-              min_level = ?,
-              events_enabled = ?
-        WHERE name = ?`,
-      [slowmode, isLocked, maintenance, vipOnly, staffOnly, minLevel, eventsEnabled, roomName]
-    );
-    await emitRoomStructureUpdate();
-    return res.json({ ok: true });
-
-app.get("/api/rooms/:id/events", strictLimiter, requireAdminPlus, async (req, res) => {
-  const roomName = sanitizeRoomName(req.params.id || "");
-  if (!roomName) return res.status(400).send("Invalid room");
-  return res.json({ ok: true, events: getActiveEventsForRoom(roomName) });
-});
-
-app.post("/api/rooms/:id/events", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
-  const roomName = sanitizeRoomName(req.params.id || "");
-  if (!roomName) return res.status(400).send("Invalid room");
-  const type = String(req.body?.type || "").trim();
-  const durationSec = Math.max(0, Math.min(24 * 60 * 60, Number(req.body?.duration_seconds ?? 0) || 0));
-  const payload = req.body?.payload && typeof req.body.payload === "object" ? req.body.payload : {};
-  const id = ROOM_EVENT_SEQ++;
-  const startedAt = Date.now();
-  const endsAt = durationSec ? startedAt + durationSec * 1000 : null;
-  const ev = { id, type, payload, startedAt, endsAt, createdBy: req.session?.user?.username || null };
-  addRoomEvent(roomName, ev);
-
-  // Broadcast a room-scoped system message
-  let text = "";
-  if (type === "announcement") text = payload?.text ? String(payload.text).slice(0, 500) : "📢 Announcement";
-  else if (type === "prompt") text = payload?.text ? String(payload.text).slice(0, 500) : "💬 Prompt event started.";
-  else if (type === "boost") text = `✨ Boost event started${durationSec ? ` for ${durationSec}s` : ""}.`;
-  else text = `🎉 Event started: ${type || "custom"}.`;
-  io.to(roomName).emit("system", { room: roomName, text });
-
-  return res.json({ ok: true, event: ev });
-});
-
-app.post("/api/room-events/:id/stop", strictLimiter, requireAdminPlus, async (req, res) => {
-  const id = Number(req.params.id);
-  if (!Number.isFinite(id) || id < 1) return res.status(400).send("Invalid event");
-  const stopped = stopRoomEventById(id);
-  if (!stopped) return res.status(404).send("Not found");
-  io.to(stopped.room).emit("system", { room: stopped.room, text: "⛔ Room event ended." });
-  return res.json({ ok: true });
-});
-
-  } catch (e) {
-    console.warn("[rooms][settings]", e?.message || e);
-    return res.status(500).send("Failed");
-  }
-});
-
     const categoryId = resolved?.categoryId ?? null;
     const categoryRow = categoryId
       ? await dbGetAsync(
@@ -9680,12 +9762,134 @@ app.post("/api/room-events/:id/stop", strictLimiter, requireAdminPlus, async (re
   }
 });
 
+app.patch("/api/rooms/:id/settings", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  const slowmode = Number(req.body?.slowmode_seconds ?? req.body?.slowmode ?? 0);
+  const isLocked = Number(req.body?.is_locked ?? 0) ? 1 : 0;
+  const maintenance = Number(req.body?.maintenance_mode ?? 0) ? 1 : 0;
+  const vipOnly = Number(req.body?.vip_only ?? 0) ? 1 : 0;
+  const staffOnly = Number(req.body?.staff_only ?? 0) ? 1 : 0;
+  const minLevel = Math.max(0, Math.min(999, Number(req.body?.min_level ?? 0) || 0));
+  const eventsEnabled = Number(req.body?.events_enabled ?? 1) ? 1 : 0;
+
+  if (!Number.isFinite(slowmode) || slowmode < 0 || slowmode > 3600) {
+    return res.status(400).send("Invalid slowmode");
+  }
+  try {
+    const roomRow = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [roomName]);
+    if (!roomRow) return res.status(404).send("Not found");
+    await dbRunAsync(
+      `UPDATE rooms
+          SET slowmode_seconds = ?,
+              is_locked = ?,
+              maintenance_mode = ?,
+              vip_only = ?,
+              staff_only = ?,
+              min_level = ?,
+              events_enabled = ?
+        WHERE name = ?`,
+      [slowmode, isLocked, maintenance, vipOnly, staffOnly, minLevel, eventsEnabled, roomName]
+    );
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[rooms][settings]", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/rooms/:id/archive", strictLimiter, requireAdminPlus, async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  const actor = req.session?.user;
+  if (isCoreRoomName(roomName) && !requireMinRole(actor?.role, "Owner")) {
+    return res.status(403).send("Core rooms can only be archived by the Owner");
+  }
+  try {
+    const row = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [roomName]);
+    if (!row) return res.status(404).send("Not found");
+    await dbRunAsync(`UPDATE rooms SET archived = 1 WHERE name = ?`, [roomName]);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[rooms] archive failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.patch("/api/rooms/:id/restore", strictLimiter, requireAdminPlus, async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  try {
+    const row = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [roomName]);
+    if (!row) return res.status(404).send("Not found");
+    await dbRunAsync(`UPDATE rooms SET archived = 0 WHERE name = ?`, [roomName]);
+    await emitRoomStructureUpdate();
+    return res.json({ ok: true });
+  } catch (e) {
+    console.warn("[rooms] restore failed", e?.message || e);
+    return res.status(500).send("Failed");
+  }
+});
+
+app.get("/api/rooms/:id/events", strictLimiter, requireAdminPlus, async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  return res.json({ ok: true, events: getActiveEventsForRoom(roomName) });
+});
+
+app.post("/api/rooms/:id/events", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
+  const roomName = sanitizeRoomName(req.params.id || "");
+  if (!roomName) return res.status(400).send("Invalid room");
+  const type = String(req.body?.type || "").trim();
+  const allowedTypes = new Set(["announcement", "prompt", "flair"]);
+  if (!allowedTypes.has(type)) return res.status(400).send("Invalid event type");
+  const roomRow = await dbGetAsync(`SELECT events_enabled, archived FROM rooms WHERE name = ?`, [roomName]);
+  if (!roomRow) return res.status(404).send("Not found");
+  if (Number(roomRow.archived || 0) === 1) return res.status(400).send("Room is archived");
+  if (Number(roomRow.events_enabled ?? 1) === 0) return res.status(400).send("Events are disabled for this room");
+  const durationSec = Math.max(0, Math.min(24 * 60 * 60, Number(req.body?.duration_seconds ?? 0) || 0));
+  const payload = req.body?.payload && typeof req.body.payload === "object" ? req.body.payload : {};
+  const id = ROOM_EVENT_SEQ++;
+  const startedAt = Date.now();
+  const endsAt = durationSec ? startedAt + durationSec * 1000 : null;
+  const rawText = String(payload?.text || "").trim();
+  if (type === "announcement" && !rawText) return res.status(400).send("Text required");
+  const resolvedText = type === "prompt" ? (rawText || selectPromptText()) : rawText;
+  const title = resolvedText ? resolvedText.slice(0, 80) : type === "flair" ? "Visual Flair" : "Room Event";
+  const ev = { id, type, title, payload: { ...payload, text: resolvedText }, startedAt, endsAt, createdBy: req.session?.user?.username || null };
+  await addRoomEvent(roomName, ev);
+  io.to(roomName).emit("room:event", { room: roomName, active: ev, at: Date.now() });
+
+  if (type === "announcement" || type === "prompt") {
+    const text = resolvedText ? String(resolvedText).slice(0, 500) : "💬 Prompt event started.";
+    io.to(roomName).emit("system", { room: roomName, text });
+  }
+
+  return res.json({ ok: true, event: ev });
+});
+
+app.post("/api/room-events/:id/stop", strictLimiter, requireAdminPlus, async (req, res) => {
+  const id = Number(req.params.id);
+  if (!Number.isFinite(id) || id < 1) return res.status(400).send("Invalid event");
+  const stopped = await stopRoomEventById(id);
+  if (!stopped) return res.status(404).send("Not found");
+  io.to(stopped.room).emit("system", { room: stopped.room, text: "⛔ Room event ended." });
+  io.to(stopped.room).emit("room:event", { room: stopped.room, active: null, at: Date.now() });
+  return res.json({ ok: true });
+});
+
 
 app.patch("/api/rooms/:id", strictLimiter, requireAdminPlus, express.json({ limit: "16kb" }), async (req, res) => {
   const oldName = sanitizeRoomName(req.params.id || "");
   const nextName = sanitizeRoomName(req.body?.name || "");
   if (!oldName || !nextName) return res.status(400).send("Invalid room");
   if (oldName === nextName) return res.json({ ok: true, name: nextName });
+  const actor = req.session?.user;
+  if (isCoreRoomName(oldName) && !requireMinRole(actor?.role, "Owner")) {
+    return res.status(403).send("Core rooms can only be renamed by the Owner");
+  }
   try {
     const roomRow = await dbGetAsync(`SELECT name FROM rooms WHERE name = ?`, [oldName]);
     if (!roomRow) return res.status(404).send("Not found");
@@ -13054,7 +13258,7 @@ enforceVipGate(desired, (allowed) => {
   }
 
   db.get(
-  `SELECT name, vip_only, staff_only, min_level, is_locked, maintenance_mode FROM rooms WHERE name=?`,
+  `SELECT name, vip_only, staff_only, min_level, is_locked, maintenance_mode, archived FROM rooms WHERE name=?`,
   [desired],
   (_err, row) => {
     if (!row) return doJoin("main", status);
@@ -13068,6 +13272,11 @@ enforceVipGate(desired, (allowed) => {
     // Maintenance gate: Admin+ only
     if (Number(row.maintenance_mode || 0) === 1 && roleRankServer(sessUser.role) < roleRankServer("Admin")) {
       try { socket.emit("system", { room: "__global__", text: "That room is in maintenance.", meta: { kind: "global" } }); } catch (_) {}
+      return doJoin("main", status);
+    }
+
+    if (Number(row.archived || 0) === 1) {
+      try { socket.emit("system", { room: "__global__", text: "That room is archived.", meta: { kind: "global" } }); } catch (_) {}
       return doJoin("main", status);
     }
 
@@ -14348,11 +14557,16 @@ if (!room) {
         }
 
         db.get(
-          `SELECT slowmode_seconds, is_locked FROM rooms WHERE name=?`,
+          `SELECT slowmode_seconds, is_locked, archived FROM rooms WHERE name=?`,
           [room],
           (_err, settings) => {
             const slowSeconds = Number(settings?.slowmode_seconds || 0);
             const locked = Number(settings?.is_locked || 0) === 1;
+            const archived = Number(settings?.archived || 0) === 1;
+            if (archived) {
+              socket.emit("command response", { ok: false, message: "Room is archived" });
+              return;
+            }
             if (locked && !requireMinRole(socket.user.role, "Moderator")) {
               socket.emit("command response", { ok: false, message: "Room is locked" });
               return;
@@ -15340,6 +15554,12 @@ async function startServer() {
   }
   if (pgResult.status === "rejected") {
     console.error("[startup] Postgres init failed", pgResult.reason);
+  }
+
+  try {
+    await ensureCoreRoomsExist();
+  } catch (e) {
+    console.warn("[startup] core room ensure failed", e?.message || e);
   }
 
   await new Promise((resolve) => {


### PR DESCRIPTION
### Motivation

- Core site rooms were missing and needed to be restored with stable identities and their prior behavior so clients and special-room features (dice/survival) keep working. 
- Provide a safe, incremental Room Management surface (Phase 1) so the existing "…" menu actions do real work and admins can manage categories/rooms without placeholder UI or stub endpoints.
- Introduce safe, room-scoped events (Phase 3 minimal) that cannot affect global economy/state and are gated to Admin+.

### Description

- Restored core rooms at server startup via `ensureCoreRoomsExist()` which idempotently seeds `main`, `music`, `nsfw`, `diceroom`, and `survivalsimulator` into SQLite and Postgres where present, and protects them from accidental archive/rename by non-Owner roles. 
- Added room management server-side support including DB schema additions (`vip_only`, `staff_only`, `min_level`, `events_enabled`, `archived`), endpoints for creating/moving/renaming/reordering rooms and categories, and new `archive`/`restore` endpoints with role checks and safeguards for core rooms. 
- Implemented room-scoped events subsystem (server in-memory + persisted config sync): `announcement`, `prompt` (with randomized prompts), and `flair` visual events; APIs to start/stop events (`/api/rooms/:id/events`, `/api/room-events/:id/stop`) with Admin+ enforcement and room-only broadcasts, and restored client handling to show banners and apply temporary visual flair to the room UI. 
- Wired the client UI: added a real room actions dropdown in the channels header, a fully functional Room Management modal (masters/categories/create/rooms/events tabs), Create Room flows (with VIP/staff/min-level settings), Manage Rooms move/rename/archive/restore, and Events tab to start/stop room events; permissions and visibility are enforced server-side. 

### Testing

- Ran `node --check server.js` and it completed with no syntax errors (server logged Postgres init failure but started and fell back to SQLite). (succeeded)
- Ran `node --check public/app.js` with no syntax errors. (succeeded)
- Started the server (`node server.js`) as an automated smoke check: server started and is reachable, Postgres init reported connectivity failure in this environment and fell back to SQLite as designed (server up). (succeeded with expected PG connectivity warning)
- Attempted automated E2E via Playwright in this environment and the browser-based script timed out/crashed (Playwright container issues), so interactive end-to-end click-throughs were not completed here. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972d19277988333b0e731aa7ff1f93c)