### PR TITLE
Profile modal: accordion UI, centralized actions, and lifecycle fixes

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -4563,6 +4563,9 @@ const copyUsernameBtn = document.getElementById("copyUsernameBtn");
 const mediaMsg = document.getElementById("mediaMsg");
 const profileActionMsg = document.getElementById("profileActionMsg");
 const customizeMsg = document.getElementById("customizeMsg");
+const profileSections = document.getElementById("profileSections");
+const profileModerationSection = document.getElementById("profileModerationSection");
+const profileModerationOpenBtn = document.getElementById("profileModerationOpenBtn");
 const levelPanel = document.getElementById("levelPanel");
 const levelBadge = document.getElementById("levelBadge");
 const xpText = document.getElementById("xpText");
@@ -4790,10 +4793,6 @@ function closeMemberActionsOverlay(){
 }
 
 // Actions button wiring (staff quick menu)
-if (actionsBtn && !actionsBtn._wired){
-  actionsBtn._wired = true;
-  actionsBtn.addEventListener("click", openMemberActionsOverlay);
-}
 if (closeMemberActionsBtn && !closeMemberActionsBtn._wired){
   closeMemberActionsBtn._wired = true;
   closeMemberActionsBtn.addEventListener("click", closeMemberActionsOverlay);
@@ -9158,8 +9157,11 @@ function threadLabel(t){
   return others[0] || otherUser || "Direct Message";
 }
 
+let bodyLockCount = 0;
 function lockBodyScroll(lock){
-  document.body.classList.toggle("bodyLocked", !!lock);
+  if (lock) bodyLockCount += 1;
+  else bodyLockCount = Math.max(0, bodyLockCount - 1);
+  document.body.classList.toggle("bodyLocked", bodyLockCount > 0);
 }
 
 function formatDmTime(ts){
@@ -10781,29 +10783,6 @@ dmText?.addEventListener("keydown", (e) => {
 });
 dmText?.addEventListener("input", ()=>renderMentionDropdown(dmMentionDropdown, dmText));
 
-// "Message" button on profile -> always direct DM
-dmUserBtn?.addEventListener("click", () => {
-  if (modalTargetUsername) {
-    closeModal();
-    startDirectMessage(modalTargetUsername, modalTargetUserId);
-  }
-});
-dmChessQuickBtn?.addEventListener("click", () => {
-  if (modalTargetUsername && modalTargetUserId) {
-    pendingChessChallenge = { userId: modalTargetUserId, username: modalTargetUsername };
-    closeModal();
-    startDirectMessage(modalTargetUsername, modalTargetUserId);
-  }
-});
-profileEditBtn?.addEventListener("click", () => {
-  if (!currentProfileIsSelf) return;
-  setProfileEditMode(true);
-  setTab("profile");
-});
-profileEditToggleBtn?.addEventListener("click", () => {
-  if (!currentProfileIsSelf) return;
-  setProfileEditMode(!profileEditMode);
-});
 function closeProfileSettingsMenu(){
   if (!profileSettingsMenu) return;
   profileSettingsMenu.hidden = true;
@@ -11393,6 +11372,16 @@ tabActions?.addEventListener("click", async ()=>{
   if (viewModeration?.style.display !== "none") await refreshLogs();
 });
 
+profileSections?.addEventListener("toggle", (e) => {
+  const details = e.target;
+  if (!(details instanceof HTMLDetailsElement)) return;
+  if (!details.open) return;
+  if (!window.matchMedia("(max-width: 760px)").matches) return;
+  profileSections.querySelectorAll(".profileSection").forEach((section) => {
+    if (section !== details) section.open = false;
+  });
+});
+
 
 function hardHideProfileModal(){
   try{
@@ -11404,6 +11393,7 @@ function hardHideProfileModal(){
   }catch{}
   setModalTargetUsername(null, "hardHideProfileModal");
   modalTargetUserId=null;
+  lockBodyScroll(false);
 }
 // modal open/close
 function openModal(){
@@ -11414,17 +11404,26 @@ function openModal(){
   logProfileModal("openModal");
   modal.style.display="flex";
   modal.classList.remove("modal-closing");
+  lockBodyScroll(true);
+  if (profileSections && window.matchMedia("(max-width: 760px)").matches) {
+    const sections = profileSections.querySelectorAll(".profileSection");
+    sections.forEach((section, index) => {
+      section.open = index === 0;
+    });
+  }
   logProfileModal("openModal display set", { display: modal.style.display });
   if (PREFERS_REDUCED_MOTION) {
     modal.classList.add("modal-visible");
     logProfileModal("openModal visible (reduced motion)");
     traceProfileModalOnce("modal visible (reduced motion)");
+    try { closeModalBtn?.focus({ preventScroll: true }); } catch {}
     return;
   }
   requestAnimationFrame(() => {
     modal.classList.add("modal-visible");
     logProfileModal("openModal visible (animated)");
     traceProfileModalOnce("modal visible (animated)");
+    try { closeModalBtn?.focus({ preventScroll: true }); } catch {}
   });
 }
 function closeModal(){
@@ -11442,15 +11441,120 @@ function closeModal(){
   logsMsg.textContent="";
   setMsgline(mediaMsg, "");
   if (customizeMsg) customizeMsg.textContent = "";
-  if (PREFERS_REDUCED_MOTION) {
+  const finalizeClose = () => {
     modal.style.display="none";
     modal.classList.remove("modal-closing");
+    lockBodyScroll(false);
+  };
+  if (PREFERS_REDUCED_MOTION) {
+    finalizeClose();
     return;
   }
-  setTimeout(() => {
-    modal.style.display="none";
-    modal.classList.remove("modal-closing");
-  }, 220);
+  setTimeout(finalizeClose, 220);
+}
+
+async function handleAddFriendAction(){
+  if (addFriendBtn?.disabled) return;
+  const st = String(modalFriendInfo?.status || 'none');
+  const rid = Number(addFriendBtn?.dataset?.requestId || modalFriendInfo?.requestId || 0);
+  if (!modalTargetUsername) return;
+  setMsgline(profileActionMsg, "");
+  try {
+    if (st === 'incoming' && rid) {
+      const res = await fetch('/api/friends/respond', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ requestId: rid, action: 'accept' }) });
+      if (!res.ok) throw new Error(await res.text());
+      modalFriendInfo = { status: 'friends', requestId: null };
+      friendsDirty = true;
+      setMsgline(profileActionMsg, 'Friend request accepted.');
+    } else if (st === 'none') {
+      const res = await fetch('/api/friends/request', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ to: modalTargetUsername }) });
+      if (!res.ok) throw new Error(await res.text());
+      const data = await res.json().catch(()=>({}));
+      modalFriendInfo = { status: data?.autoAccepted ? 'friends' : 'outgoing', requestId: null };
+      friendsDirty = true;
+      setMsgline(profileActionMsg, data?.autoAccepted ? 'Friend added.' : 'Friend request sent.');
+    }
+  } catch (e) {
+    setMsgline(profileActionMsg, e?.message || 'Could not update friend.');
+  } finally {
+    updateProfileActions({ isSelf: false, canModerate: (roleRank(me.role) >= roleRank("Moderator")) });
+  }
+}
+
+async function handleDeclineFriendAction(){
+  if (!modalTargetUsername) return;
+  const st = String(modalFriendInfo?.status || 'none');
+  const rid = Number(declineFriendBtn?.dataset?.requestId || modalFriendInfo?.requestId || 0);
+  if (st !== 'incoming' || !rid) return;
+  setMsgline(profileActionMsg, "");
+  try {
+    const res = await fetch('/api/friends/respond', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ requestId: rid, action: 'decline' }) });
+    if (!res.ok) throw new Error(await res.text());
+    modalFriendInfo = { status: 'none', requestId: null };
+    friendsDirty = true;
+    setMsgline(profileActionMsg, 'Friend request declined.');
+  } catch (e) {
+    setMsgline(profileActionMsg, e?.message || 'Could not decline.');
+  } finally {
+    updateProfileActions({ isSelf: false, canModerate: (roleRank(me.role) >= roleRank("Moderator")) });
+  }
+}
+
+async function handleProfileModalAction(action, btn){
+  switch(action){
+    case "profile:close":
+      closeModal();
+      return;
+    case "profile:message":
+      if (modalTargetUsername) {
+        closeModal();
+        startDirectMessage(modalTargetUsername, modalTargetUserId);
+      }
+      return;
+    case "profile:chess":
+      if (modalTargetUsername && modalTargetUserId) {
+        pendingChessChallenge = { userId: modalTargetUserId, username: modalTargetUsername };
+        closeModal();
+        startDirectMessage(modalTargetUsername, modalTargetUserId);
+      }
+      return;
+    case "profile:edit":
+      if (!currentProfileIsSelf) return;
+      setProfileEditMode(true);
+      setTab("profile");
+      return;
+    case "profile:toggle-edit":
+      if (!currentProfileIsSelf) return;
+      setProfileEditMode(!profileEditMode);
+      return;
+    case "profile:like":
+      await toggleProfileLike();
+      return;
+    case "profile:friend":
+      await handleAddFriendAction();
+      return;
+    case "profile:friend-decline":
+      await handleDeclineFriendAction();
+      return;
+    case "profile:customize":
+      if (!currentProfileIsSelf) return;
+      setTab("customize");
+      return;
+    case "profile:themes":
+      if (!currentProfileIsSelf) return;
+      openThemesModal();
+      return;
+    case "profile:moderation":
+      if (tabActions?.style.display === "none") return;
+      setTab("actions");
+      if (viewModeration?.style.display !== "none") await refreshLogs();
+      return;
+    case "profile:moderation-overlay":
+      openMemberActionsOverlay();
+      return;
+    default:
+      return;
+  }
 }
 
 // Couples popout modal (reuses the existing Couples nodes from the profile editor)
@@ -11559,8 +11663,17 @@ document.addEventListener("keydown", (e) => {
   }
 });
 
-closeModalBtn.addEventListener("click", closeModal);
 modal.addEventListener("click", (e)=>{ if(e.target===modal) closeModal(); });
+modal.addEventListener("click", (e) => {
+  const actionBtn = e.target.closest("[data-profile-action]");
+  if (!actionBtn || !modal.contains(actionBtn)) return;
+  if (actionBtn.disabled) return;
+  const action = actionBtn.dataset.profileAction;
+  if (!action) return;
+  e.preventDefault();
+  e.stopPropagation();
+  void handleProfileModalAction(action, actionBtn);
+});
 
 survivalNewSeasonBtn?.addEventListener("click", openSurvivalNewSeasonModal);
 survivalNewSeasonClose?.addEventListener("click", closeSurvivalNewSeasonModal);
@@ -16316,6 +16429,12 @@ function updateProfileActions({ isSelf = false, canModerate = false } = {}){
   const showActionsTab = canModerate && !isSelf;
   if (viewModeration) viewModeration.style.display = canModerate ? "" : "none";
   if (tabActions) tabActions.style.display = showActionsTab ? "" : "none";
+  if (profileModerationSection) profileModerationSection.style.display = showActionsTab ? "" : "none";
+  if (profileModerationOpenBtn) profileModerationOpenBtn.disabled = !modalCanModerate;
+  modal?.querySelectorAll("[data-profile-action='profile:customize'], [data-profile-action='profile:themes']").forEach((btn) => {
+    if (!(btn instanceof HTMLButtonElement)) return;
+    btn.disabled = !isSelf;
+  });
   [actionMuteBtn, actionKickBtn, actionBanBtn, actionAppealsBtn].forEach((btn) => {
     if (!btn) return;
     btn.style.display = showActionsTab ? "" : "none";
@@ -17590,56 +17709,61 @@ async function toggleProfileLike() {
   }
 }
 
-likeProfileBtn?.addEventListener("click", async () => {
-  await toggleProfileLike();
-});
-
-declineFriendBtn?.addEventListener("click", async () => {
-  if (!modalTargetUsername) return;
-  const st = String(modalFriendInfo?.status || 'none');
-  const rid = Number(declineFriendBtn.dataset.requestId || modalFriendInfo?.requestId || 0);
-  if (st !== 'incoming' || !rid) return;
-  setMsgline(profileActionMsg, "");
-  try {
-    const res = await fetch('/api/friends/respond', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ requestId: rid, action: 'decline' }) });
-    if (!res.ok) throw new Error(await res.text());
-    modalFriendInfo = { status: 'none', requestId: null };
-    friendsDirty = true;
-    setMsgline(profileActionMsg, 'Friend request declined.');
-  } catch (e) {
-    setMsgline(profileActionMsg, e?.message || 'Could not decline.');
-  } finally {
-    updateProfileActions({ isSelf: false, canModerate: (roleRank(me.role) >= roleRank("Moderator")) });
+window.runProfileModalSelfTest = async function runProfileModalSelfTest(targetUsername = null){
+  const target = String(targetUsername || modalTargetUsername || me?.username || "").trim();
+  const results = [];
+  const wait = (ms = 160) => new Promise((resolve) => setTimeout(resolve, ms));
+  const log = (label, ok, detail = "") => {
+    results.push({ label, ok, detail });
+    const msg = `[profile-modal-test] ${label}: ${ok ? "PASS" : "FAIL"}${detail ? ` (${detail})` : ""}`;
+    if (ok) console.log(msg);
+    else console.warn(msg);
+  };
+  if (!target) {
+    log("open", false, "No target username");
+    return results;
   }
-});
+  const opened = target === me?.username ? await openMyProfile() : await openMemberProfile(target);
+  log("open", !!opened, opened ? "" : "Open failed");
+  if (!opened) return results;
 
-addFriendBtn?.addEventListener("click", async () => {
-  if (addFriendBtn.disabled) return;
-  const st = String(modalFriendInfo?.status || 'none');
-  const rid = Number(addFriendBtn.dataset.requestId || modalFriendInfo?.requestId || 0);
-  if (!modalTargetUsername) return;
-  setMsgline(profileActionMsg, "");
-  try {
-    if (st === 'incoming' && rid) {
-      const res = await fetch('/api/friends/respond', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ requestId: rid, action: 'accept' }) });
-      if (!res.ok) throw new Error(await res.text());
-      modalFriendInfo = { status: 'friends', requestId: null };
-      friendsDirty = true;
-      setMsgline(profileActionMsg, 'Friend request accepted.');
-    } else if (st === 'none') {
-      const res = await fetch('/api/friends/request', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ to: modalTargetUsername }) });
-      if (!res.ok) throw new Error(await res.text());
-      const data = await res.json().catch(()=>({}));
-      modalFriendInfo = { status: data?.autoAccepted ? 'friends' : 'outgoing', requestId: null };
-      friendsDirty = true;
-      setMsgline(profileActionMsg, data?.autoAccepted ? 'Friend added.' : 'Friend request sent.');
+  const clickAction = async (action, label, { expectTab = null, expectEditToggle = false } = {}) => {
+    const btn = modal?.querySelector(`[data-profile-action="${action}"]`);
+    if (!btn) return log(label, false, "Missing button");
+    if (btn.disabled) return log(label, false, "Disabled");
+    const beforeEdit = profileEditMode;
+    btn.click();
+    await wait(220);
+    if (expectTab && activeProfileTab !== expectTab) {
+      return log(label, false, `Expected tab ${expectTab}`);
     }
-  } catch (e) {
-    setMsgline(profileActionMsg, e?.message || 'Could not update friend.');
-  } finally {
-    updateProfileActions({ isSelf: false, canModerate: (roleRank(me.role) >= roleRank("Moderator")) });
+    if (expectEditToggle && profileEditMode === beforeEdit) {
+      return log(label, false, "Edit mode did not toggle");
+    }
+    log(label, true);
+  };
+
+  await clickAction("profile:like", "like");
+  if (currentProfileIsSelf) {
+    await clickAction("profile:toggle-edit", "toggle-edit", { expectEditToggle: true });
+    await clickAction("profile:customize", "customize", { expectTab: "customize" });
+    await clickAction("profile:themes", "themes");
+    try { closeThemesModal(); } catch {}
   }
-});
+
+  const closeBtn = modal?.querySelector(`[data-profile-action="profile:close"]`);
+  if (closeBtn && !closeBtn.disabled) {
+    closeBtn.click();
+    await wait(280);
+    const closed = modal?.style.display === "none";
+    const unlocked = !document.body.classList.contains("bodyLocked");
+    log("close", !!closed && unlocked, closed ? "" : "Modal still visible");
+  } else {
+    log("close", false, "Missing close button");
+  }
+  return results;
+};
+
 
 likeCount?.addEventListener("click", async () => {
   if (profileLikeState.isSelf) return;

--- a/public/index.html
+++ b/public/index.html
@@ -780,9 +780,9 @@
 </div>
 </div>
 <div class="profileHeaderActions">
-<button aria-label="Edit profile" class="iconBtn smallIcon" id="profileEditBtn" style="display:none;" title="Edit profile" type="button">✏️</button>
-<button aria-label="Moderation actions" class="iconBtn smallIcon" id="actionsBtn" style="display:none;" title="Moderation actions" type="button">🛡️</button>
-<button aria-label="Close profile" class="iconBtn smallIcon" id="closeModalBtn" type="button">✕</button>
+<button aria-label="Edit profile" class="iconBtn smallIcon" data-profile-action="profile:edit" id="profileEditBtn" style="display:none;" title="Edit profile" type="button">✏️</button>
+<button aria-label="Moderation actions" class="iconBtn smallIcon" data-profile-action="profile:moderation-overlay" id="actionsBtn" style="display:none;" title="Moderation actions" type="button">🛡️</button>
+<button aria-label="Close profile" class="iconBtn smallIcon" data-profile-action="profile:close" id="closeModalBtn" type="button">✕</button>
 </div>
 </div>
 </div>
@@ -804,16 +804,25 @@
 </div>
 <div class="modalContent" id="modalContent">
 <div id="viewProfile">
+<div class="profileSections" id="profileSections">
+<details class="profileSection" data-section="actions" open="">
+<summary>Actions</summary>
+<div class="profileSectionBody">
 <div class="profileQuickActions" id="profileQuickActions">
 <div class="quickActionGroup">
-<button class="btn btnSecondary" id="dmUserBtn" type="button">Message</button>
-<button class="btn btnSecondary" id="dmChessQuickBtn" type="button">Play Chess</button>
-<button class="btn btnSecondary" id="addFriendBtn" style="display:none;" type="button">🤝 Add Friend</button>
-<button class="btn btnSecondary" id="declineFriendBtn" style="display:none;" type="button">✖ Decline</button>
-<button class="btn btnSecondary" id="likeProfileBtn" type="button">❤️ Like</button>
-<button class="btn btnSecondary" id="profileEditToggleBtn" style="display:none;" type="button">Edit profile</button>
+<button class="btn btnSecondary" data-profile-action="profile:message" id="dmUserBtn" type="button">Message</button>
+<button class="btn btnSecondary" data-profile-action="profile:chess" id="dmChessQuickBtn" type="button">Play Chess</button>
+<button class="btn btnSecondary" data-profile-action="profile:friend" id="addFriendBtn" style="display:none;" type="button">🤝 Add Friend</button>
+<button class="btn btnSecondary" data-profile-action="profile:friend-decline" id="declineFriendBtn" style="display:none;" type="button">✖ Decline</button>
+<button class="btn btnSecondary" data-profile-action="profile:like" id="likeProfileBtn" type="button">❤️ Like</button>
+<button class="btn btnSecondary" data-profile-action="profile:toggle-edit" id="profileEditToggleBtn" style="display:none;" type="button">Edit profile</button>
 </div>
 </div>
+</div>
+</details>
+<details class="profileSection" data-section="stats">
+<summary>Stats</summary>
+<div class="profileSectionBody">
 <div class="profileInfoGrid">
 <div class="profileInfoCard">
 <div class="infoLabel">Age</div>
@@ -861,9 +870,26 @@
 <span class="coupleChip" id="profileCoupleChip" style="display:none;"></span>
 </div>
 </div>
+</div>
+</details>
+<details class="profileSection" data-section="about">
+<summary>About</summary>
+<div class="profileSectionBody">
 <div class="profileBioCard" id="viewAbout">
 <div class="sectionTitle">Bio</div>
 <div class="bioRender" id="bioRender">(no bio)</div>
+</div>
+</div>
+</details>
+<details class="profileSection" data-section="customize">
+<summary>Customization</summary>
+<div class="profileSectionBody">
+<div class="panelBox">
+<div class="small">Jump into the full customization panel or apply a theme.</div>
+<div class="row" style="margin-top:10px; gap:8px; flex-wrap:wrap;">
+<button class="btn btnSecondary" data-profile-action="profile:customize" type="button">Open customize panel</button>
+<button class="btn btnSecondary" data-profile-action="profile:themes" type="button">Themes</button>
+</div>
 </div>
 <div class="panelBox profileEditSection" id="profileEditSection" style="display:none;">
 <div id="myProfileEdit" style="display:none;">
@@ -1079,6 +1105,19 @@
 <div class="msgline" id="profileMsg"></div>
 </div>
 </div>
+</div>
+</details>
+<details class="profileSection" data-section="moderation" id="profileModerationSection" style="display:none;">
+<summary>Moderation</summary>
+<div class="profileSectionBody">
+<div class="panelBox">
+<div class="small">Moderator tools for this member.</div>
+<div class="row" style="margin-top:10px; gap:8px; flex-wrap:wrap;">
+<button class="btn btnSecondary" data-profile-action="profile:moderation" id="profileModerationOpenBtn" type="button">Open moderation panel</button>
+</div>
+</div>
+</div>
+</details>
 </div>
 </div>
 <div id="viewTimeline" style="display:none;">

--- a/public/styles.css
+++ b/public/styles.css
@@ -4014,9 +4014,13 @@ body:not(.polish-pack) .tonePicker{
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding: 18px;
-  z-index: 400;
+  z-index: 900;
+  pointer-events: none;
 }
-#modal.modal-visible{ opacity: 1; }
+#modal.modal-visible{
+  opacity: 1;
+  pointer-events: auto;
+}
 .modal{
   position: fixed;
   inset: 0;
@@ -4030,7 +4034,7 @@ body:not(.polish-pack) .tonePicker{
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding: calc(18px + env(safe-area-inset-top)) calc(18px + env(safe-area-inset-right)) calc(18px + env(safe-area-inset-bottom)) calc(18px + env(safe-area-inset-left));
-  z-index: 410;
+  z-index: 920;
 }
 .modal.modal-visible{ opacity: 1; }
 
@@ -4047,7 +4051,7 @@ body:not(.polish-pack) .tonePicker{
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding: 18px;
-  z-index: 401; /* above main modal */
+  z-index: 910; /* above main modal */
 }
 #couplesModal.modal-visible{ opacity: 1; }
 .roomModal{
@@ -4063,7 +4067,7 @@ body:not(.polish-pack) .tonePicker{
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   padding: 18px;
-  z-index: 1200;
+  z-index: 930;
 }
 .roomModal.modal-visible{ opacity: 1; }
 .roomModalCard{
@@ -4144,6 +4148,46 @@ body:not(.polish-pack) .tonePicker{
 }
 .profileModalCard .modalBody{
   padding: 0 12px 12px;
+}
+
+.profileSections{
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+}
+.profileSection{
+  border:1px solid var(--border);
+  border-radius:12px;
+  background: var(--panel);
+  overflow:hidden;
+}
+.profileSection summary{
+  list-style:none;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  padding: 12px 14px;
+  font-weight: 700;
+  cursor:pointer;
+  min-height: 44px;
+}
+.profileSection summary::-webkit-details-marker{ display:none; }
+.profileSection summary::after{
+  content:"▾";
+  font-size: 12px;
+  opacity: 0.7;
+  transition: transform 140ms ease;
+}
+.profileSection[open] summary::after{
+  transform: rotate(180deg);
+}
+.profileSectionBody{
+  padding: 12px 14px 14px;
+  border-top: 1px solid var(--border);
+  display:flex;
+  flex-direction:column;
+  gap:12px;
 }
 .notificationsModal{
   position: fixed;


### PR DESCRIPTION
### Motivation
- Fix multiple regressions in the profile modal lifecycle (stuck overlays, z-index stacking, scroll lock) and make the modal UI scalable instead of a long scrolling sheet.  
- Ensure every interactive control in the profile modal routes reliably to a single handler and remains functional on mobile (iOS Safari) and after re-renders.  
- Add a small developer self-test to help catch regressions during future changes.

### Description
- Reworked profile modal HTML to a modular accordion layout (Actions / Stats / About / Customization / Moderation) and annotated actionable buttons with `data-profile-action` attributes to provide stable action targets (`public/index.html`).  
- Centralized action routing via delegated click handling on the modal and implemented `handleProfileModalAction(action, btn)` to map `data-profile-action` values to their handlers (message, like, friend, edit, customize, themes, moderation, close, etc.), removing fragile per-button wiring that broke on re-render (`public/app.js`).  
- Hardened modal lifecycle: added a reference-counted `lockBodyScroll` (body lock refcount), ensured `openModal()` sets scroll lock and initial accordion state, and `closeModal()`/`hardHideProfileModal()` reliably release locks and remove modal DOM visibility without leaving invisible overlays (`public/app.js`).  
- Reworked friend actions into dedicated async helpers (`handleAddFriendAction`, `handleDeclineFriendAction`) so they work via the new delegated wiring and maintain consistent UI updates (`public/app.js`).  
- Added small responsive UX: only one accordion stays open on narrow screens and sections default to a reasonable open/closed state when opening the modal (`public/app.js`).  
- Adjusted modal stacking and pointer behavior in CSS (increased `#modal`/modal z-index, pointer-events gating to prevent hidden overlay tap interception, and styles for accordion sections) to prevent modals from blocking main UI when closed (`public/styles.css`).  
- Added `window.runProfileModalSelfTest(targetUsername)` developer helper that programmatically opens a profile and exercises safe/non-destructive actions and verifies modal close + scroll-lock cleanup (`public/app.js`).

### Testing
- Started the dev server with `LOCAL_DEV=1 node server.js`; the server process started but reported upstream Postgres DNS errors in this environment which caused the UI login/profile flow to remain behind a blocked state (server fallback behavior was visible). — partially succeeded (server up) but backend connectivity prevented full end-to-end verification.  
- Attempted an automated Playwright login + profile modal screenshot to validate the UI; the script timed out because the profile button never became visible due to the backend connectivity issue. — failed (timeout due to hidden profile button).  
- No other automated test suites were run; the `runProfileModalSelfTest` helper was added for local developer verification and can be executed from the browser console after logging in to exercise modal controls and confirm close/scroll-lock behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973aae6ecc48333b9a93cbd8b0ca661)