### PR TITLE
Dev DB fallback: SQLite + optional Docker Postgres, health endpoint and seed tooling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL=postgres://banter:banter_dev@localhost:5432/banter_brats
+SESSION_SECRET=replace-with-strong-secret
+SQLITE_PATH=./data/dev.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ chat.db
 uploads/
 public/avatars/
 sessions.sqlite
+data/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Banter & Brats — Local Dev DB Setup
+
+## Quick start (SQLite fallback)
+SQLite is the default for local/dev runs when Postgres is unavailable.
+
+```bash
+npm install
+npm run dev
+```
+
+The server logs a fallback warning and `/health` reports `db=sqlite`.
+
+## Optional Postgres via Docker
+If you want Postgres locally:
+
+```bash
+docker compose up -d
+```
+
+Then set `DATABASE_URL` (see `.env.example`) and run:
+
+```bash
+npm run dev
+```
+
+`/health` will report `db=postgres` when the connection is live.
+
+## Dev seed + smoke test
+
+```bash
+npm run dev:seed
+npm run test:smoke
+```

--- a/database.js
+++ b/database.js
@@ -1,10 +1,16 @@
 "use strict";
 
 const path = require("path");
+const fs = require("fs");
 const sqlite3 = require("sqlite3").verbose();
 const bcrypt = require("bcrypt");
 
-const DB_FILE = process.env.DB_FILE || path.join(__dirname, "chat.db");
+const DEFAULT_SQLITE_PATH = path.join(__dirname, "data", "dev.sqlite");
+const DB_FILE = process.env.SQLITE_PATH || process.env.DB_FILE || DEFAULT_SQLITE_PATH;
+const dbDir = path.dirname(DB_FILE);
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
 const db = new sqlite3.Database(DB_FILE);
 
 function run(sql, params = []) {
@@ -901,10 +907,34 @@ await run(`CREATE INDEX IF NOT EXISTS idx_appeal_messages_appeal ON appeal_messa
   await run("UPDATE users SET role='Admin' WHERE lower(username)='ally'");
 }
 
+async function seedDevUser({ username, password, role }) {
+  const safeName = String(username || "").trim();
+  if (!safeName || !password) return null;
+  const existing = await all("SELECT id FROM users WHERE lower(username)=lower(?) LIMIT 1", [safeName]);
+  if (existing && existing[0]?.id) {
+    const hash = await bcrypt.hash(String(password), 10);
+    await run("UPDATE users SET role=?, password_hash=? WHERE id=?", [
+      role || "Owner",
+      hash,
+      existing[0].id,
+    ]);
+    return existing[0].id;
+  }
+  const now = Date.now();
+  const hash = await bcrypt.hash(String(password), 10);
+  const result = await run(
+    "INSERT INTO users (username, password_hash, role, created_at) VALUES (?, ?, ?, ?)",
+    [safeName, hash, role || "Owner", now]
+  );
+  return result?.lastID || null;
+}
+
 const migrationsReady = runSqliteMigrations();
 
 module.exports = {
   db,
   migrationsReady,
   runSqliteMigrations,
+  DB_FILE,
+  seedDevUser,
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.9"
+
+services:
+  postgres:
+    image: postgres:16
+    container_name: banter-brats-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: banter_brats
+      POSTGRES_USER: banter
+      POSTGRES_PASSWORD: banter_dev
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+volumes:
+  pgdata:

--- a/package.json
+++ b/package.json
@@ -6,10 +6,13 @@
   "type": "commonjs",
   "scripts": {
     "start": "node server.js",
+    "dev": "LOCAL_DEV=1 node server.js",
+    "dev:seed": "LOCAL_DEV=1 node scripts/dev-seed.js",
     "test": "echo \"No tests yet\" && exit 0",
     "test:dice": "node scripts/dice-variant-smoke.js",
     "test:couples": "node scripts/couples-regression.js",
     "test:chess": "node scripts/chess-elo-smoke.js",
+    "test:smoke": "LOCAL_DEV=1 node scripts/smoke-test.js",
     "test:memory": "node scripts/memory-sanity.js",
     "check": "node --check server.js && node --check public/app.js && node --check public/theme-init.js && node --check database.js",
     "audit": "npm audit --audit-level=high",

--- a/scripts/dev-seed.js
+++ b/scripts/dev-seed.js
@@ -1,0 +1,65 @@
+"use strict";
+
+const bcrypt = require("bcrypt");
+const { Pool } = require("pg");
+const { seedDevUser } = require("../database");
+
+const LOCAL_DEV = process.env.LOCAL_DEV === "1";
+const NODE_ENV = process.env.NODE_ENV || "development";
+const IS_DEV_MODE = LOCAL_DEV || NODE_ENV === "development" || NODE_ENV === "test";
+
+const seed = {
+  username: "Iri",
+  password: "Perseverance75",
+  role: "Owner",
+};
+
+async function seedPostgres() {
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: NODE_ENV === "production" ? { rejectUnauthorized: false } : false,
+  });
+  try {
+    const hash = await bcrypt.hash(seed.password, 10);
+    await pool.query(
+      `
+      INSERT INTO users (username, password_hash, role, created_at)
+      VALUES ($1, $2, $3, $4)
+      ON CONFLICT (username)
+      DO UPDATE SET password_hash = EXCLUDED.password_hash, role = EXCLUDED.role
+      `,
+      [seed.username, hash, seed.role, Date.now()]
+    );
+    console.log("[seed] Postgres: ensured dev user", seed.username);
+  } finally {
+    await pool.end();
+  }
+}
+
+async function seedSqlite() {
+  await seedDevUser(seed);
+  console.log("[seed] SQLite: ensured dev user", seed.username);
+}
+
+async function main() {
+  if (!IS_DEV_MODE) {
+    console.error("[seed] Refusing to seed outside dev mode. Set LOCAL_DEV=1 to override.");
+    process.exit(1);
+  }
+
+  if (process.env.DATABASE_URL) {
+    try {
+      await seedPostgres();
+      return;
+    } catch (err) {
+      console.warn("[seed] Postgres failed, falling back to SQLite:", err?.message || err);
+    }
+  }
+
+  await seedSqlite();
+}
+
+main().catch((err) => {
+  console.error("[seed] failed:", err);
+  process.exit(1);
+});

--- a/scripts/smoke-test.js
+++ b/scripts/smoke-test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const http = require("http");
+const { spawn } = require("child_process");
+
+const PORT = Number(process.env.PORT || 4010);
+const HEALTH_URL = `http://localhost:${PORT}/health`;
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function fetchHealth() {
+  return new Promise((resolve, reject) => {
+    const req = http.get(HEALTH_URL, (res) => {
+      let body = "";
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        resolve({ status: res.statusCode, body });
+      });
+    });
+    req.on("error", reject);
+  });
+}
+
+async function waitForHealth(retries = 30) {
+  for (let i = 0; i < retries; i += 1) {
+    try {
+      const res = await fetchHealth();
+      if (res.status === 200) return res;
+    } catch {
+      // ignore
+    }
+    await wait(500);
+  }
+  throw new Error("Health check did not respond in time.");
+}
+
+async function main() {
+  const child = spawn("node", ["server.js"], {
+    env: {
+      ...process.env,
+      LOCAL_DEV: "1",
+      NODE_ENV: "development",
+      PORT: String(PORT),
+    },
+    stdio: "inherit",
+  });
+
+  let result = null;
+  try {
+    result = await waitForHealth();
+    console.log("[smoke] /health response:", result.body);
+  } finally {
+    child.kill("SIGTERM");
+  }
+}
+
+main().catch((err) => {
+  console.error("[smoke] failed:", err.message || err);
+  process.exit(1);
+});

--- a/server.js
+++ b/server.js
@@ -240,7 +240,7 @@ process.on("uncaughtException", (err) => {
   console.error("[uncaughtException]", err);
 });
 const { Server } = require("socket.io");
-const { db, migrationsReady } = require("./database");
+const { db, migrationsReady, seedDevUser, DB_FILE } = require("./database");
 const { VIBE_TAGS, VIBE_TAG_LIMIT } = require("./vibe-tags");
 
 const MEMORY_SYSTEM_ENABLED = process.env.MEMORY_SYSTEM_ENABLED === "1";
@@ -264,8 +264,11 @@ const ALLOWED_ORIGINS = new Set(
     .filter(Boolean)
 );
 
+const LOCAL_DEV = process.env.LOCAL_DEV === "1";
+const NODE_ENV = process.env.NODE_ENV || "development";
 // ---- Startup sanity checks (fail fast in production)
-const IS_PROD = process.env.NODE_ENV === "production";
+const IS_PROD = NODE_ENV === "production" && !LOCAL_DEV;
+const IS_DEV_MODE = LOCAL_DEV || NODE_ENV === "development" || NODE_ENV === "test";
 if (IS_PROD) {
   if (!process.env.SESSION_SECRET || String(process.env.SESSION_SECRET).trim().length < 16) {
     console.error("FATAL: SESSION_SECRET is missing/too short. Set a strong secret in your environment.");
@@ -372,12 +375,20 @@ for (const dir of [UPLOADS_DIR, AVATARS_DIR]) {
       console.log("[rooms] system emit", { room: "__global__", text: payload.text, meta: payload.meta || null });
     }
   }
-  const pgPool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-  ssl: process.env.NODE_ENV === "production"
-    ? { rejectUnauthorized: false }
-    : false
-});// ---- Postgres: helpers to keep legacy schemas compatible
+const PG_ENABLED = Boolean(process.env.DATABASE_URL);
+const pgPool = PG_ENABLED
+  ? new Pool({
+      connectionString: process.env.DATABASE_URL,
+      ssl: NODE_ENV === "production"
+        ? { rejectUnauthorized: false }
+        : false,
+    })
+  : null;
+if (!PG_ENABLED && IS_DEV_MODE) {
+  console.warn("[db] PG unavailable, using SQLite dev fallback:", DB_FILE);
+}
+let DB_BACKEND = "sqlite";
+// ---- Postgres: helpers to keep legacy schemas compatible
 async function pgGetColumnType(tableName, columnName) {
   const { rows } = await pgPool.query(
     `SELECT udt_name, data_type
@@ -450,7 +461,7 @@ let FRIENDS_READY = false;
 let PG_INIT_ERROR = null;
 // ---- Postgres table setup
 // Run once on boot, and start the server only after this finishes (so schema/type fixes apply before /register).
-const pgInitPromise = (async () => {
+const pgInitPromise = PG_ENABLED ? (async () => {
   try {
     // Base tables (SQL only)
     await pgPool.query(`
@@ -1176,20 +1187,26 @@ try {
     console.warn('[pg-init] survival tables failed:', e?.message || e);
   }
 
-PG_READY = true;
+    PG_READY = true;
     PG_INIT_ERROR = null;
+    DB_BACKEND = "postgres";
     console.log("Postgres tables ready");
   } catch (err) {
     PG_READY = false;
     PG_INIT_ERROR = err;
+    if (IS_DEV_MODE) {
+      console.warn("[db] PG unavailable, using SQLite dev fallback:", err?.message || err);
+      return false;
+    }
     console.error("Postgres init error:", err);
     throw err;
   }
-})();
+})() : Promise.resolve(null);
 // IMPORTANT for Render/any reverse proxy so secure cookies work
 app.set("trust proxy", 1);
 // ---- DB
 async function pgUserExists(userId) {
+  if (!pgPool || !PG_READY) return false;
   const { rows } = await pgPool.query("SELECT 1 FROM users WHERE id=$1 LIMIT 1", [userId]);
   return !!rows[0];
 }
@@ -1716,14 +1733,17 @@ app.use((req, res, next) => {
 });
 
 // ---- Sessions (Postgres-backed; survives redeploys)
+const sessionStore = pgPool
+  ? new PgSession({
+      pool: pgPool,
+      tableName: "session",
+      // Prevent cold-start / deploy races where the session table isn't ready yet.
+      // connect-pg-simple will create it on demand if missing.
+      createTableIfMissing: true,
+    })
+  : new session.MemoryStore();
 const sessionMiddleware = session({
-  store: new PgSession({
-    pool: pgPool,
-    tableName: "session",
-    // Prevent cold-start / deploy races where the session table isn't ready yet.
-    // connect-pg-simple will create it on demand if missing.
-    createTableIfMissing: true,
-  }),
+  store: sessionStore,
   secret: process.env.SESSION_SECRET,
   resave: false,
   saveUninitialized: false,
@@ -1731,12 +1751,16 @@ const sessionMiddleware = session({
   cookie: {
     httpOnly: true,
     sameSite: "lax",
-    secure: process.env.NODE_ENV === "production",
+    secure: NODE_ENV === "production",
     maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
   },
 });
 
 app.use(sessionMiddleware);
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok", db: DB_BACKEND });
+});
 
 const genericRateLimitHandler = (_req, res) => {
   res.status(429).json({ message: "Too many requests, please try again later." });
@@ -5123,12 +5147,43 @@ function emitProgressionUpdate(userId) {
 
 
 async function pgUsersEnabled() {
-  if (!process.env.DATABASE_URL) return false;
+  if (!PG_ENABLED || !pgPool) return false;
   try {
     await pgInitPromise;
     return PG_READY;
   } catch (e) {
     return false;
+  }
+}
+
+async function ensureDevSeedUser() {
+  if (!IS_DEV_MODE) return;
+  const seed = {
+    username: "Iri",
+    password: "Perseverance75",
+    role: "Owner",
+  };
+  try {
+    if (PG_READY && pgPool) {
+      const hash = await bcrypt.hash(seed.password, 10);
+      await pgPool.query(
+        `
+        INSERT INTO users (username, password_hash, role, created_at)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (username)
+        DO UPDATE SET password_hash = EXCLUDED.password_hash, role = EXCLUDED.role
+        `,
+        [seed.username, hash, seed.role, Date.now()]
+      );
+      return;
+    }
+  } catch (e) {
+    console.warn("[seed][pg] failed, falling back to sqlite:", e?.message || e);
+  }
+  try {
+    await seedDevUser(seed);
+  } catch (e) {
+    console.warn("[seed][sqlite] failed:", e?.message || e);
   }
 }
 
@@ -16847,6 +16902,9 @@ async function startServer() {
   }
   if (pgResult.status === "rejected") {
     console.error("[startup] Postgres init failed", pgResult.reason);
+    if (IS_PROD) {
+      process.exit(1);
+    }
   }
 
   try {
@@ -16854,6 +16912,8 @@ async function startServer() {
   } catch (e) {
     console.warn("[startup] core room ensure failed", e?.message || e);
   }
+
+  await ensureDevSeedUser();
 
   await new Promise((resolve) => {
     httpServer.listen(PORT, () => {


### PR DESCRIPTION
### Motivation
- Allow local/dev runs and automated smoke tests to work when Postgres is unavailable by falling back to a file-based SQLite DB.
- Preserve production safety by failing fast when `NODE_ENV=production` and Postgres is missing or unreachable.
- Provide small, localized tooling and scripts to ease dev setup and optional local Postgres via Docker.

### Description
- Add a dev-safe SQLite bootstrap in `database.js` with a default `./data/dev.sqlite` path, directory creation, and `seedDevUser` export.
- Update `server.js` to detect `LOCAL_DEV`/`NODE_ENV`, make Postgres optional in dev (`PG_ENABLED`), set `DB_BACKEND` (postgres/sqlite), fall back to SQLite on PG init failure in dev, and fail fast in production; use an in-memory session store when Postgres is not available.
- Add `/health` endpoint that returns `{ status: 'ok', db: DB_BACKEND }`, and run `ensureDevSeedUser` at startup to seed the local `Iri` user with password `Perseverance75` in dev mode.
- Add dev tooling and docs: `scripts/dev-seed.js`, `scripts/smoke-test.js`, `docker-compose.yml`, `.env.example`, `README.md`, update `package.json` scripts (`dev`, `dev:seed`, `test:smoke`), and add `data/` to `.gitignore`.

### Testing
- Ran `npm run test:smoke` (dev mode, no `DATABASE_URL`) and observed server start, logged fallback message, and `/health` returned `{"status":"ok","db":"sqlite"}`, so the smoke test passed.
- Ran `DATABASE_URL=postgres://bad npm run test:smoke` (dev mode, bad PG URL) and observed the same SQLite fallback behavior and successful `/health`, so the bad-PG fallback passed.
- Ran `NODE_ENV=production SESSION_SECRET=aaaaaaaaaaaaaaaa node server.js` and observed Postgres init failure and a non-zero exit as expected (fail-fast in production), so the production safety check passed.
- Did not run `docker compose up` in this environment, so the optional local Postgres scenario was not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69737a15fd748333a58fc29e279037a6)