### PR TITLE
Survival arena: canonical zone names + overlay alignment; Members admin modal fixes; room structure persistence reload

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -3607,7 +3607,7 @@ function renderSurvivalLog(targetEl, events) {
     icon.textContent = getSurvivalEventIcon(event.outcome || {});
     const text = document.createElement("div");
     text.className = "survivalLogText";
-    const zone = event?.outcome?.zone || null;
+    const zone = normalizeSurvivalZoneName(event?.outcome?.zone) || null;
     const scope = event?.outcome?.scope || null;
     const baseText = event.text || "";
     text.innerHTML = applyMentions(baseText, { linkifyText: false });
@@ -3626,15 +3626,41 @@ function renderSurvivalLog(targetEl, events) {
 }
 
 const SURVIVAL_ARENA_ZONES = [
-  "Open Field",
   "Pine Woods",
-  "Rocky Ridge",
-  "Ruins",
-  "River Bend",
-  "Caves",
-  "Swamp",
-  "Cornucopia",
+  "Old Ruins",
+  "Ridge",
+  "Shimmer Lake",
+  "Central Plaza",
+  "Cave Mouth",
+  "Mossy Swamp",
+  "Supply Drop Zone",
 ];
+const SURVIVAL_ZONE_ALIASES = new Map([
+  ["open field", "Central Plaza"],
+  ["rocky ridge", "Ridge"],
+  ["ruins", "Old Ruins"],
+  ["river bend", "Shimmer Lake"],
+  ["caves", "Cave Mouth"],
+  ["swamp", "Mossy Swamp"],
+  ["cornucopia", "Supply Drop Zone"],
+  ["pine woods", "Pine Woods"],
+  ["old ruins", "Old Ruins"],
+  ["ridge", "Ridge"],
+  ["shimmer lake", "Shimmer Lake"],
+  ["central plaza", "Central Plaza"],
+  ["cave mouth", "Cave Mouth"],
+  ["mossy swamp", "Mossy Swamp"],
+  ["supply drop zone", "Supply Drop Zone"],
+]);
+
+function normalizeSurvivalZoneName(zone) {
+  const raw = String(zone || "").trim();
+  if (!raw) return null;
+  const key = raw.toLowerCase();
+  if (SURVIVAL_ZONE_ALIASES.has(key)) return SURVIVAL_ZONE_ALIASES.get(key);
+  const direct = SURVIVAL_ARENA_ZONES.find((z) => z.toLowerCase() === key);
+  return direct || raw;
+}
 
 function renderSurvivalArena() {
   if (!survivalArenaGrid) return;
@@ -3643,13 +3669,13 @@ function renderSurvivalArena() {
   const byZone = new Map();
   zones.forEach((z)=>byZone.set(z, []));
   participants.forEach((p) => {
-    const zRaw = (p?.location || "Open Field").toString();
-    const z = zones.find((n) => n.toLowerCase() === zRaw.toLowerCase()) || "Open Field";
+    const zRaw = normalizeSurvivalZoneName(p?.location) || SURVIVAL_ARENA_ZONES[0];
+    const z = zones.find((n) => n.toLowerCase() === zRaw.toLowerCase()) || SURVIVAL_ARENA_ZONES[0];
     byZone.get(z).push(p);
   });
 
   // Selected zone for inspecting + filtering.
-  const selected = survivalState?.arena?.selectedZone || null;
+  const selected = normalizeSurvivalZoneName(survivalState?.arena?.selectedZone) || null;
 
   const dangerLevels = survivalState.arena?.dangerLevels || {};
   const zoneMeta = zones.map((z) => {
@@ -3665,20 +3691,21 @@ function renderSurvivalArena() {
   const wrap = document.createElement("div");
   wrap.className = "survivalMapWrap";
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  svg.setAttribute("viewBox", "0 0 400 220");
+  svg.setAttribute("viewBox", "0 0 1536 1024");
   svg.setAttribute("class", "survivalMapSvg");
   svg.setAttribute("role", "img");
   svg.setAttribute("aria-label", "Arena map");
+  svg.setAttribute("preserveAspectRatio", "xMidYMid meet");
 
   const layout = [
-    { z: "Pine Woods", x: 20, y: 20, w: 140, h: 70 },
-    { z: "Rocky Ridge", x: 170, y: 20, w: 120, h: 70 },
-    { z: "Ruins", x: 300, y: 20, w: 80, h: 70 },
-    { z: "River Bend", x: 20, y: 100, w: 150, h: 60 },
-    { z: "Open Field", x: 180, y: 100, w: 120, h: 60 },
-    { z: "Cornucopia", x: 310, y: 100, w: 70, h: 60 },
-    { z: "Caves", x: 20, y: 170, w: 180, h: 40 },
-    { z: "Swamp", x: 210, y: 170, w: 170, h: 40 },
+    { z: "Pine Woods", x: 70, y: 130, w: 520, h: 250 },
+    { z: "Old Ruins", x: 560, y: 170, w: 500, h: 230 },
+    { z: "Ridge", x: 1080, y: 170, w: 400, h: 230 },
+    { z: "Shimmer Lake", x: 70, y: 380, w: 520, h: 280 },
+    { z: "Central Plaza", x: 540, y: 370, w: 520, h: 300 },
+    { z: "Cave Mouth", x: 1040, y: 470, w: 450, h: 270 },
+    { z: "Mossy Swamp", x: 150, y: 680, w: 540, h: 260 },
+    { z: "Supply Drop Zone", x: 620, y: 740, w: 650, h: 220 },
   ];
 
   layout.forEach((cell) => {
@@ -3877,21 +3904,47 @@ async function loadSurvivalSeason(seasonId, { beforeId = null } = {}) {
 }
 
 function applySurvivalPayload(payload, { replaceEvents = false } = {}) {
+  const normalizeZone = (zone) => normalizeSurvivalZoneName(zone) || zone;
   if (payload.season) survivalState.season = payload.season;
-  if (Array.isArray(payload.participants)) survivalState.participants = payload.participants;
+  if (Array.isArray(payload.participants)) {
+    survivalState.participants = payload.participants.map((p) => ({
+      ...p,
+      location: normalizeZone(p?.location),
+    }));
+  }
   if (Array.isArray(payload.alliances)) survivalState.alliances = payload.alliances;
   if (payload.winner !== undefined) survivalState.winner = payload.winner;
   if (Array.isArray(payload.history)) survivalState.history = payload.history;
   if (Array.isArray(payload.events)) {
+    const normalizedEvents = payload.events.map((ev) => {
+      const outcome = ev?.outcome && typeof ev.outcome === "object"
+        ? { ...ev.outcome, zone: normalizeZone(ev.outcome.zone) }
+        : ev?.outcome;
+      return { ...ev, outcome };
+    });
     if (replaceEvents) {
-      survivalState.events = payload.events;
+      survivalState.events = normalizedEvents;
     } else {
-      survivalState.events = [...payload.events];
+      survivalState.events = [...normalizedEvents];
     }
     survivalState.logBeforeId = payload.events?.[0]?.id || survivalState.logBeforeId;
   }
   if (payload.arena && typeof payload.arena === "object") {
-    survivalState.arena = payload.arena;
+    const arenaZones = Array.isArray(payload.arena.zones)
+      ? payload.arena.zones.map((z) => normalizeZone(z)).filter(Boolean)
+      : null;
+    const dangerLevels = payload.arena.dangerLevels && typeof payload.arena.dangerLevels === "object"
+      ? Object.entries(payload.arena.dangerLevels).reduce((acc, [key, val]) => {
+        const normalized = normalizeZone(key) || key;
+        acc[normalized] = val;
+        return acc;
+      }, {})
+      : payload.arena.dangerLevels;
+    survivalState.arena = {
+      ...payload.arena,
+      zones: arenaZones || payload.arena.zones,
+      dangerLevels,
+    };
     if (Array.isArray(payload.arena.lobbyUserIds)) {
       survivalState.lobbyUserIds = payload.arena.lobbyUserIds.map((x) => Number(x)).filter((x) => x > 0);
     }
@@ -8772,14 +8825,29 @@ function toggleMembersAdminMenu(force){
 function bindTapAction(btn, handler){
   if(!btn || typeof handler !== "function") return;
   let touchActivated = false;
+  const markTouch = () => {
+    touchActivated = true;
+    setTimeout(() => { touchActivated = false; }, 450);
+  };
+  const run = () => {
+    handler();
+    markTouch();
+  };
   btn.addEventListener("pointerup", (e) => {
     if (e.pointerType !== "touch") return;
-    touchActivated = true;
-    handler();
-    setTimeout(() => { touchActivated = false; }, 450);
-  });
-  btn.addEventListener("click", () => {
+    e.preventDefault();
+    e.stopPropagation();
+    run();
+  }, { passive: false });
+  btn.addEventListener("touchend", (e) => {
+    e.preventDefault();
+    e.stopPropagation();
     if (touchActivated) return;
+    run();
+  }, { passive: false });
+  btn.addEventListener("click", (e) => {
+    if (touchActivated) return;
+    e.preventDefault();
     handler();
   });
 }
@@ -15430,12 +15498,27 @@ function getHeaderGradientInputValues(){
 }
 
 function closeFeatureFlagsPanel(){
-  if(featureFlagsPanel) featureFlagsPanel.hidden = true;
+  if(featureFlagsPanel){
+    featureFlagsPanel.hidden = true;
+    featureFlagsPanel.style.display = "";
+    featureFlagsPanel.classList.remove("open");
+  }
   if(featureFlagsMsg) featureFlagsMsg.textContent = "";
 }
 function closeSessionsPanel(){
-  if(sessionsPanel) sessionsPanel.hidden = true;
+  if(sessionsPanel){
+    sessionsPanel.hidden = true;
+    sessionsPanel.style.display = "";
+    sessionsPanel.classList.remove("open");
+  }
   if(sessionsMsg) sessionsMsg.textContent = "";
+}
+
+function forceShowOwnerPanel(panel){
+  if(!panel) return;
+  panel.hidden = false;
+  panel.style.display = "flex";
+  panel.classList.add("open");
 }
 
 async function loadFeatureFlags(){
@@ -15507,7 +15590,7 @@ function renderFeatureFlagsGrid(){
 
 function openFeatureFlagsPanel(){
   if(!me || roleRank(me.role) < roleRank("Owner")) return;
-  if(featureFlagsPanel) featureFlagsPanel.hidden = false;
+  forceShowOwnerPanel(featureFlagsPanel);
   loadFeatureFlags();
 }
 
@@ -15547,7 +15630,7 @@ function renderSessions(rows){
 
 function openSessionsPanel(){
   if(!me || roleRank(me.role) < roleRank("Owner")) return;
-  if(sessionsPanel) sessionsPanel.hidden = false;
+  forceShowOwnerPanel(sessionsPanel);
   loadSessions();
 }
 
@@ -17758,7 +17841,9 @@ window.addEventListener("online", () => {
   }
 });
 socket.on("roomStructure:update", (payload)=>setRoomStructure(payload, { updateCollapse: false }));
-socket.on("rooms update", (rooms)=>renderRoomsList(rooms));
+socket.on("rooms update", () => {
+  loadRooms();
+});
   socket.on("changelog updated", ()=>{
     changelogDirty = true;
     if(rightPanelMode === "menu" && activeMenuTab === "changelog") loadChangelog(true);

--- a/public/index.html
+++ b/public/index.html
@@ -581,9 +581,6 @@
   <button class="adminDropdownItem" id="adminMenuFeatureFlagsBtn" type="button" role="menuitem">Flags</button>
   <button class="adminDropdownItem" id="adminMenuSessionsBtn" type="button" role="menuitem">Sessions</button>
 </div>
-<button class="btn secondary small legacyAdminBtn" hidden="" id="roleDebugPanelBtn" type="button">Role debug</button>
-<button class="btn secondary small legacyAdminBtn" hidden="" id="featureFlagsPanelBtn" type="button">Flags</button>
-<button class="btn secondary small legacyAdminBtn" hidden="" id="sessionsPanelBtn" type="button">Sessions</button>
 <button class="iconBtn smallIcon" id="membersCloseBtn" title="Close" type="button">✕</button>
 </div>
 <div aria-live="polite" class="memberGold" id="memberGold"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -9182,11 +9182,12 @@ body.comfortMode[data-theme="Iris & Lola Neon"] .chat::after{
 .ownerPanel{
   position: fixed;
   inset: 0;
-  z-index: 9999;
+  z-index: 10000;
   display: flex;
   flex-direction: column;
   background: rgba(0,0,0,0.70);
   backdrop-filter: blur(10px);
+  pointer-events: auto;
 }
 .ownerPanelHeader{
   display:flex;

--- a/server.js
+++ b/server.js
@@ -5136,19 +5136,45 @@ function sanitizeDisplayName(name) {
 
 // Must match the client arena map zone labels.
 const SURVIVAL_ZONES = [
-  "Open Field",
   "Pine Woods",
-  "Rocky Ridge",
-  "Ruins",
-  "River Bend",
-  "Caves",
-  "Swamp",
-  "Cornucopia",
+  "Old Ruins",
+  "Ridge",
+  "Shimmer Lake",
+  "Central Plaza",
+  "Cave Mouth",
+  "Mossy Swamp",
+  "Supply Drop Zone",
 ];
+const SURVIVAL_ZONE_ALIASES = new Map([
+  ["open field", "Central Plaza"],
+  ["rocky ridge", "Ridge"],
+  ["ruins", "Old Ruins"],
+  ["river bend", "Shimmer Lake"],
+  ["caves", "Cave Mouth"],
+  ["swamp", "Mossy Swamp"],
+  ["cornucopia", "Supply Drop Zone"],
+  ["pine woods", "Pine Woods"],
+  ["old ruins", "Old Ruins"],
+  ["ridge", "Ridge"],
+  ["shimmer lake", "Shimmer Lake"],
+  ["central plaza", "Central Plaza"],
+  ["cave mouth", "Cave Mouth"],
+  ["mossy swamp", "Mossy Swamp"],
+  ["supply drop zone", "Supply Drop Zone"],
+]);
+
+function normalizeSurvivalZoneName(zone) {
+  const raw = String(zone || "").trim();
+  if (!raw) return null;
+  const key = raw.toLowerCase();
+  if (SURVIVAL_ZONE_ALIASES.has(key)) return SURVIVAL_ZONE_ALIASES.get(key);
+  const direct = SURVIVAL_ZONES.find((z) => z.toLowerCase() === key);
+  return direct || raw;
+}
 
 function pickSurvivalSpawnLocation(rng) {
   const fn = typeof rng === "function" ? rng : () => Math.random();
-  return SURVIVAL_ZONES[Math.floor(fn() * SURVIVAL_ZONES.length)] || "central";
+  return SURVIVAL_ZONES[Math.floor(fn() * SURVIVAL_ZONES.length)] || SURVIVAL_ZONES[0];
 }
 
 function buildSurvivalSeedPayload(seed, options) {
@@ -5265,13 +5291,17 @@ function normalizeSurvivalParticipantRow(row) {
     inventory: Array.isArray(row.inventory) ? row.inventory : safeJsonParse(row.inventory_json || "[]", []),
     traits: row.traits || safeJsonParse(row.traits_json || "{}", {}),
     last_event_at: row.last_event_at ? Number(row.last_event_at) : null,
-    location: row.location || null,
+    location: normalizeSurvivalZoneName(row.location) || null,
     created_at: row.created_at ? Number(row.created_at) : null,
   };
 }
 
 function normalizeSurvivalEventRow(row) {
   if (!row) return null;
+  const outcome = safeJsonParse(row.outcome_json || "{}", {});
+  if (outcome && outcome.zone) {
+    outcome.zone = normalizeSurvivalZoneName(outcome.zone) || outcome.zone;
+  }
   return {
     id: Number(row.id),
     season_id: Number(row.season_id),
@@ -5280,7 +5310,7 @@ function normalizeSurvivalEventRow(row) {
     order_index: Number(row.order_index),
     text: row.text,
     involved_user_ids: safeJsonParse(row.involved_user_ids_json || "[]", []),
-    outcome: safeJsonParse(row.outcome_json || "{}", {}),
+    outcome,
     created_at: row.created_at ? Number(row.created_at) : null,
   };
 }
@@ -5677,7 +5707,7 @@ function pickZoneFromAlive(alive, rng){
   // Prefer zones that currently have people (so the map feels alive).
   const counts = new Map();
   for(const p of alive){
-    const z = String(p.location || SURVIVAL_ZONES[0]);
+    const z = normalizeSurvivalZoneName(p.location) || SURVIVAL_ZONES[0];
     counts.set(z, (counts.get(z) || 0) + 1);
   }
   const weighted = Array.from(counts.entries()).map(([zone, c]) => ({ zone, weight: Math.max(1, c) }));
@@ -5698,7 +5728,7 @@ function maybeGenerateArenaEvent({ season, participants, rng, now }) {
   const zone = scope === "zone" ? pickZoneFromAlive(alive, rng) : null;
 
   const population = scope === "zone"
-    ? alive.filter((p) => String(p.location || SURVIVAL_ZONES[0]).toLowerCase() === String(zone || "").toLowerCase())
+    ? alive.filter((p) => normalizeSurvivalZoneName(p.location) === normalizeSurvivalZoneName(zone))
     : alive;
 
   if (!population.length) return null;
@@ -8668,7 +8698,7 @@ function buildSurvivalArenaPayload(season, participants = []) {
   const dangerLevels = {};
   for (const z of SURVIVAL_ZONES) {
     // 0–5, lightly influenced by population + RNG (purely cosmetic for now).
-    const pop = participants.filter((p) => p.alive && String(p.location || "").toLowerCase() === String(z).toLowerCase()).length;
+    const pop = participants.filter((p) => p.alive && normalizeSurvivalZoneName(p.location) === z).length;
     const base = clamp(Math.round(rng() * 3) + (pop ? 1 : 0), 0, 5);
     dangerLevels[z] = base;
   }
@@ -9106,6 +9136,9 @@ app.post("/api/survival/seasons/:id/advance", survivalLimiter, requireCoOwner, e
 
   const participants = await fetchSurvivalParticipants(seasonId);
   const alliances = await fetchSurvivalAlliances(seasonId);
+  participants.forEach((p) => {
+    p.location = normalizeSurvivalZoneName(p.location) || SURVIVAL_ZONES[0];
+  });
   const alive = participants.filter((p) => p.alive);
   if (alive.length <= 1) {
     season.status = "finished";
@@ -9218,7 +9251,9 @@ app.post("/api/survival/seasons/:id/advance", survivalLimiter, requireCoOwner, e
 
     // Attach a best-guess zone for this event so the arena map can filter/animate.
     try {
-      const zones = (selectedParticipants || []).map((p) => String(p.location || "")).filter(Boolean);
+      const zones = (selectedParticipants || [])
+        .map((p) => normalizeSurvivalZoneName(p.location))
+        .filter(Boolean);
       const zone = zones.length
         ? zones
             .sort(
@@ -9227,7 +9262,7 @@ app.post("/api/survival/seasons/:id/advance", survivalLimiter, requireCoOwner, e
             )
             .pop()
         : null;
-      if (zone) outcome.zone = zone;
+      if (zone) outcome.zone = normalizeSurvivalZoneName(zone) || zone;
     } catch {}
 
     orderIndex += 1;


### PR DESCRIPTION
### Motivation
- Make Survival Simulator arena zones match the arena image labels exactly and keep old data working by mapping legacy zone names to canonical labels.
- Ensure the SVG overlay lines up with the background image so tappable regions reliably target the correct zones (desktop + iOS).
- Simplify Members header to a single Admin control and make Owner panels (Flags / Sessions) reliably open on mobile Safari by improving tap handling and stacking.
- Treat the DB as the source-of-truth for rooms and reload room structure on updates so category/room ordering persists across logins.

### Description
- Replaced the survival zone lists with the canonical labels in `server.js` and `public/app.js` and added a legacy alias map (`SURVIVAL_ZONE_ALIASES`) plus `normalizeSurvivalZoneName()` to normalize legacy values to canonical names.
- Applied normalization everywhere server-side where locations are read/written: participant rows, event outcomes, arena population/danger calculations, spawn selection, and during season advance so stored values use canonical names.
- Updated client `public/app.js` to normalize incoming survival payloads in `applySurvivalPayload`, normalize event/outcome zones, and normalize participant locations before render.
- Reworked the arena overlay in `public/app.js`: changed SVG `viewBox` to `0 0 1536 1024`, added `preserveAspectRatio`, and replaced the rectangle layout with the provided approximate coordinates so each clickable zone sits over the correct region; labels use canonical names.
- Hardened owner admin panels and mobile taps: improved `bindTapAction()` to use `pointerup`/`touchend` with preventDefault/stopPropagation and a touch debounce to avoid lost taps on iOS, and added `forceShowOwnerPanel()` + safer open/close logic so Feature Flags and Sessions reliably show above overlays; updated owner panel CSS z-index and `pointer-events` to prevent being hidden behind overlays.
- Removed legacy top-row Members buttons from `public/index.html` so the Members header shows only the Admin dropdown and close button.
- Changed the socket handler for room updates in `public/app.js` to call `loadRooms()` instead of simply rendering an array, ensuring the client reloads the authoritative DB-backed room structure (preserves masters/categories/room ordering).
- Small supporting changes: normalized zone lookups in map filtering/selection and ensured arena payload dangerLevels/zones are normalized before applying to client state.

### Testing
- Launched the server with `npm start`; server came up and began listening on http://localhost:3000, but Postgres initialization failed in this environment due to DNS resolution for the configured PG host (`ENOTFOUND dpg-...`); server fallback and start proceeded (noted as a warning), so runtime changes were exercised where possible (start succeeded). (Succeeded with Postgres init warning)
- Attempted an automated UI smoke run via Playwright to register/login and open the Members drawer; the script timed out waiting for the app to reach the post-login state in this environment, so the end-to-end UI check could not be completed. (Timed out / failed)
- No other automated tests were added or executed; code was exercised by starting the Node process and verifying no immediate syntax/runtime exceptions prevented boot aside from the external Postgres connectivity issue. (Partial)

If you want, I can follow up with a focused browser test against a fully-local DB (or adjust env to point to a reachable Postgres) and capture screenshots of the updated arena overlay and Members drawer on desktop and an iOS-like viewport.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69735acdde408333a8dfe5fed6dba1bd)