### PR TITLE
Harden system message routing and UI containment

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4,6 +4,7 @@
 window.__TAP_DEBUG__ = window.__TAP_DEBUG__ ?? false;
 const IS_IOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
 const PREFERS_REDUCED_MOTION = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+const IS_DEV = ["localhost", "127.0.0.1"].includes(window.location.hostname);
 const DELETE_ANIM_MS = PREFERS_REDUCED_MOTION ? 1 : 200;
 
 function safeJsonParse(raw, fallback) {
@@ -5937,26 +5938,6 @@ function isDiceResultSystemMessage(text){
 
 // ---- Room-scoped system message routing
 // Server can send { room, text } for room-scoped system messages.
-// Buffer off-room system messages so they don't appear in the wrong room.
-const pendingSystemByRoom = new Map(); // room -> Array<string>
-function bufferSystemForRoom(room, text){
-  const r = String(room || "").trim();
-  if(!r) return;
-  const arr = pendingSystemByRoom.get(r) || [];
-  arr.push(String(text ?? ""));
-  if(arr.length > 80) arr.splice(0, arr.length - 80);
-  pendingSystemByRoom.set(r, arr);
-}
-function flushBufferedSystem(room){
-  const r = String(room || "").trim();
-  if(!r) return;
-  const arr = pendingSystemByRoom.get(r);
-  if(!arr || !arr.length) return;
-  pendingSystemByRoom.delete(r);
-  for(const msg of arr){
-    addSystem(msg, { className: isDiceResultSystemMessage(msg) ? "diceResult" : "" });
-  }
-}
 
 function addSystem(text, options = {}){
   const div=document.createElement("div");
@@ -11485,6 +11466,13 @@ function setActiveRoom(room){
     renderLuckMeter();
     requestLuckState();
   }
+  try {
+    if (nowDiceRoom) {
+      mountDiceFx();
+    } else {
+      unmountDiceFx();
+    }
+  } catch {}
   if (wasSurvivalRoom && !nowSurvivalRoom) {
     stopSurvivalAutoRun();
   }
@@ -11546,7 +11534,6 @@ function joinRoom(room){
 
   setActiveRoom(room);
   clearMsgs();
-  try { flushBufferedSystem(room); } catch(_){ }
   socket?.emit("join room", { room, status: normalizeStatusLabel(statusSelect.value, "Online") });
   closeDrawers();
 }
@@ -17940,6 +17927,11 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
       : "";
     const room = (String(rawRoom || "").startsWith("#")) ? String(rawRoom || "").slice(1) : String(rawRoom || "");
     const meta = (payload && typeof payload === "object") ? (payload.meta || null) : null;
+    const scope = (payload && typeof payload === "object") ? String(payload.scope || "") : "";
+
+    if (IS_DEV && !room && !scope) {
+      console.warn("[system] Missing roomId or scope", payload);
+    }
 
     // Extra safety: certain system kinds must ONLY ever render in their dedicated rooms.
     // If a server-side misroute happens, this prevents "bleed" into other rooms.
@@ -17952,16 +17944,13 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
     // Global system messages should ONLY render when explicitly marked.
     // This prevents accidental room bleed if something is emitted with room="__global__".
     if (room === "__global__") {
-      if (meta && typeof meta === "object" && meta.kind === "global") {
+      if ((meta && typeof meta === "object" && meta.kind === "global") || scope === "global") {
         addSystem(text, { className: isDiceResultSystemMessage(text) ? "diceResult" : "" });
       }
       return;
     }
     if (!room) return;
-    if (room !== currentRoom) {
-      bufferSystemForRoom(room, text);
-      return;
-    }
+    if (room !== currentRoom) return;
 
     addSystem(text, { className: isDiceResultSystemMessage(text) ? "diceResult" : "" });
   });
@@ -17988,11 +17977,25 @@ socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
   confettiLayer.id = "confettiLayer";
   confettiLayer.style.display = "none";
 
-  // attach overlays to chat area
-  const chatMain = document.querySelector("main.chat") || document.getElementById("chatMain") || document.body;
-  chatMain.style.position = chatMain.style.position || "relative";
-  chatMain.appendChild(diceOverlay);
-  chatMain.appendChild(confettiLayer);
+  let diceFxMounted = false;
+  function mountDiceFx(){
+    if (diceFxMounted) return;
+    const chatMain = document.querySelector("main.chat") || document.getElementById("chatMain") || document.body;
+    chatMain.style.position = chatMain.style.position || "relative";
+    if (!chatMain.contains(diceOverlay)) chatMain.appendChild(diceOverlay);
+    if (!chatMain.contains(confettiLayer)) chatMain.appendChild(confettiLayer);
+    diceFxMounted = true;
+  }
+  function unmountDiceFx(){
+    if (!diceFxMounted) return;
+    diceOverlay.style.display = "none";
+    confettiLayer.style.display = "none";
+    confettiLayer.innerHTML = "";
+    restoreDiceOverlayLift();
+    diceOverlay.remove();
+    confettiLayer.remove();
+    diceFxMounted = false;
+  }
 
   function restoreDiceOverlayLift(){
     try {

--- a/public/styles.css
+++ b/public/styles.css
@@ -2565,6 +2565,12 @@ body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + e
   align-self:center; color:var(--messageSystemText); font-size:12px;
   padding:6px 10px; border-radius:999px;
   background:var(--messageSystemBg); border:1px solid var(--border);
+  max-width:min(90%, 640px);
+  overflow-wrap:anywhere;
+  word-break:break-word;
+  margin:2px 0;
+  position:relative;
+  z-index:2;
 }
 
 .dmMessages,

--- a/server.js
+++ b/server.js
@@ -320,7 +320,7 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
   //
   // For room-scoped system messages, we now emit an explicit payload
   // { room, text, meta? } so the client can route it correctly.
-  function buildSystemPayload(room, text, meta) {
+  function buildSystemPayload(room, text, meta, scope) {
     const ts = Date.now();
     const payload = {
       id: `sys-${ts}-${Math.random().toString(36).slice(2, 8)}`,
@@ -329,6 +329,8 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
       type: "system",
       text: String(text ?? ""),
     };
+    const resolvedScope = String(scope || (payload.room === "__global__" ? "global" : (payload.room ? "room" : "")));
+    if (resolvedScope) payload.scope = resolvedScope;
     if (meta && typeof meta === "object") payload.meta = meta;
     return payload;
   }
@@ -336,7 +338,7 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
   function emitRoomSystem(room, text, meta) {
     const r = typeof room === "string" ? room : "";
     if (!r) return;
-    const payload = buildSystemPayload(r, text, meta);
+    const payload = buildSystemPayload(r, text, meta, "room");
     // IMPORTANT: Some historical code paths can leave a socket joined to a room
     // even after its "currentRoom" changes (e.g., legacy "#room" mismatches or
     // reconnect races). If we emit to the Socket.IO room directly, those stale
@@ -364,7 +366,7 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
     // safely ignore accidental global emissions (prevents room bleed).
     const m = (meta && typeof meta === "object") ? { ...meta } : {};
     if (!m.kind) m.kind = "global";
-    const payload = buildSystemPayload("__global__", text, m);
+    const payload = buildSystemPayload("__global__", text, m, "global");
     io.emit("system", payload);
     if (DEBUG_ROOMS) {
       console.log("[rooms] system emit", { room: "__global__", text: payload.text, meta: payload.meta || null });


### PR DESCRIPTION
### Motivation

- Prevent system messages from bleeding into unrelated rooms by making routing explicit and client-side guarded.
- Ensure dice/survival/mod action system messages render only in their dedicated rooms and global announcements require explicit marking.
- Contain system message visuals so they don't overlap the composer, escape scroll containers, or sit above modals.
- Mount dice FX only when the user is in the Dice Room so FX/toasts cannot block inputs in other rooms.

### Description

- Server: added an explicit `scope` field to `buildSystemPayload` and pass `"room"`/`"global"` from `emitRoomSystem`/`emitGlobalSystem` so payloads carry unambiguous routing info (`server.js`).
- Client: stopped buffering/off-room message re-insertion and now drop system messages that do not match `currentRoom`, added a dev-only `console.warn` when a message arrives without `room` or `scope`, and require either `meta.kind === "global"` or `scope === "global"` for global rendering (`public/app.js`).
- Dice FX: added `mountDiceFx` / `unmountDiceFx` and wire them into `setActiveRoom` so dice overlay and confetti are only attached when `currentRoom` is the Dice Room and fully removed on room change (`public/app.js`).
- Styles: tightened `.sys` styling with `max-width`, `overflow-wrap`, `word-break`, margins and z-index to keep system messages inside the message list and below modals (`public/styles.css`).

### Testing

- Started the app with `npm start`; the HTTP server bound to `http://localhost:3000` successfully but Postgres initialization logged an external `ENOTFOUND` (DB host unreachable) warning—server remained up for local UI checks.
- Ran a Playwright script that loaded `http://localhost:3000` and produced a screenshot artifact `artifacts/system-message-polish.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735b2091688333a4f6fc91918677a6)