### PR TITLE
Survival Simulator → room-scoped modal; Members actions dropdown; Profile Themes entry

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3010,6 +3010,11 @@ const memberMenuName = document.getElementById("memberMenuName");
 const memberViewProfileBtn = document.getElementById("memberViewProfileBtn");
 const memberDmBtn = document.getElementById("memberDmBtn");
 const memberReferBtn = document.getElementById("memberReferBtn");
+const memberModSection = document.getElementById("memberModSection");
+const memberKickBtn = document.getElementById("memberKickBtn");
+const memberMuteBtn = document.getElementById("memberMuteBtn");
+const memberBanBtn = document.getElementById("memberBanBtn");
+const memberLogsBtn = document.getElementById("memberLogsBtn");
 
 const appRoot = document.getElementById("app");
 if (memberMenu && appRoot && memberMenu.parentElement !== appRoot) {
@@ -3251,7 +3256,9 @@ const luckMeterBar = document.getElementById("luckMeterBar");
 const luckMeterBarText = document.getElementById("luckMeterBarText");
 const luckMeterValue = document.getElementById("luckMeterValue");
 const luckMeterStreak = document.getElementById("luckMeterStreak");
-const survivalPanel = document.getElementById("survivalPanel");
+const survivalOpenBtn = document.getElementById("survivalOpenBtn");
+const survivalModal = document.getElementById("survivalModal");
+const survivalModalClose = document.getElementById("survivalModalClose");
 const survivalSeasonTitle = document.getElementById("survivalSeasonTitle");
 const survivalStatus = document.getElementById("survivalStatus");
 const survivalDayPhase = document.getElementById("survivalDayPhase");
@@ -3260,20 +3267,15 @@ const survivalNewSeasonBtn = document.getElementById("survivalNewSeasonBtn");
 const survivalAdvanceBtn = document.getElementById("survivalAdvanceBtn");
 const survivalAutoRunBtn = document.getElementById("survivalAutoRunBtn");
 const survivalEndBtn = document.getElementById("survivalEndBtn");
-const survivalRosterBtn = document.getElementById("survivalRosterBtn");
 const survivalLogBtn = document.getElementById("survivalLogBtn");
-const survivalHideViewBtn = document.getElementById("survivalHideViewBtn");
-const survivalCollapseBtn = document.getElementById("survivalCollapseBtn");
-const survivalMiniBtn = document.getElementById("survivalMiniBtn");
 const survivalArenaBtn = document.getElementById("survivalArenaBtn");
+const survivalControlsBtn = document.getElementById("survivalControlsBtn");
 const survivalLobbyBtn = document.getElementById("survivalLobbyBtn");
 const survivalHistorySelect = document.getElementById("survivalHistorySelect");
-const survivalLogFeed = document.getElementById("survivalLogFeed");
-const survivalLogList = document.getElementById("survivalLogList");
 const survivalArena = document.getElementById("survivalArena");
 const survivalArenaGrid = document.getElementById("survivalArenaGrid");
 const survivalLobbyCount = document.getElementById("survivalLobbyCount");
-const survivalNewSeasonModal = document.getElementById("survivalNewSeasonModal");
+const survivalNewSeasonPanel = document.getElementById("survivalNewSeasonPanel");
 const survivalNewSeasonClose = document.getElementById("survivalNewSeasonClose");
 const survivalSeasonTitleInput = document.getElementById("survivalSeasonTitleInput");
 const survivalParticipantList = document.getElementById("survivalParticipantList");
@@ -3284,11 +3286,7 @@ const survivalNpcNames = document.getElementById("survivalNpcNames");
 const survivalFillSlots = document.getElementById("survivalFillSlots");
 const survivalSeasonStartBtn = document.getElementById("survivalSeasonStartBtn");
 const survivalSeasonMsg = document.getElementById("survivalSeasonMsg");
-const survivalRosterModal = document.getElementById("survivalRosterModal");
-const survivalRosterClose = document.getElementById("survivalRosterClose");
 const survivalRosterList = document.getElementById("survivalRosterList");
-const survivalLogModal = document.getElementById("survivalLogModal");
-const survivalLogClose = document.getElementById("survivalLogClose");
 const survivalLogModalList = document.getElementById("survivalLogModalList");
 const survivalLogLoadBtn = document.getElementById("survivalLogLoadBtn");
 
@@ -3297,26 +3295,64 @@ let voiceRec = { recorder: null, stream: null, chunks: [], startedAt: 0 };
 let dicePayoutOpen = false;
 
 
-// Survival UI can be collapsed to a small button (spectators can rely on system messages).
-let survivalUiCollapsed = false;
-try { survivalUiCollapsed = localStorage.getItem("survivalUiCollapsed") === "1"; } catch {}
+let survivalModalOpen = false;
+let survivalModalTab = "log";
 
-function setSurvivalUiCollapsed(collapsed) {
-  survivalUiCollapsed = !!collapsed;
-  try { localStorage.setItem("survivalUiCollapsed", survivalUiCollapsed ? "1" : "0"); } catch {}
-  const inRoom = isSurvivalRoom(currentRoom);
-  if (survivalPanel) survivalPanel.hidden = !inRoom || survivalUiCollapsed;
-  if (survivalMiniBtn) survivalMiniBtn.hidden = !inRoom || !survivalUiCollapsed;
-  // When collapsed, close expanded views; system messages remain visible in chat.
-  if (survivalUiCollapsed) {
-    survivalState.view = "none";
-  }
-  renderSurvivalPanel();
+function setSurvivalModalTab(tab){
+  const next = (tab === "map" || tab === "controls") ? tab : "log";
+  survivalModalTab = next;
+  survivalState.view = next;
+  if (survivalLogBtn) survivalLogBtn.classList.toggle("active", next === "log");
+  if (survivalArenaBtn) survivalArenaBtn.classList.toggle("active", next === "map");
+  if (survivalControlsBtn) survivalControlsBtn.classList.toggle("active", next === "controls");
+  document.querySelectorAll("[data-survival-view]").forEach((section) => {
+    section.classList.toggle("active", section.dataset.survivalView === next);
+    section.hidden = section.dataset.survivalView !== next;
+  });
 }
 
-// Wire collapse/expand controls
-survivalCollapseBtn?.addEventListener("click", () => setSurvivalUiCollapsed(!survivalUiCollapsed));
-survivalMiniBtn?.addEventListener("click", () => setSurvivalUiCollapsed(false));
+function openSurvivalModal(){
+  if (!survivalModal || !isSurvivalRoom(currentRoom)) return;
+  closeMemberMenu();
+  closeMembersAdminMenu();
+  closeThemesModal();
+  closeProfileSettingsMenu();
+  survivalModalOpen = true;
+  survivalModal.hidden = false;
+  survivalModal.style.display = "flex";
+  survivalModal.classList.remove("modal-closing");
+  lockBodyScroll(true);
+  setSurvivalModalTab(survivalModalTab);
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
+  renderSurvivalRoster();
+  renderSurvivalPanel();
+  if (PREFERS_REDUCED_MOTION) {
+    survivalModal.classList.add("modal-visible");
+  } else {
+    requestAnimationFrame(() => survivalModal.classList.add("modal-visible"));
+  }
+}
+
+function closeSurvivalModal(){
+  if (!survivalModal) return;
+  survivalModalOpen = false;
+  survivalModal.classList.remove("modal-visible");
+  closeSurvivalNewSeasonModal();
+  if (PREFERS_REDUCED_MOTION) {
+    survivalModal.style.display = "none";
+    survivalModal.classList.remove("modal-closing");
+    survivalModal.hidden = true;
+    lockBodyScroll(false);
+    return;
+  }
+  survivalModal.classList.add("modal-closing");
+  setTimeout(() => {
+    survivalModal.style.display = "none";
+    survivalModal.classList.remove("modal-closing");
+    survivalModal.hidden = true;
+    lockBodyScroll(false);
+  }, 180);
+}
 
 // On boot, hide dice-only UI unless we are already in the Dice Room.
 try {
@@ -3324,11 +3360,7 @@ try {
   if (diceVariantWrap) diceVariantWrap.style.display = nowDiceRoom ? "" : "none";
   if (luckMeter) luckMeter.style.display = nowDiceRoom ? "" : "none";
   const nowSurvivalRoom = isSurvivalRoom(currentRoom);
-  if (survivalPanel) survivalPanel.hidden = !nowSurvivalRoom || survivalUiCollapsed;
-  if (survivalMiniBtn) survivalMiniBtn.hidden = !nowSurvivalRoom || !survivalUiCollapsed;
-  // Expanded log/map views are optional; spectators can rely on system messages in chat.
-  if (survivalLogFeed) survivalLogFeed.hidden = !nowSurvivalRoom || survivalUiCollapsed || survivalState.view !== "log";
-  if (survivalArena) survivalArena.hidden = !nowSurvivalRoom || survivalUiCollapsed || survivalState.view !== "arena";
+  if (survivalOpenBtn) survivalOpenBtn.hidden = !nowSurvivalRoom;
 } catch {}
 
 function closeMediaMenu(){
@@ -3508,7 +3540,7 @@ function getSurvivalAliveCount() {
 }
 
 function renderSurvivalPanel() {
-  if (!survivalPanel) return;
+  if (!survivalSeasonTitle || !survivalStatus || !survivalDayPhase || !survivalAliveCount) return;
   const season = survivalState.season;
   const aliveCount = getSurvivalAliveCount();
   if (survivalSeasonTitle) survivalSeasonTitle.textContent = season ? season.title : "No season";
@@ -3526,25 +3558,14 @@ function renderSurvivalPanel() {
   }
   if (survivalAliveCount) survivalAliveCount.textContent = `Alive: ${aliveCount}`;
 
-  if (survivalCollapseBtn) {
-    survivalCollapseBtn.textContent = survivalUiCollapsed ? '▸' : '▾';
-    survivalCollapseBtn.setAttribute('aria-expanded', survivalUiCollapsed ? 'false' : 'true');
-  }
-
   if (survivalNewSeasonBtn) survivalNewSeasonBtn.disabled = !survivalIsOwner();
   if (survivalAdvanceBtn) survivalAdvanceBtn.disabled = !survivalIsOwner() || !season || season.status !== "running";
   if (survivalAutoRunBtn) survivalAutoRunBtn.disabled = !survivalIsOwner() || !season || season.status !== "running";
   if (survivalEndBtn) survivalEndBtn.disabled = !survivalIsOwner() || !season;
   if (survivalAutoRunBtn) survivalAutoRunBtn.textContent = survivalAutoRunning ? "Stop Auto" : "Auto-Run";
   updateSurvivalHistorySelect();
-
-  // View toggles
-  const nowSurvivalRoom = isSurvivalRoom(currentRoom);
-  const collapsed = !!survivalUiCollapsed;
-  if (survivalPanel) survivalPanel.hidden = !nowSurvivalRoom || collapsed;
-  if (survivalMiniBtn) survivalMiniBtn.hidden = !nowSurvivalRoom || !collapsed;
-  if (survivalLogFeed) survivalLogFeed.hidden = !nowSurvivalRoom || collapsed || survivalState.view !== "log";
-  if (survivalArena) survivalArena.hidden = !nowSurvivalRoom || collapsed || survivalState.view !== "arena";
+  if (survivalOpenBtn) survivalOpenBtn.hidden = !isSurvivalRoom(currentRoom);
+  setSurvivalModalTab(survivalModalTab);
 }
 
 function getSurvivalEventIcon(outcome = {}) {
@@ -3711,9 +3732,9 @@ function renderSurvivalArena() {
           if (ev?.outcome?.scope === "global") return true;
           return String(ev?.outcome?.zone || "").toLowerCase() === String(z).toLowerCase();
         });
-        renderSurvivalLog(survivalLogList, filtered);
+        renderSurvivalLog(survivalLogModalList, filtered);
       } else {
-        renderSurvivalLog(survivalLogList, survivalState.events);
+        renderSurvivalLog(survivalLogModalList, survivalState.events);
       }
     });
 
@@ -3772,7 +3793,7 @@ function renderSurvivalArena() {
       survivalState.arena = survivalState.arena || {};
       survivalState.arena.selectedZone = null;
       renderSurvivalArena();
-      renderSurvivalLog(survivalLogList, survivalState.events);
+      renderSurvivalLog(survivalLogModalList, survivalState.events);
     });
     detail.appendChild(buildZoneCard(selected));
   } else {
@@ -3871,12 +3892,13 @@ function applySurvivalPayload(payload, { replaceEvents = false } = {}) {
     survivalState.selectedSeasonId = payload.season.id;
   }
   renderSurvivalPanel();
-  renderSurvivalLog(survivalLogList, survivalState.events);
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
   renderSurvivalArena();
+  renderSurvivalRoster();
 }
 
 async function openSurvivalNewSeasonModal() {
-  if (!survivalNewSeasonModal) return;
+  if (!survivalNewSeasonPanel) return;
   if (!survivalIsOwner()) return toast("Only Owner/Co-Owner can start a season.");
   survivalSeasonMsg.textContent = "";
   const now = new Date();
@@ -3897,73 +3919,17 @@ async function openSurvivalNewSeasonModal() {
     row.innerHTML = `<input type="checkbox" value="${user.id}"/> ${escapeHtml(user.name)}`;
     survivalParticipantList.appendChild(row);
   });
-  survivalNewSeasonModal.hidden = false;
-  survivalNewSeasonModal.style.display = "flex";
-  survivalNewSeasonModal.classList.remove("modal-closing");
-  if (PREFERS_REDUCED_MOTION) {
-    survivalNewSeasonModal.classList.add("modal-visible");
-  } else {
-    requestAnimationFrame(() => survivalNewSeasonModal.classList.add("modal-visible"));
-  }
+  if (!survivalModalOpen) openSurvivalModal();
+  setSurvivalModalTab("controls");
+  survivalNewSeasonPanel.hidden = false;
+  requestAnimationFrame(() => {
+    try { survivalNewSeasonPanel.scrollIntoView({ block: "start", behavior: "smooth" }); } catch {}
+  });
 }
 
 function closeSurvivalNewSeasonModal() {
-  if (!survivalNewSeasonModal) return;
-  survivalNewSeasonModal.classList.remove("modal-visible");
-  survivalNewSeasonModal.classList.add("modal-closing");
-  setTimeout(() => {
-    survivalNewSeasonModal.style.display = "none";
-    survivalNewSeasonModal.classList.remove("modal-closing");
-    survivalNewSeasonModal.hidden = true;
-  }, 140);
-}
-
-function openSurvivalRosterModal() {
-  if (!survivalRosterModal) return;
-  renderSurvivalRoster();
-  survivalRosterModal.hidden = false;
-  survivalRosterModal.style.display = "flex";
-  survivalRosterModal.classList.remove("modal-closing");
-  if (PREFERS_REDUCED_MOTION) {
-    survivalRosterModal.classList.add("modal-visible");
-  } else {
-    requestAnimationFrame(() => survivalRosterModal.classList.add("modal-visible"));
-  }
-}
-
-function closeSurvivalRosterModal() {
-  if (!survivalRosterModal) return;
-  survivalRosterModal.classList.remove("modal-visible");
-  survivalRosterModal.classList.add("modal-closing");
-  setTimeout(() => {
-    survivalRosterModal.style.display = "none";
-    survivalRosterModal.classList.remove("modal-closing");
-    survivalRosterModal.hidden = true;
-  }, 140);
-}
-
-function openSurvivalLogModal() {
-  if (!survivalLogModal) return;
-  renderSurvivalLog(survivalLogModalList, survivalState.events);
-  survivalLogModal.hidden = false;
-  survivalLogModal.style.display = "flex";
-  survivalLogModal.classList.remove("modal-closing");
-  if (PREFERS_REDUCED_MOTION) {
-    survivalLogModal.classList.add("modal-visible");
-  } else {
-    requestAnimationFrame(() => survivalLogModal.classList.add("modal-visible"));
-  }
-}
-
-function closeSurvivalLogModal() {
-  if (!survivalLogModal) return;
-  survivalLogModal.classList.remove("modal-visible");
-  survivalLogModal.classList.add("modal-closing");
-  setTimeout(() => {
-    survivalLogModal.style.display = "none";
-    survivalLogModal.classList.remove("modal-closing");
-    survivalLogModal.hidden = true;
-  }, 140);
+  if (!survivalNewSeasonPanel) return;
+  survivalNewSeasonPanel.hidden = true;
 }
 
 async function startSurvivalSeason() {
@@ -4335,6 +4301,7 @@ const dmSettingsBtn = document.getElementById("dmSettingsBtn");
 const likeProfileBtn = document.getElementById("likeProfileBtn");
 const profileEditBtn = document.getElementById("profileEditBtn");
 const profileSettingsBtn = document.getElementById("profileSettingsBtn");
+const profileSettingsMenu = document.getElementById("profileSettingsMenu");
 const likeCount = document.getElementById("likeCount");
 const profileLikeMsg = document.getElementById("profileLikeMsg");
 const leaderboardXp = document.getElementById("leaderboardXp");
@@ -6953,18 +6920,23 @@ async function purchaseTheme(themeId){
 }
 function openThemesModal(){
   if (!themesModal) return;
+  closeSurvivalModal();
+  closeMemberMenu();
+  closeProfileSettingsMenu();
   themeRecents = loadThemeRecents();
   themeSelectedId = themeIdFromName(currentTheme);
   updateThemePreview(themeSelectedId);
   renderThemeCatalog();
   themesModal.classList.add("show");
   themesModal.setAttribute("aria-hidden", "false");
+  lockBodyScroll(true);
 }
 function closeThemesModal(){
   themesModal?.classList.remove("show");
   themesModal?.setAttribute("aria-hidden", "true");
   closeThemeActionSheet();
   closeThemesFiltersSheet();
+  lockBodyScroll(false);
 }
 function openThemesFiltersSheet(){
   themesFiltersSheet?.classList.add("show");
@@ -8100,6 +8072,19 @@ function positionMemberMenu() {
     return;
   }
 
+  const useSheet = window.matchMedia("(max-width: 640px)").matches;
+  memberMenu.classList.toggle("sheet", useSheet);
+  if (useSheet) {
+    memberMenu.style.left = "12px";
+    memberMenu.style.right = "12px";
+    memberMenu.style.top = "auto";
+    memberMenu.style.bottom = `calc(12px + env(safe-area-inset-bottom))`;
+    memberMenu.style.visibility = "";
+    return;
+  }
+  memberMenu.style.right = "";
+  memberMenu.style.bottom = "";
+
   const anchorRect = memberMenuAnchor.getBoundingClientRect();
   const viewport = window.visualViewport;
   const viewportWidth = viewport?.width ?? window.innerWidth;
@@ -8152,6 +8137,49 @@ function closeMemberMenu(){
   }
 }
 
+function canModerateMember(user){
+  if (!user || !me?.role) return false;
+  const targetRole = user?.role || "User";
+  if (roleRank(me.role) < roleRank("Moderator")) return false;
+  return roleRank(me.role) > roleRank(targetRole);
+}
+
+async function runMemberModAction(action){
+  const target = (memberMenuUsername || memberMenuUser?.username || memberMenuUser?.name || "").trim();
+  if (!target) return;
+  const reason = prompt(`Reason for ${action} ${target}:`, "") || "";
+  const cleaned = reason.trim();
+  if (!cleaned) return;
+  if (!confirmModeration(action, target)) return;
+  if (action === "kick") {
+    const durationSeconds = Number(quickKickSeconds?.value || 300);
+    const resp = await emitModWithAck("mod kick", { username: target, reason: cleaned, durationSeconds });
+    if (!resp?.ok) return toast?.(resp?.error || "Kick failed.");
+    showToast(`Kicked ${target} for ${formatDurationLabel({ seconds: durationSeconds })}`, {
+      actionLabel: "Undo",
+      actionFn: () => undoWithAck("mod unkick", { username: target }),
+      durationMs: 5200
+    });
+    return;
+  }
+  if (action === "mute") {
+    const minutes = Number(quickMuteMins?.value || 10);
+    const resp = await emitModWithAck("mod mute", { username: target, minutes, reason: cleaned });
+    if (!resp?.ok) return toast?.(resp?.error || "Mute failed.");
+    showToast(`Muted ${target}`, {
+      actionLabel: "Undo",
+      actionFn: () => undoWithAck("mod unmute", { username: target, reason: "Undo mute" }),
+      durationMs: 5200
+    });
+    return;
+  }
+  if (action === "ban") {
+    const minutes = Number(quickBanMins?.value || 0);
+    const resp = await emitModWithAck("mod ban", { username: target, minutes, reason: cleaned });
+    if (!resp?.ok) return toast?.(resp?.error || "Ban failed.");
+  }
+}
+
 
 // ---- Member quick-actions menu buttons
 memberViewProfileBtn?.addEventListener("click", ()=>{
@@ -8181,14 +8209,30 @@ memberReferBtn?.addEventListener("click", ()=>{
   });
   closeMemberMenu();
 });
+memberKickBtn?.addEventListener("click", async () => {
+  await runMemberModAction("kick");
+  closeMemberMenu();
+});
+memberMuteBtn?.addEventListener("click", async () => {
+  await runMemberModAction("mute");
+  closeMemberMenu();
+});
+memberBanBtn?.addEventListener("click", async () => {
+  await runMemberModAction("ban");
+  closeMemberMenu();
+});
+memberLogsBtn?.addEventListener("click", async () => {
+  const target = (memberMenuUsername || memberMenuUser?.username || memberMenuUser?.name || "").trim();
+  if (!target) return;
+  closeMemberMenu();
+  await openMyProfile();
+  setTab("actions");
+  if (logUser) logUser.value = target;
+  await refreshLogs();
+});
 
 function openMemberMenu(user, anchor){
-  if (!memberMenu || !membersPane) {
-    // Fallback if the quick-actions menu is unavailable
-    const uname = user?.username || user?.name || "";
-    if (uname) openMemberProfile(uname);
-    return;
-  }
+  if (!memberMenu || !membersPane) return;
 
   const anchorEl = anchor?.querySelector(".mName") || anchor;
   if (memberMenu.classList.contains("open") && memberMenuAnchor === anchorEl) {
@@ -8204,7 +8248,15 @@ function openMemberMenu(user, anchor){
     const isSelf = (memberMenuUsername && me?.username && memberMenuUsername.toLowerCase()===me.username.toLowerCase());
     memberReferBtn.style.display = (!isSelf && (me?.role==="Moderator")) ? "inline-flex" : "none";
   }
-  if (memberMenuName) memberMenuName.textContent = `${roleIcon(user.role)} ${user.name}`;
+  if (memberModSection) {
+    const canMod = canModerateMember(user);
+    memberModSection.style.display = canMod ? "flex" : "none";
+    if (memberLogsBtn) memberLogsBtn.style.display = canMod && !!logUser ? "inline-flex" : "none";
+  }
+  if (memberMenuName) {
+    const displayName = user?.name || user?.username || memberMenuUsername || "";
+    memberMenuName.textContent = `${roleIcon(user.role)} ${displayName}`.trim();
+  }
   memberMenu.classList.add("open");
   scheduleMemberMenuPosition();
 }
@@ -10545,6 +10597,22 @@ profileEditToggleBtn?.addEventListener("click", () => {
   if (!currentProfileIsSelf) return;
   setProfileEditMode(!profileEditMode);
 });
+function closeProfileSettingsMenu(){
+  if (!profileSettingsMenu) return;
+  profileSettingsMenu.hidden = true;
+  profileSettingsBtn?.setAttribute("aria-expanded", "false");
+}
+function openProfileSettingsMenu(){
+  if (!profileSettingsMenu) return;
+  closeMemberMenu();
+  profileSettingsMenu.hidden = false;
+  profileSettingsBtn?.setAttribute("aria-expanded", "true");
+}
+function toggleProfileSettingsMenu(){
+  if (!profileSettingsMenu) return;
+  if (profileSettingsMenu.hidden) openProfileSettingsMenu();
+  else closeProfileSettingsMenu();
+}
 profileSettingsBtn?.addEventListener("click", async () => {
   if (!currentProfileIsSelf) {
     if (modalTargetUsername) {
@@ -10553,9 +10621,26 @@ profileSettingsBtn?.addEventListener("click", async () => {
     }
     return;
   }
+  toggleProfileSettingsMenu();
+});
+profileSettingsMenu?.addEventListener("click", async (e) => {
+  const btn = e.target?.closest?.("[data-profile-menu]");
+  if (!btn) return;
+  const action = btn.dataset.profileMenu;
+  closeProfileSettingsMenu();
+  if (action === "themes") {
+    openThemesModal();
+    return;
+  }
   setTab("customize");
   try { syncSoundPrefsUI(true); } catch {}
   await loadChatFxPrefs({ force: true });
+});
+document.addEventListener("click", (e) => {
+  if (!profileSettingsMenu || profileSettingsMenu.hidden) return;
+  if (profileSettingsMenu.contains(e.target)) return;
+  if (profileSettingsBtn?.contains(e.target)) return;
+  closeProfileSettingsMenu();
 });
 
 roomChessBtn?.addEventListener("click", () => {
@@ -11116,6 +11201,9 @@ function hardHideProfileModal(){
 // modal open/close
 function openModal(){
   if (!modal) return;
+  closeSurvivalModal();
+  closeMemberMenu();
+  closeProfileSettingsMenu();
   logProfileModal("openModal");
   modal.style.display="flex";
   modal.classList.remove("modal-closing");
@@ -11141,6 +11229,7 @@ function closeModal(){
   modalTargetUserId=null;
   setProfileEditMode(false);
   setCustomizePage(null);
+  closeProfileSettingsMenu();
   quickModMsg.textContent="";
   modMsg.textContent="";
   logsMsg.textContent="";
@@ -11195,6 +11284,9 @@ function undockCouplesFromModal(){
 
 function openCouplesModal(){
   if (!couplesModal) return;
+  closeSurvivalModal();
+  closeMemberMenu();
+  closeProfileSettingsMenu();
   const ok = dockCouplesIntoModal();
   if (!ok) {
     toast?.("Open your profile first to use Couples.");
@@ -11249,14 +11341,14 @@ document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && roomCreateModal && roomCreateModal.style.display !== "none") {
     closeRoomCreateModal();
   }
-  if (e.key === "Escape" && survivalNewSeasonModal && survivalNewSeasonModal.style.display !== "none") {
+  if (e.key === "Escape" && profileSettingsMenu && !profileSettingsMenu.hidden) {
+    closeProfileSettingsMenu();
+  }
+  if (e.key === "Escape" && survivalNewSeasonPanel && !survivalNewSeasonPanel.hidden) {
     closeSurvivalNewSeasonModal();
   }
-  if (e.key === "Escape" && survivalRosterModal && survivalRosterModal.style.display !== "none") {
-    closeSurvivalRosterModal();
-  }
-  if (e.key === "Escape" && survivalLogModal && survivalLogModal.style.display !== "none") {
-    closeSurvivalLogModal();
+  if (e.key === "Escape" && survivalModal && survivalModal.style.display !== "none") {
+    closeSurvivalModal();
   }
 });
 
@@ -11265,30 +11357,25 @@ modal.addEventListener("click", (e)=>{ if(e.target===modal) closeModal(); });
 
 survivalNewSeasonBtn?.addEventListener("click", openSurvivalNewSeasonModal);
 survivalNewSeasonClose?.addEventListener("click", closeSurvivalNewSeasonModal);
-survivalNewSeasonModal?.addEventListener("click", (e) => {
-  if (e.target === survivalNewSeasonModal) closeSurvivalNewSeasonModal();
+survivalOpenBtn?.addEventListener("click", openSurvivalModal);
+survivalModalClose?.addEventListener("click", closeSurvivalModal);
+survivalModal?.addEventListener("click", (e) => {
+  if (e.target === survivalModal) closeSurvivalModal();
 });
 survivalSeasonStartBtn?.addEventListener("click", startSurvivalSeason);
 survivalAdvanceBtn?.addEventListener("click", advanceSurvivalSeason);
 survivalEndBtn?.addEventListener("click", endSurvivalSeason);
-survivalRosterBtn?.addEventListener("click", openSurvivalRosterModal);
-survivalRosterClose?.addEventListener("click", closeSurvivalRosterModal);
-survivalRosterModal?.addEventListener("click", (e) => {
-  if (e.target === survivalRosterModal) closeSurvivalRosterModal();
-});
-survivalLogBtn?.addEventListener("click", (e) => {
-  survivalState.view = "log";
-  renderSurvivalPanel();
-  if (e?.shiftKey) openSurvivalLogModal();
+survivalLogBtn?.addEventListener("click", () => {
+  setSurvivalModalTab("log");
+  renderSurvivalLog(survivalLogModalList, survivalState.events);
 });
 survivalArenaBtn?.addEventListener("click", () => {
-  survivalState.view = "arena";
-  renderSurvivalPanel();
+  setSurvivalModalTab("map");
   renderSurvivalArena();
 });
-survivalLogClose?.addEventListener("click", closeSurvivalLogModal);
-survivalLogModal?.addEventListener("click", (e) => {
-  if (e.target === survivalLogModal) closeSurvivalLogModal();
+survivalControlsBtn?.addEventListener("click", () => {
+  setSurvivalModalTab("controls");
+  renderSurvivalRoster();
 });
 survivalLogLoadBtn?.addEventListener("click", loadOlderSurvivalLog);
 survivalLobbyBtn?.addEventListener("click", async () => {
@@ -11321,13 +11408,6 @@ survivalHistorySelect?.addEventListener("change", async (e) => {
   renderSurvivalLog(survivalLogModalList, survivalState.events);
   renderSurvivalRoster();
 });
-// Allow viewers to close the expanded log/map UI (system messages remain in chat).
-survivalHideViewBtn?.addEventListener("click", () => {
-  survivalState.view = "none";
-  renderSurvivalPanel();
-});
-
-
 // rooms
 function setActiveRoom(room){
   const wasDiceRoom = isDiceRoom(currentRoom);
@@ -11335,6 +11415,8 @@ function setActiveRoom(room){
   currentRoom = room;
   setRoomEvent(null);
   closeMembersAdminMenu();
+  closeMemberMenu();
+  closeProfileSettingsMenu();
   const nowDiceRoom = isDiceRoom(room);
   const nowSurvivalRoom = isSurvivalRoom(room);
   document.body.classList.toggle("dice-room", nowDiceRoom);
@@ -11347,22 +11429,17 @@ function setActiveRoom(room){
   // Ensure room-specific UI doesn't leak into other rooms.
   if (diceVariantWrap) diceVariantWrap.style.display = nowDiceRoom ? "" : "none";
   if (luckMeter) luckMeter.style.display = nowDiceRoom ? "" : "none";
-  if (survivalPanel) survivalPanel.hidden = !nowSurvivalRoom || survivalUiCollapsed;
-  if (survivalMiniBtn) survivalMiniBtn.hidden = !nowSurvivalRoom || !survivalUiCollapsed;
-  if (survivalLogFeed) survivalLogFeed.hidden = !nowSurvivalRoom || survivalUiCollapsed || survivalState.view !== "log";
-  if (survivalArena) survivalArena.hidden = !nowSurvivalRoom || survivalUiCollapsed || survivalState.view !== "arena";
+  if (survivalOpenBtn) survivalOpenBtn.hidden = !nowSurvivalRoom;
+  if (!nowSurvivalRoom) {
+    closeSurvivalModal();
+    closeSurvivalNewSeasonModal();
+  }
   // If a modal is open that is built around room/profile context, close it when switching rooms.
   try {
     if (couplesModal && couplesModal.style.display && couplesModal.style.display !== "none") closeCouplesModal();
   } catch {}
   try {
-    if (survivalRosterModal && survivalRosterModal.style.display && survivalRosterModal.style.display !== "none") closeSurvivalRosterModal();
-  } catch {}
-  try {
-    if (survivalLogModal && survivalLogModal.style.display && survivalLogModal.style.display !== "none") closeSurvivalLogModal();
-  } catch {}
-  try {
-    if (survivalNewSeasonModal && survivalNewSeasonModal.style.display && survivalNewSeasonModal.style.display !== "none") closeSurvivalNewSeasonModal();
+    if (survivalModal && survivalModal.style.display && survivalModal.style.display !== "none" && !nowSurvivalRoom) closeSurvivalModal();
   } catch {}
 
 
@@ -15760,6 +15837,7 @@ function syncProfileEditUi(){
 
 function updateProfileActions({ isSelf = false, canModerate = false } = {}){
   // Quick "Edit profile" button now lives in the top quick-actions row.
+  if (!isSelf) closeProfileSettingsMenu();
   if (profileEditToggleBtn) profileEditToggleBtn.style.display = isSelf ? "" : "none";
   if (profileEditToggleRow) profileEditToggleRow.style.display = "none";
   applyCustomizeVisibility();
@@ -15794,7 +15872,7 @@ function updateProfileActions({ isSelf = false, canModerate = false } = {}){
     profileEditBtn.style.display = "none";
   }
   if (profileSettingsBtn) {
-    profileSettingsBtn.style.display = "none";
+    profileSettingsBtn.style.display = isSelf ? "" : "none";
   }
   syncProfileEditUi();
   updateMemoryVisibility();
@@ -17599,10 +17677,7 @@ initAppealsDurationSelect();
     if (!payload || payload.seasonId !== survivalState.season?.id) return;
     if (!Array.isArray(payload.events)) return;
     survivalState.events = [...survivalState.events, ...payload.events];
-    renderSurvivalLog(survivalLogList, survivalState.events);
-    if (survivalLogModal && survivalLogModal.style.display !== "none") {
-      renderSurvivalLog(survivalLogModalList, survivalState.events);
-    }
+    renderSurvivalLog(survivalLogModalList, survivalState.events);
   });
 
   socket.on("survival:lobby", (payload = {}) => {

--- a/public/index.html
+++ b/public/index.html
@@ -335,6 +335,7 @@
 <button class="iconBtn withBadge" id="groupDmToggleBtn" title="Group DMs" type="button">👥<span class="notifDot" id="groupDmBadgeDot" title="New group DMs"></span></button>
 <button aria-label="Notifications" class="iconBtn withBadge" id="notificationsBtn" title="Notifications" type="button">🔔<span class="notifDot" id="notificationsDot" title="New notifications"></span></button>
 <button class="iconBtn" id="roomChessBtn" title="Chess Table" type="button">♟</button>
+<button class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" type="button">Open Simulator</button>
 <button class="iconBtn mobOnly" id="openMembersBtn" title="Members" type="button">👥</button>
 </div>
 </div>
@@ -404,63 +405,96 @@
 </div>
 </div>
 </div>
-<div class="modal" hidden="" id="survivalNewSeasonModal">
-<div class="modalCard survivalModal">
-<div class="modalTop">
-<strong>New Survival Season</strong>
+<div class="modal" hidden="" id="survivalModal">
+<div class="modalCard survivalModal survivalModalShell">
+<div class="modalTop survivalModalTop">
+<div class="survivalModalHeading">
+<strong>Survival Simulator</strong>
+<div class="survivalModalMeta">
+<span class="survivalModalSeason" id="survivalSeasonTitle">No season</span>
+<span class="survivalModalStatus" id="survivalStatus">No season</span>
+<span class="survivalModalPhase" id="survivalDayPhase">Day 1 — Day</span>
+<span class="survivalModalAlive" id="survivalAliveCount">Alive: 0</span>
+</div>
+</div>
+<button aria-label="Close" class="iconBtn" id="survivalModalClose" type="button">✕</button>
+</div>
+<div class="survivalModalTabs">
+<button class="pillBtn active" id="survivalLogBtn" type="button">Log</button>
+<button class="pillBtn" id="survivalArenaBtn" type="button">Map</button>
+<button class="pillBtn" id="survivalControlsBtn" type="button">Controls</button>
+</div>
+<div class="modalBody survivalModalBody">
+<section class="survivalModalSection" data-survival-view="log">
+<div class="survivalLogHeaderRow">
+<button class="btn secondary small" id="survivalLogLoadBtn" type="button">Load older</button>
+<label class="survivalHistoryLabel">History
+<select id="survivalHistorySelect"></select>
+</label>
+</div>
+<div class="survivalLogList" id="survivalLogModalList"></div>
+</section>
+<section class="survivalModalSection" data-survival-view="map" hidden>
+<div class="survivalArena" id="survivalArena">
+<div class="survivalArenaHeader">
+<span class="survivalArenaTitle">Arena Map</span>
+<span class="small muted" id="survivalLobbyCount"></span>
+</div>
+<div class="survivalArenaGrid" id="survivalArenaGrid"></div>
+</div>
+</section>
+<section class="survivalModalSection" data-survival-view="controls" hidden>
+<div class="survivalPanelControls">
+<div class="survivalPanelGroup">
+<button class="btn secondary small" id="survivalNewSeasonBtn" type="button">New Season</button>
+<button class="btn secondary small" id="survivalAdvanceBtn" type="button">Advance</button>
+<button class="btn secondary small" id="survivalAutoRunBtn" type="button">Auto-Run</button>
+<button class="btn secondary small" id="survivalEndBtn" type="button">Reset/End</button>
+</div>
+<div class="survivalPanelGroup">
+<button class="btn secondary small" id="survivalLobbyBtn" type="button">Opt-in</button>
+</div>
+</div>
+<div class="survivalNewSeasonPanel" hidden id="survivalNewSeasonPanel">
+<div class="survivalPanelHeader">
+<div class="survivalPanelTitle">
+<span class="survivalPanelName">New Survival Season</span>
+<span class="small muted">Set up a fresh run.</span>
+</div>
+<div class="survivalPanelMeta">
 <button aria-label="Close" class="iconBtn" id="survivalNewSeasonClose" type="button">✕</button>
 </div>
-<div class="modalBody">
+</div>
 <label class="fieldLabel">Title
   <input id="survivalSeasonTitleInput" maxlength="120" placeholder="Season — ..." type="text"/>
 </label>
 <div class="survivalPicker">
-  <div class="survivalPickerModes">
-    <label><input checked="" name="survivalPickMode" type="radio" value="online"/> Everyone online</label>
-    <label><input name="survivalPickMode" type="radio" value="select"/> Select users</label>
-  </div>
-  <div class="survivalParticipantList" id="survivalParticipantList"></div>
+<div class="survivalPickerModes">
+<label><input checked="" name="survivalPickMode" type="radio" value="online"/> Everyone online</label>
+<label><input name="survivalPickMode" type="radio" value="select"/> Select users</label>
+</div>
+<div class="survivalParticipantList" id="survivalParticipantList"></div>
 </div>
 <div class="survivalOptions">
-  <label><input id="survivalCouplesToggle" type="checkbox"/> Include Couples synergy</label>
-  <label><input id="survivalChaosToggle" type="checkbox"/> Chaotic mode</label>
-  <label><input id="survivalLobbyToggle" type="checkbox"/> Include lobby signups</label>
-  <div class="survivalNpcFields">
-    <label class="small muted">Custom names (one per line... and set fill slots to auto-top-up)</label>
-    <textarea id="survivalNpcNames" placeholder="e.g.\nKat\nPeeta\nRue" rows="4"></textarea>
-    <div class="survivalNpcRow">
-      <label class="small muted">Fill slots (0 = no auto fill)</label>
-      <input id="survivalFillSlots" type="number" min="0" max="48" value="0"/>
-    </div>
-  </div>
+<label><input id="survivalCouplesToggle" type="checkbox"/> Include Couples synergy</label>
+<label><input id="survivalChaosToggle" type="checkbox"/> Chaotic mode</label>
+<label><input id="survivalLobbyToggle" type="checkbox"/> Include lobby signups</label>
+<div class="survivalNpcFields">
+<label class="small muted">Custom names (one per line... and set fill slots to auto-top-up)</label>
+<textarea id="survivalNpcNames" placeholder="e.g.\nKat\nPeeta\nRue" rows="4"></textarea>
+<div class="survivalNpcRow">
+<label class="small muted">Fill slots (0 = no auto fill)</label>
+<input id="survivalFillSlots" type="number" min="0" max="48" value="0"/>
+</div>
+</div>
 </div>
 <div class="modalActions">
-  <button class="btn" id="survivalSeasonStartBtn" type="button">Start</button>
+<button class="btn" id="survivalSeasonStartBtn" type="button">Start</button>
 </div>
 <div class="small muted" id="survivalSeasonMsg"></div>
 </div>
-</div>
-</div>
-<div class="modal" hidden="" id="survivalRosterModal">
-<div class="modalCard survivalModal">
-<div class="modalTop">
-<strong>Survival Roster</strong>
-<button aria-label="Close" class="iconBtn" id="survivalRosterClose" type="button">✕</button>
-</div>
-<div class="modalBody">
 <div class="survivalRosterList" id="survivalRosterList"></div>
-</div>
-</div>
-</div>
-<div class="modal" hidden="" id="survivalLogModal">
-<div class="modalCard survivalModal">
-<div class="modalTop">
-<strong>Survival Log</strong>
-<button aria-label="Close" class="iconBtn" id="survivalLogClose" type="button">✕</button>
-</div>
-<div class="modalBody">
-<button class="btn secondary small" id="survivalLogLoadBtn" type="button">Load older</button>
-<div class="survivalLogList" id="survivalLogModalList"></div>
+</section>
 </div>
 </div>
 </div>
@@ -473,53 +507,6 @@
   <div aria-label="Luck meter" class="luckMeterBar" id="luckMeterBar" role="meter" aria-valuemin="-2.0" aria-valuemax="0.30" aria-valuenow="0">
     <span class="luckMeterBarText" id="luckMeterBarText">|------------^------------|</span>
   </div>
-</div>
-<div class="survivalPanel" hidden="" id="survivalPanel">
-  <div class="survivalPanelHeader">
-    <div class="survivalPanelTitle">
-      <span class="survivalPanelName">Survival Simulator</span>
-      <span class="survivalPanelSeasonTitle" id="survivalSeasonTitle">No season</span>
-      <span class="survivalPanelStatus" id="survivalStatus">No season</span>
-    </div>
-    <div class="survivalPanelMeta">
-      <span class="survivalPanelPhase" id="survivalDayPhase">Day 1 — Day</span>
-      <span class="survivalPanelAlive" id="survivalAliveCount">Alive: 0</span>
-      <button class="iconBtn survivalCollapseBtn" id="survivalCollapseBtn" type="button" aria-label="Collapse survival UI">▾</button>
-    </div>
-  </div>
-  <div class="survivalPanelControls">
-    <div class="survivalPanelGroup">
-      <button class="btn secondary small" id="survivalNewSeasonBtn" type="button">New Season</button>
-      <button class="btn secondary small" id="survivalAdvanceBtn" type="button">Advance</button>
-      <button class="btn secondary small" id="survivalAutoRunBtn" type="button">Auto-Run</button>
-      <button class="btn secondary small" id="survivalEndBtn" type="button">Reset/End</button>
-    </div>
-    <div class="survivalPanelGroup">
-      <button class="btn secondary small" id="survivalLobbyBtn" type="button">Opt-in</button>
-      <button class="btn secondary small" id="survivalRosterBtn" type="button">View Roster</button>
-      <button class="btn secondary small" id="survivalLogBtn" type="button">View Log</button>
-      <button class="btn secondary small" id="survivalArenaBtn" type="button">Arena</button>
-      <button class="btn secondary small" id="survivalHideViewBtn" type="button">Hide</button>
-      <label class="survivalHistoryLabel">History
-        <select id="survivalHistorySelect"></select>
-      </label>
-    </div>
-  </div>
-<div class="survivalArena" hidden id="survivalArena">
-    <div class="survivalArenaHeader">
-      <span class="survivalArenaTitle">Arena Map</span>
-      <span class="small muted" id="survivalLobbyCount"></span>
-    </div>
-    <div class="survivalArenaGrid" id="survivalArenaGrid"></div>
-  </div>
-</div>
-
-<!-- Small minimized survival button (spectators can rely on system messages) -->
-<button class="survivalMiniBtn" id="survivalMiniBtn" type="button" hidden aria-label="Open survival UI">⚔️ Survival</button>
-
-<div class="survivalLogFeed" hidden="" id="survivalLogFeed">
-  <div class="survivalLogHeader">Recent Log</div>
-  <div class="survivalLogList" id="survivalLogList"></div>
 </div>
 <div class="msgs" id="msgs"></div>
 <div class="typing" id="typing"></div>
@@ -616,6 +603,15 @@
 <button class="btn secondary" id="memberViewProfileBtn" type="button">View profile</button>
 <button class="btn" id="memberDmBtn" type="button">DM</button>
 <button class="btn secondary" id="memberReferBtn" style="display:none;" type="button">Refer ban</button>
+<div class="memberMenuSection" id="memberModSection" style="display:none;">
+<div class="memberMenuSectionTitle">Moderation</div>
+<div class="memberMenuSectionActions">
+<button class="btn secondary" id="memberKickBtn" type="button">Kick</button>
+<button class="btn secondary" id="memberMuteBtn" type="button">Mute</button>
+<button class="btn danger" id="memberBanBtn" type="button">Ban</button>
+<button class="btn secondary" id="memberLogsBtn" type="button">View logs</button>
+</div>
+</div>
 
 <div class="menuSection" data-menu-section="daily">
   <div class="menuSectionHeader">
@@ -789,7 +785,13 @@
 </div>
 <div class="profileHeaderActions">
 <button aria-label="Edit profile" class="iconBtn smallIcon" id="profileEditBtn" style="display:none;" title="Edit profile" type="button">✏️</button>
-<button aria-label="Preferences" class="iconBtn smallIcon" id="profileSettingsBtn" style="display:none;" title="Preferences" type="button">⚙️</button>
+<div class="profileSettingsWrap" id="profileSettingsWrap">
+<button aria-label="Preferences" aria-expanded="false" aria-haspopup="menu" class="iconBtn smallIcon" id="profileSettingsBtn" style="display:none;" title="Preferences" type="button">⚙️</button>
+<div class="profileSettingsMenu" hidden id="profileSettingsMenu" role="menu">
+<button class="profileSettingsItem" data-profile-menu="customize" role="menuitem" type="button">Customize</button>
+<button class="profileSettingsItem" data-profile-menu="themes" role="menuitem" type="button">Themes</button>
+</div>
+</div>
 <button aria-label="Moderation actions" class="iconBtn smallIcon" id="actionsBtn" style="display:none;" title="Moderation actions" type="button">🛡️</button>
 <button aria-label="Close profile" class="iconBtn smallIcon" id="closeModalBtn" type="button">✕</button>
 </div>
@@ -1131,12 +1133,6 @@
 <div class="cardTitle">Chat &amp; Identity</div>
 <div class="cardHint">Bubbles, fonts, name color, and message text.</div>
 <div class="cardPreview chatPreview"></div>
-</button>
-
-<button class="customizeCard" data-category="themes" data-search="themes theme appearance preview apply palette" id="openThemesModalBtn" type="button">
-<div class="cardTitle">Themes</div>
-<div class="cardHint">Browse, preview, and apply themes.</div>
-<div class="cardPreview themesPreview"></div>
 </button>
 
 <button class="customizeCard" data-category="profile" data-search="profile appearance header gradient avatar aura" type="button">

--- a/public/styles.css
+++ b/public/styles.css
@@ -2698,6 +2698,70 @@ body.survival-room .survivalPanel{
   gap:8px 12px;
 }
 
+.survivalOpenBtn{
+  white-space:nowrap;
+}
+.survivalModalShell{
+  width:min(1100px, 100%);
+  max-height:calc(100vh - env(safe-area-inset-top) - env(safe-area-inset-bottom));
+}
+.survivalModalTop{
+  display:flex;
+  align-items:flex-start;
+  justify-content:space-between;
+  gap:12px;
+}
+.survivalModalHeading{
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+}
+.survivalModalMeta{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  font-size:12px;
+  color:var(--muted);
+}
+.survivalModalTabs{
+  display:flex;
+  gap:8px;
+  padding:0 16px 12px;
+  border-bottom:1px solid var(--line);
+  flex-wrap:wrap;
+}
+.survivalModalBody{
+  overflow:auto;
+  display:flex;
+  flex-direction:column;
+  gap:16px;
+}
+.survivalModalSection{
+  display:none;
+  flex-direction:column;
+  gap:12px;
+  min-height:0;
+}
+.survivalModalSection.active{
+  display:flex;
+}
+.survivalLogHeaderRow{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  flex-wrap:wrap;
+}
+.survivalNewSeasonPanel{
+  border:1px solid var(--border);
+  border-radius:16px;
+  padding:12px;
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+  background:color-mix(in srgb, var(--panel) 92%, transparent);
+}
+
 .survivalCollapseBtn{ margin-left:auto; }
 
 /* Mini collapsed button shown at the very top when survival UI is collapsed */
@@ -3889,6 +3953,38 @@ body:not(.polish-pack) .tonePicker{
 .memberMenuName{ font-weight:900; }
 .memberMenuActions{ display:flex; gap:8px; flex-wrap:wrap; }
 .memberMenuActions .btn{ flex:1; }
+.memberMenuSection{
+  width:100%;
+  display:flex;
+  flex-direction:column;
+  gap:6px;
+  border-top:1px solid var(--border);
+  padding-top:8px;
+  margin-top:4px;
+}
+.memberMenuSectionTitle{
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:0.06em;
+  color:var(--muted);
+  font-weight:700;
+}
+.memberMenuSectionActions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+}
+.memberMenuSectionActions .btn{ flex:1; }
+
+@media (max-width: 640px){
+  .memberMenu.sheet{
+    left:12px !important;
+    right:12px !important;
+    top:auto !important;
+    bottom:calc(12px + env(safe-area-inset-bottom));
+    max-width:calc(100vw - 24px);
+  }
+}
 
 /* Modal/Profile */
 #modal{
@@ -3908,6 +4004,22 @@ body:not(.polish-pack) .tonePicker{
   z-index: 400;
 }
 #modal.modal-visible{ opacity: 1; }
+.modal{
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.55);
+  display: none;
+  align-items: flex-start;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  overflow: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  padding: calc(18px + env(safe-area-inset-top)) calc(18px + env(safe-area-inset-right)) calc(18px + env(safe-area-inset-bottom)) calc(18px + env(safe-area-inset-left));
+  z-index: 410;
+}
+.modal.modal-visible{ opacity: 1; }
 
 #couplesModal{
   position: fixed;
@@ -4889,6 +5001,39 @@ body.lockScroll{ overflow:hidden; }
 .adminDropdownItem:focus-visible{
   background: color-mix(in srgb, var(--accent) 18%, var(--panel));
   border-color: color-mix(in srgb, var(--accent) 40%, transparent);
+}
+.profileSettingsWrap{
+  position:relative;
+  display:inline-flex;
+}
+.profileSettingsMenu{
+  position:absolute;
+  top:calc(100% + 8px);
+  right:0;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:12px;
+  padding:6px;
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+  min-width:160px;
+  box-shadow:var(--shadowMd);
+  z-index:520;
+}
+.profileSettingsItem{
+  background:transparent;
+  border:1px solid transparent;
+  border-radius:10px;
+  padding:8px 10px;
+  text-align:left;
+  color:var(--text);
+  font-weight:600;
+}
+.profileSettingsItem:hover,
+.profileSettingsItem:focus-visible{
+  background:color-mix(in srgb, var(--panel2) 80%, transparent);
+  border-color:var(--borderStrong);
 }
 /* DM panel */
 .dmPanel{


### PR DESCRIPTION
### Motivation

- Consolidate scattered Survival Simulator popouts into a single, room-scoped modal to avoid UI bleed across rooms and simplify mobile UX.
- Replace scattered members actions with a contextual, anchored dropdown that includes moderation shortcuts for eligible staff and adapts to small screens.
- Surface theme customization from a compact profile settings dropdown and put the full picker inside the existing Themes modal, keeping overlays consistent.

### Description

- Replaced the old multi-modal survival UI with a single `#survivalModal` in `public/index.html` and added a topbar launcher `#survivalOpenBtn` visible only in the simulator room, plus tabbed sections for `Log`, `Map`, and `Controls` inside the modal (files changed: `public/index.html`, `public/styles.css`).
- Moved all existing simulator wiring into the modal: re-used existing renderers/handlers (log, arena, roster, season controls), ensured all socket emits / payload handling continue to use the room key, and updated calls to render the modal-scoped log list (`survivalLogModalList`) (file changed: `public/app.js`).
- Added modal lifecycle safety: `openSurvivalModal()` / `closeSurvivalModal()` lock/unlock background scroll, respect iOS safe-area insets, and auto-close on room switches so the simulator UI never bleeds into other rooms (file changed: `public/app.js`, `public/styles.css`).
- Reworked Members List quick-actions into a stable anchored menu that: adds a moderation section (`Kick`, `Mute`, `Ban`, `View logs`) shown only when `canModerateMember(user)` returns true (re-uses existing `emitModWithAck`/`confirmModeration` flows), adapts to mobile as a bottom-sheet (`.memberMenu.sheet`), and preserves previous profile/DM behavior (files changed: `public/index.html`, `public/app.js`, `public/styles.css`).
- Added a compact Profile Settings dropdown (`#profileSettingsMenu`) attached to the profile header with a `Themes` entry that opens the existing Themes modal; ensured opening these menus closes other overlays to prevent stacking and stuck overlays (file changed: `public/index.html`, `public/app.js`, `public/styles.css`).
- Minor UI/UX fixes: member-menu positioning respects small screens and safe-area insets, member menu name rendering is more robust, and existing theme application/persistence logic is reused (files changed: `public/app.js`, `public/styles.css`).

### Testing

- Dev server start: attempted `node server.js` and confirmed the server process runs and binds to the local port, but Postgres init failed (`ENOTFOUND`), so full end-to-end backend-backed UI tests could not complete; server printed `Server running on http://localhost:3000` (result: partial, Postgres error observed). 
- UI smoke via Playwright: ran a short Playwright script to load the site and exercise `#profileSettingsBtn`, but the run timed out (result: failed / timed out). 
- Unit / integration tests: none executed in this rollout (no test suite run).

Notes: automated attempts were limited by environment DB connectivity and the Playwright timeout; the client-side changes are intentionally incremental and reuse existing role checks, socket emit helpers, and theme logic to minimize risk to message, DM, dice, and profile flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972f8e8cde483338761059d4b035101)