### PR TITLE
Tighten survival simulator header, restore arena graphic, dedupe admin/profile UI, and fix touch handlers

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3741,7 +3741,15 @@ function renderSurvivalArena() {
     svg.appendChild(g);
   });
 
-  wrap.appendChild(svg);
+  const mapGraphic = document.createElement("div");
+  mapGraphic.className = "survivalMapGraphic";
+  const mapImg = document.createElement("img");
+  mapImg.src = "/arena/arena_map.png";
+  mapImg.alt = "Arena map";
+  mapImg.loading = "lazy";
+  mapGraphic.appendChild(mapImg);
+  mapGraphic.appendChild(svg);
+  wrap.appendChild(mapGraphic);
 
   // Zone detail list (either selected zone, or all zones as cards).
   const detail = document.createElement("div");
@@ -8761,6 +8769,20 @@ function toggleMembersAdminMenu(force){
   membersAdminMenu.hidden = !shouldOpen;
   membersAdminMenuBtn?.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
 }
+function bindTapAction(btn, handler){
+  if(!btn || typeof handler !== "function") return;
+  let touchActivated = false;
+  btn.addEventListener("pointerup", (e) => {
+    if (e.pointerType !== "touch") return;
+    touchActivated = true;
+    handler();
+    setTimeout(() => { touchActivated = false; }, 450);
+  });
+  btn.addEventListener("click", () => {
+    if (touchActivated) return;
+    handler();
+  });
+}
 
 function closeDrawers(){
   channelsPane?.classList.remove("open");
@@ -8854,11 +8876,11 @@ adminMenuRoleDebugBtn?.addEventListener("click", () => {
   closeMembersAdminMenu();
   openRoleDebugPanel();
 });
-adminMenuFeatureFlagsBtn?.addEventListener("click", () => {
+bindTapAction(adminMenuFeatureFlagsBtn, () => {
   closeMembersAdminMenu();
   openFeatureFlagsPanel();
 });
-adminMenuSessionsBtn?.addEventListener("click", () => {
+bindTapAction(adminMenuSessionsBtn, () => {
   closeMembersAdminMenu();
   openSessionsPanel();
 });
@@ -14060,8 +14082,10 @@ function renderLatestUpdateSnippet(){
     ? new Date(latestChangelogEntry.createdAt).toLocaleString()
     : "";
 
-  // Render a compact reactions row directly under the timestamp.
   if(latestUpdateReactions){
+    latestUpdateReactions.hidden = !latestUpdateExpanded;
+  }
+  if(latestUpdateReactions && latestUpdateExpanded){
     latestUpdateReactions.innerHTML = "";
     const reactions = normalizeChangelogReactions(latestChangelogEntry.reactions);
     const myReactions = normalizeMyChangelogReactions(latestChangelogEntry.myReactions);
@@ -15528,11 +15552,11 @@ function openSessionsPanel(){
 }
 
 function bindOwnerPanels(){
-  featureFlagsPanelBtn?.addEventListener("click", openFeatureFlagsPanel);
+  bindTapAction(featureFlagsPanelBtn, openFeatureFlagsPanel);
   featureFlagsCloseBtn?.addEventListener("click", closeFeatureFlagsPanel);
   featureFlagsReloadBtn?.addEventListener("click", loadFeatureFlags);
 
-  sessionsPanelBtn?.addEventListener("click", openSessionsPanel);
+  bindTapAction(sessionsPanelBtn, openSessionsPanel);
   sessionsCloseBtn?.addEventListener("click", closeSessionsPanel);
   sessionsReloadBtn?.addEventListener("click", loadSessions);
 }

--- a/public/index.html
+++ b/public/index.html
@@ -335,7 +335,7 @@
 <button class="iconBtn withBadge" id="groupDmToggleBtn" title="Group DMs" type="button">👥<span class="notifDot" id="groupDmBadgeDot" title="New group DMs"></span></button>
 <button aria-label="Notifications" class="iconBtn withBadge" id="notificationsBtn" title="Notifications" type="button">🔔<span class="notifDot" id="notificationsDot" title="New notifications"></span></button>
 <button class="iconBtn" id="roomChessBtn" title="Chess Table" type="button">♟</button>
-<button class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" type="button">Open Simulator</button>
+<button aria-label="Open Simulator" class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" title="Open Simulator" type="button">🧭</button>
 <button class="iconBtn mobOnly" id="openMembersBtn" title="Members" type="button">👥</button>
 </div>
 </div>
@@ -581,8 +581,6 @@
   <button class="adminDropdownItem" id="adminMenuFeatureFlagsBtn" type="button" role="menuitem">Flags</button>
   <button class="adminDropdownItem" id="adminMenuSessionsBtn" type="button" role="menuitem">Sessions</button>
 </div>
-<button class="btn secondary small legacyAdminBtn" hidden="" id="appealsPanelBtn" type="button">Appeals</button>
-<button class="btn secondary small legacyAdminBtn" hidden="" id="referralsPanelBtn" type="button">Referrals</button>
 <button class="btn secondary small legacyAdminBtn" hidden="" id="roleDebugPanelBtn" type="button">Role debug</button>
 <button class="btn secondary small legacyAdminBtn" hidden="" id="featureFlagsPanelBtn" type="button">Flags</button>
 <button class="btn secondary small legacyAdminBtn" hidden="" id="sessionsPanelBtn" type="button">Sessions</button>
@@ -785,13 +783,6 @@
 </div>
 <div class="profileHeaderActions">
 <button aria-label="Edit profile" class="iconBtn smallIcon" id="profileEditBtn" style="display:none;" title="Edit profile" type="button">✏️</button>
-<div class="profileSettingsWrap" id="profileSettingsWrap">
-<button aria-label="Preferences" aria-expanded="false" aria-haspopup="menu" class="iconBtn smallIcon" id="profileSettingsBtn" style="display:none;" title="Preferences" type="button">⚙️</button>
-<div class="profileSettingsMenu" hidden id="profileSettingsMenu" role="menu">
-<button class="profileSettingsItem" data-profile-menu="customize" role="menuitem" type="button">Customize</button>
-<button class="profileSettingsItem" data-profile-menu="themes" role="menuitem" type="button">Themes</button>
-</div>
-</div>
 <button aria-label="Moderation actions" class="iconBtn smallIcon" id="actionsBtn" style="display:none;" title="Moderation actions" type="button">🛡️</button>
 <button aria-label="Close profile" class="iconBtn smallIcon" id="closeModalBtn" type="button">✕</button>
 </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2700,6 +2700,13 @@ body.survival-room .survivalPanel{
 
 .survivalOpenBtn{
   white-space:nowrap;
+  min-width:32px;
+  width:32px;
+  height:32px;
+  padding:0;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
 }
 .survivalModalShell{
   width:min(1100px, 100%);
@@ -11122,13 +11129,25 @@ body[data-theme="Iris & Lola Neon"] .irisLolaDrawerEasterStar{
   gap:10px;
   margin-bottom:10px;
 }
-.survivalMapSvg{
+.survivalMapGraphic{
+  position:relative;
   width:100%;
   max-width:860px;
+}
+.survivalMapGraphic img{
+  display:block;
+  width:100%;
   height:auto;
   border-radius:14px;
   border:1px solid rgba(255,255,255,.12);
-  background:rgba(0,0,0,.14);
+}
+.survivalMapSvg{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  border-radius:14px;
+  background:rgba(0,0,0,.18);
 }
 .survivalMapZone rect{
   fill:rgba(255,255,255,.06);


### PR DESCRIPTION
### Motivation
- The Survival Simulator header was overcrowded by a long text button which pushed other controls and reduced usable space. 
- Appeals/Referrals were duplicated as visible pills while also present in the admin dropdown, and Sessions/Flag taps were unreliable on touch devices. 
- The simulator map rendered only text (no visual) and the changelog preview showed reactions in the compact preview, making list rows too tall. 

### Description
- Replace the text `Open Simulator` header button with an icon-only control and tighten its sizing to avoid crowding (`public/index.html`, `public/styles.css`).
- Render a graphic map behind the existing SVG overlay by inserting the arena image ` 2Farena/arena_map.png 2F` into the simulator map container while preserving the SVG zone overlays and interaction (`public/app.js`, `public/styles.css`).
- Remove redundant on-screen Appeals/Referrals legacy pills and remove the redundant profile gear menu markup from the profile modal header to reduce clutter (`public/index.html`).
- Hide changelog preview reactions in the compact snippet and only render/show them when the preview is expanded, reducing row height (`public/app.js`).
- Add a small `bindTapAction` helper that prioritizes touch (`pointerup`) then falls back to `click` to reliably open Flags/Sessions admin panels on mobile, and apply it to the relevant admin controls (`public/app.js`).

### Testing
- Attempted to start the server with `npm start`; the process launched but failed to fully initialize due to an external Postgres host DNS resolution error (`ENOTFOUND dpg-d58vamshg0os73c1revg-a`), so end-to-end runtime verification in this environment could not be completed. (failure)
- Static code changes were applied and committed to the repository (`git commit` succeeded). (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697307b4b22c8333b0de627f2aa4f039)