### PR TITLE
Raise themes modal layering above profile modal

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -4238,7 +4238,7 @@ body:not(.polish-pack) .tonePicker{
   display:none;
   align-items:stretch;
   justify-content:center;
-  z-index:420;
+  z-index:960;
   padding:env(safe-area-inset-top) env(safe-area-inset-right) env(safe-area-inset-bottom) env(safe-area-inset-left);
 }
 .themesModal.show{ display:flex; }
@@ -4531,7 +4531,7 @@ body:not(.polish-pack) .tonePicker{
   display:none;
   align-items:flex-end;
   background:rgba(0,0,0,0.4);
-  z-index:430;
+  z-index:970;
 }
 .themesFiltersSheet.show,
 .themesActionSheet.show{ display:flex; }


### PR DESCRIPTION
### Motivation
- Fix a critical UI bug where the Themes modal could open behind the Profile modal and be visually present but not interactable by ensuring the Themes modal stacks above other modals.

### Description
- Updated `public/styles.css` to increase `.themesModal` z-index from `420` to `960` and `.themesFiltersSheet`/`.themesActionSheet` z-index from `430` to `970` so the Themes UI and its sheets reliably appear above the profile/modal layer while keeping changes minimal and scoped to layering only (`public/styles.css`).

### Testing
- Started the dev server with `npm run dev` (server launched successfully) and ran a headless Playwright script that forced the profile modal visible, opened the themes modal, and captured a screenshot at `artifacts/themes-modal-zindex.png`, confirming the Themes modal renders above the Profile modal (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973efe757808333b267722d98c48e3f)