### PR TITLE
Replace bubble customization with Message Layout controls

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1695,6 +1695,21 @@ function normalizeChatFx(input){
   };
 }
 
+function stripBubbleSettings(fx){
+  return {
+    ...fx,
+    enabled: true,
+    glow: CHAT_FX_DEFAULTS.glow,
+    radius: CHAT_FX_DEFAULTS.radius,
+    border: CHAT_FX_DEFAULTS.border,
+    glass: CHAT_FX_DEFAULTS.glass,
+    blur: CHAT_FX_DEFAULTS.blur,
+    density: CHAT_FX_DEFAULTS.density,
+    accent: CHAT_FX_DEFAULTS.accent,
+    bubbleColor: CHAT_FX_DEFAULTS.bubbleColor
+  };
+}
+
 function updateUserFxMap(username, fx){
   if (!username) return;
   const key = String(username);
@@ -1901,7 +1916,9 @@ function queueContrastReinforcement(bubble){
 function applyChatFxToBubble(bubble, fx, options = {}){
   if (!bubble) return;
   const resolved = normalizeChatFx(fx);
-  const effective = resolved.enabled ? resolved : CHAT_FX_DEFAULTS;
+  const isDmBubble = !!options.dmRow || bubble.classList.contains("dmBubble");
+  const sanitized = isDmBubble ? resolved : stripBubbleSettings(resolved);
+  const effective = sanitized.enabled ? sanitized : CHAT_FX_DEFAULTS;
   const glowMap = { off: 0, soft: 0.4, neon: 0.8, strong: 1.15 };
   const glowValue = glowMap[effective.glow] ?? 0;
   const textGlowMap = { off: 0, soft: 0.35, neon: 0.8, strong: 1.2 };
@@ -2955,11 +2972,15 @@ const customizeCards = Array.from(document.querySelectorAll(".customizeCard"));
 const customizeBackBtns = Array.from(document.querySelectorAll(".customizeBackBtn"));
 const customizePages = Array.from(document.querySelectorAll(".customizeSubpage"));
 
-const chatSpacingCompact = document.getElementById("chatSpacingCompact");
+const msgDensitySelect = document.getElementById("msgDensitySelect");
+const msgAccentStyleSelect = document.getElementById("msgAccentStyleSelect");
+const msgUsernameEmphasisSelect = document.getElementById("msgUsernameEmphasisSelect");
+const sysMsgDensitySelect = document.getElementById("sysMsgDensitySelect");
+const msgContrastSelect = document.getElementById("msgContrastSelect");
 const effectsPreset = document.getElementById("effectsPreset");
 const reduceMotionToggle = document.getElementById("reduceMotionToggle");
 
-const resetChatAppearanceBtn = document.getElementById("resetChatAppearanceBtn");
+const resetMessageLayoutBtn = document.getElementById("resetMessageLayoutBtn");
 const resetTextIdentityBtn = document.getElementById("resetTextIdentityBtn");
 const resetProfileAppearanceBtn = document.getElementById("resetProfileAppearanceBtn");
 const resetEffectsBtn = document.getElementById("resetEffectsBtn");
@@ -6498,10 +6519,103 @@ function applyComfortMode(enabled, { persistLocal = true, persistServer = true }
   }
 }
 
+const MESSAGE_LAYOUT_KEY = "messageLayout:v1";
+const MESSAGE_LAYOUT_DEFAULTS = Object.freeze({
+  msgDensity: "medium",
+  msgAccentStyle: "solid",
+  msgUsernameEmphasis: "normal",
+  sysMsgDensity: "full",
+  msgContrast: "medium"
+});
+const MESSAGE_LAYOUT_CLASSES = Object.freeze({
+  msgDensity: ["msg-density-compact", "msg-density-medium", "msg-density-comfortable"],
+  msgAccentStyle: ["msg-accent-solid", "msg-accent-dotted", "msg-accent-gradient", "msg-accent-hoverglow"],
+  msgUsernameEmphasis: ["msg-name-normal", "msg-name-bold", "msg-name-underlinehover", "msg-name-rolechip"],
+  sysMsgDensity: ["sys-density-full", "sys-density-compact", "sys-density-minimized"],
+  msgContrast: ["msg-contrast-low", "msg-contrast-medium", "msg-contrast-high"]
+});
+
+function normalizeMessageLayout(input){
+  const raw = (input && typeof input === "object") ? input : {};
+  const msgDensity = ["compact", "medium", "comfortable"].includes(raw.msgDensity)
+    ? raw.msgDensity
+    : MESSAGE_LAYOUT_DEFAULTS.msgDensity;
+  const msgAccentStyle = ["solid", "dotted", "gradient", "hoverGlow"].includes(raw.msgAccentStyle)
+    ? raw.msgAccentStyle
+    : MESSAGE_LAYOUT_DEFAULTS.msgAccentStyle;
+  const msgUsernameEmphasis = ["normal", "bold", "underlineHover", "roleChip"].includes(raw.msgUsernameEmphasis)
+    ? raw.msgUsernameEmphasis
+    : MESSAGE_LAYOUT_DEFAULTS.msgUsernameEmphasis;
+  const sysMsgDensity = ["full", "compact", "minimized"].includes(raw.sysMsgDensity)
+    ? raw.sysMsgDensity
+    : MESSAGE_LAYOUT_DEFAULTS.sysMsgDensity;
+  const msgContrast = ["low", "medium", "high"].includes(raw.msgContrast)
+    ? raw.msgContrast
+    : MESSAGE_LAYOUT_DEFAULTS.msgContrast;
+  return { msgDensity, msgAccentStyle, msgUsernameEmphasis, sysMsgDensity, msgContrast };
+}
+
+function hasMessageLayoutPrefs(prefs){
+  if (!prefs || typeof prefs !== "object") return false;
+  if (prefs.messageLayout && typeof prefs.messageLayout === "object") return true;
+  return ["msgDensity", "msgAccentStyle", "msgUsernameEmphasis", "sysMsgDensity", "msgContrast"]
+    .some((key) => Object.prototype.hasOwnProperty.call(prefs, key));
+}
+
+function readMessageLayoutStorage(){
+  try{
+    const raw = localStorage.getItem(MESSAGE_LAYOUT_KEY);
+    if (!raw) return { layout: { ...MESSAGE_LAYOUT_DEFAULTS }, hasStored: false };
+    return { layout: normalizeMessageLayout(JSON.parse(raw)), hasStored: true };
+  }catch{
+    return { layout: { ...MESSAGE_LAYOUT_DEFAULTS }, hasStored: false };
+  }
+}
+
+function syncMessageLayoutControls(layout){
+  const normalized = normalizeMessageLayout(layout);
+  if (msgDensitySelect) msgDensitySelect.value = normalized.msgDensity;
+  if (msgAccentStyleSelect) msgAccentStyleSelect.value = normalized.msgAccentStyle;
+  if (msgUsernameEmphasisSelect) msgUsernameEmphasisSelect.value = normalized.msgUsernameEmphasis;
+  if (sysMsgDensitySelect) sysMsgDensitySelect.value = normalized.sysMsgDensity;
+  if (msgContrastSelect) msgContrastSelect.value = normalized.msgContrast;
+}
+
+function readMessageLayoutForm(){
+  return normalizeMessageLayout({
+    msgDensity: msgDensitySelect?.value || MESSAGE_LAYOUT_DEFAULTS.msgDensity,
+    msgAccentStyle: msgAccentStyleSelect?.value || MESSAGE_LAYOUT_DEFAULTS.msgAccentStyle,
+    msgUsernameEmphasis: msgUsernameEmphasisSelect?.value || MESSAGE_LAYOUT_DEFAULTS.msgUsernameEmphasis,
+    sysMsgDensity: sysMsgDensitySelect?.value || MESSAGE_LAYOUT_DEFAULTS.sysMsgDensity,
+    msgContrast: msgContrastSelect?.value || MESSAGE_LAYOUT_DEFAULTS.msgContrast
+  });
+}
+
+function applyMessageLayout(layout, { persistLocal = true, persistServer = true } = {}){
+  const normalized = normalizeMessageLayout(layout);
+  const body = document.body;
+  if (body){
+    Object.values(MESSAGE_LAYOUT_CLASSES).forEach((classes) => body.classList.remove(...classes));
+    body.classList.add(`msg-density-${normalized.msgDensity}`);
+    body.classList.add(`msg-accent-${normalized.msgAccentStyle.toLowerCase()}`);
+    body.classList.add(`msg-name-${normalized.msgUsernameEmphasis.toLowerCase()}`);
+    body.classList.add(`sys-density-${normalized.sysMsgDensity}`);
+    body.classList.add(`msg-contrast-${normalized.msgContrast}`);
+  }
+  syncMessageLayoutControls(normalized);
+  if (persistLocal){
+    try{ localStorage.setItem(MESSAGE_LAYOUT_KEY, JSON.stringify(normalized)); }catch{}
+  }
+  if (persistServer){
+    queuePersistPrefs({ messageLayout: normalized });
+  }
+  return normalized;
+}
+
 function mergeChatFxDefaults(fx){
   const safe = (fx && typeof fx === "object") ? fx : {};
   const merged = { ...CHAT_FX_DEFAULTS, ...safe };
-  if (safe.enabled === false) merged.enabled = false;
+  if (safe.enabled === false && document.getElementById("chatFxEnabled")) merged.enabled = false;
   return normalizeChatFx(merged);
 }
 
@@ -6626,6 +6740,20 @@ async function loadUserPrefs(){
     applyComfortMode(comfortEnabled, { persistLocal: true, persistServer: false });
     if (comfortPref == null && comfortStored != null) {
       queuePersistPrefs({ comfortMode: comfortEnabled });
+    }
+    const { layout: storedLayout, hasStored: hasStoredLayout } = readMessageLayoutStorage();
+    const serverLayout = normalizeMessageLayout({
+      msgDensity: prefs.msgDensity ?? prefs.messageLayout?.msgDensity,
+      msgAccentStyle: prefs.msgAccentStyle ?? prefs.messageLayout?.msgAccentStyle,
+      msgUsernameEmphasis: prefs.msgUsernameEmphasis ?? prefs.messageLayout?.msgUsernameEmphasis,
+      sysMsgDensity: prefs.sysMsgDensity ?? prefs.messageLayout?.sysMsgDensity,
+      msgContrast: prefs.msgContrast ?? prefs.messageLayout?.msgContrast
+    });
+    const hasServerLayout = hasMessageLayoutPrefs(prefs);
+    const activeLayout = hasServerLayout ? serverLayout : storedLayout;
+    applyMessageLayout(activeLayout, { persistLocal: true, persistServer: false });
+    if (!hasServerLayout && hasStoredLayout) {
+      queuePersistPrefs({ messageLayout: activeLayout });
     }
     if (prefs.chatFx && typeof prefs.chatFx === "object") {
       applyChatFxPrefsFromServer(prefs.chatFx);
@@ -11364,6 +11492,7 @@ memoryFilterChips.forEach((chip) => {
 // New profile edit menu + avatar action wiring
 wireSoundPrefs();
 wireComfortMode();
+wireMessageLayoutPrefs();
 wireChatFxPrefs();
 wireProfileAvatarActions();
 wireHeaderGradientInputs();
@@ -16605,6 +16734,28 @@ function wireComfortMode(){
   });
 }
 
+function wireMessageLayoutPrefs(){
+  const selects = [
+    msgDensitySelect,
+    msgAccentStyleSelect,
+    msgUsernameEmphasisSelect,
+    sysMsgDensitySelect,
+    msgContrastSelect
+  ];
+  if (!selects.some(Boolean)) return;
+  if (msgDensitySelect && msgDensitySelect._wired) return;
+  selects.forEach((sel) => {
+    if (!sel || sel._wired) return;
+    sel._wired = true;
+    sel.addEventListener("change", () => {
+      applyMessageLayout(readMessageLayoutForm(), { persistLocal: true, persistServer: true });
+    });
+  });
+  resetMessageLayoutBtn?.addEventListener("click", () => {
+    applyMessageLayout(MESSAGE_LAYOUT_DEFAULTS, { persistLocal: true, persistServer: true });
+  });
+}
+
 function updateChatFxSliderValue(el, value, decimals = 0){
   if (!el) return;
   const num = Number(value);
@@ -16650,7 +16801,6 @@ function setChatFxDensityButtons(value){
   chatFxPrefEls.densityButtons.forEach((btn) => {
     btn.classList.toggle("active", btn.dataset.value === value);
   });
-  if (chatSpacingCompact) chatSpacingCompact.checked = value === "compact";
 }
 
 function getChatFxDensitySelection(){
@@ -16662,15 +16812,15 @@ function getChatFxDensitySelection(){
 function syncChatFxControls(fx){
   if (!chatFxPrefEls) return;
   const resolved = normalizeChatFx(fx);
-  chatFxPrefEls.enabled.checked = resolved.enabled;
-  chatFxPrefEls.glow.value = resolved.glow;
-  chatFxPrefEls.font.value = resolved.font;
+  if (chatFxPrefEls.enabled) chatFxPrefEls.enabled.checked = resolved.enabled;
+  if (chatFxPrefEls.glow) chatFxPrefEls.glow.value = resolved.glow;
+  if (chatFxPrefEls.font) chatFxPrefEls.font.value = resolved.font;
   if (chatFxPrefEls.nameFont) chatFxPrefEls.nameFont.value = resolved.nameFont;
-  chatFxPrefEls.radius.value = String(resolved.radius);
-  chatFxPrefEls.border.value = String(resolved.border);
-  chatFxPrefEls.glass.value = String(resolved.glass);
-  chatFxPrefEls.blur.value = String(resolved.blur);
-  chatFxPrefEls.accent.value = resolved.accent || "";
+  if (chatFxPrefEls.radius) chatFxPrefEls.radius.value = String(resolved.radius);
+  if (chatFxPrefEls.border) chatFxPrefEls.border.value = String(resolved.border);
+  if (chatFxPrefEls.glass) chatFxPrefEls.glass.value = String(resolved.glass);
+  if (chatFxPrefEls.blur) chatFxPrefEls.blur.value = String(resolved.blur);
+  if (chatFxPrefEls.accent) chatFxPrefEls.accent.value = resolved.accent || "";
   if (chatFxPrefEls.bubbleColor) chatFxPrefEls.bubbleColor.value = resolved.bubbleColor || "";
   if (chatFxPrefEls.textColor) chatFxPrefEls.textColor.value = resolved.textColor || "";
   if (chatFxPrefEls.nameColor) chatFxPrefEls.nameColor.value = resolved.nameColor || "";
@@ -16721,16 +16871,16 @@ function syncChatFxControls(fx){
 function readChatFxFormRaw(){
   if (!chatFxPrefEls) return { ...CHAT_FX_DEFAULTS };
   return {
-    enabled: chatFxPrefEls.enabled.checked,
-    glow: chatFxPrefEls.glow.value,
-    font: chatFxPrefEls.font.value,
+    enabled: chatFxPrefEls.enabled?.checked ?? CHAT_FX_DEFAULTS.enabled,
+    glow: chatFxPrefEls.glow?.value || CHAT_FX_DEFAULTS.glow,
+    font: chatFxPrefEls.font?.value || CHAT_FX_DEFAULTS.font,
     nameFont: chatFxPrefEls.nameFont?.value || CHAT_FX_DEFAULTS.nameFont,
-    radius: Number(chatFxPrefEls.radius.value),
-    border: Number(chatFxPrefEls.border.value),
-    glass: Number(chatFxPrefEls.glass.value),
-    blur: Number(chatFxPrefEls.blur.value),
+    radius: chatFxPrefEls.radius ? Number(chatFxPrefEls.radius.value) : CHAT_FX_DEFAULTS.radius,
+    border: chatFxPrefEls.border ? Number(chatFxPrefEls.border.value) : CHAT_FX_DEFAULTS.border,
+    glass: chatFxPrefEls.glass ? Number(chatFxPrefEls.glass.value) : CHAT_FX_DEFAULTS.glass,
+    blur: chatFxPrefEls.blur ? Number(chatFxPrefEls.blur.value) : CHAT_FX_DEFAULTS.blur,
     density: getChatFxDensitySelection(),
-    accent: (chatFxPrefEls.accent.value || "").trim(),
+    accent: (chatFxPrefEls.accent?.value || "").trim(),
     bubbleColor: (chatFxPrefEls.bubbleColor?.value || "").trim(),
     textColor: (chatFxPrefEls.textColor?.value || "").trim(),
     nameColor: (chatFxPrefEls.nameColor?.value || "").trim(),
@@ -17096,14 +17246,6 @@ function wireChatFxPrefs(){
       handleChatFxInput();
     });
   });
-  if (chatSpacingCompact && !chatSpacingCompact._wired){
-    chatSpacingCompact._wired = true;
-    chatSpacingCompact.addEventListener("change", () => {
-      const next = chatSpacingCompact.checked ? "compact" : "cozy";
-      setChatFxDensityButtons(next);
-      handleChatFxInput();
-    });
-  }
 
   if (effectsPreset && !effectsPreset._wired){
     effectsPreset._wired = true;
@@ -17194,7 +17336,6 @@ function resetChatFxSection(section){
   handleChatFxInput();
 }
 
-resetChatAppearanceBtn?.addEventListener("click", () => resetChatFxSection("chat"));
 resetTextIdentityBtn?.addEventListener("click", () => resetChatFxSection("text"));
 resetProfileAppearanceBtn?.addEventListener("click", () => resetChatFxSection("profile"));
 resetEffectsBtn?.addEventListener("click", () => resetChatFxSection("effects"));

--- a/public/index.html
+++ b/public/index.html
@@ -1167,9 +1167,9 @@
 <div class="customizeSearchWrap"><input id="customizeSearch" placeholder="Search settings…" type="search"/></div>
 </div>
 <div class="customizeCardGrid" id="customizeCardGrid">
-<button class="customizeCard" data-category="chat" data-search="chat appearance bubbles colors spacing text identity font username color readability" type="button">
+<button class="customizeCard" data-category="chat" data-search="chat appearance message layout colors spacing text identity font username color readability" type="button">
 <div class="cardTitle">Chat &amp; Identity</div>
-<div class="cardHint">Bubbles, fonts, name color, and message text.</div>
+<div class="cardHint">Message layout, fonts, name styling, and message text.</div>
 <div class="cardPreview chatPreview"></div>
 </button>
 
@@ -1206,7 +1206,7 @@
 <button aria-label="Back" class="iconBtn customizeBackBtn" data-back="chat" type="button">←</button>
 <div>
 <div class="title">Chat &amp; Identity</div>
-<div class="small muted">Bubble style, density, plus fonts and readability.</div>
+<div class="small muted">Message layout, fonts, and readability.</div>
 </div>
 </div>
 <div class="customizeChatLayout">
@@ -1226,7 +1226,7 @@
 </div>
 <div class="time" id="chatFxPreviewTime">Just now</div>
 </div>
-<div class="text" id="chatFxPreviewText">Your message preview bubble.</div>
+<div class="text" id="chatFxPreviewText">Your message preview.</div>
 </div>
 </div>
 </div>
@@ -1240,88 +1240,59 @@
 </aside>
 <div class="customizeChatControls">
 <div class="customizeSection">
-<div class="sectionTitle">Basic</div>
-<div class="panelBox" id="chatAppearanceBasic">
-<div class="field" data-customize-item="" data-search="bubble style glow">
-<label>Bubble style</label>
-<select id="chatFxGlow">
-<option value="off">Off</option>
-<option value="soft">Soft</option>
-<option value="neon">Neon</option>
-<option value="strong">Strong</option>
+<div class="sectionTitle">Message Layout</div>
+<div class="panelBox" id="messageLayoutControls">
+<div class="field" data-customize-item="" data-search="message density spacing compact comfortable">
+<label for="msgDensitySelect">Message density</label>
+<select id="msgDensitySelect">
+<option value="compact">Compact</option>
+<option value="medium">Medium</option>
+<option value="comfortable">Comfortable</option>
 </select>
+<div class="small muted">Adjust padding and gap between messages.</div>
 </div>
-<div class="field" data-customize-item="" data-search="bubble color">
-<label>Bubble color</label>
-<div class="chatFxColorRow">
-<input aria-label="Pick bubble color" id="chatFxBubbleColorPick" type="color" value="#2b2d31"/>
-<input id="chatFxBubbleColor" placeholder="#RRGGBB" type="text"/>
-<button class="pillBtn" id="chatFxBubbleColorClear" type="button">Clear</button>
+<div class="field" data-customize-item="" data-search="accent line style border">
+<label for="msgAccentStyleSelect">Accent line style</label>
+<select id="msgAccentStyleSelect">
+<option value="solid">Solid</option>
+<option value="dotted">Dotted</option>
+<option value="gradient">Subtle gradient</option>
+<option value="hoverGlow">Hover glow</option>
+</select>
+<div class="small muted">Left rail detail for each message block.</div>
 </div>
+<div class="field" data-customize-item="" data-search="username emphasis bold underline role chip">
+<label for="msgUsernameEmphasisSelect">Username emphasis</label>
+<select id="msgUsernameEmphasisSelect">
+<option value="normal">Normal</option>
+<option value="bold">Bold</option>
+<option value="underlineHover">Underline-on-hover</option>
+<option value="roleChip">Role-chip</option>
+</select>
+<div class="small muted">Pick how names stand out in chat.</div>
 </div>
-<div class="field" data-customize-item="" data-search="message spacing compact">
-<div class="toggleRow">
-<label class="switch">
-<input id="chatSpacingCompact" type="checkbox"/>
-<span class="slider"></span>
-</label>
-<div class="toggleLabel">Compact message spacing</div>
+<div class="field" data-customize-item="" data-search="system message density compact minimized">
+<label for="sysMsgDensitySelect">System message density</label>
+<select id="sysMsgDensitySelect">
+<option value="full">Full</option>
+<option value="compact">Compact</option>
+<option value="minimized">Minimized</option>
+</select>
+<div class="small muted">Tighten system message padding and size.</div>
 </div>
-</div>
-</div>
-</div>
-<details class="customizeSection" data-section="chat-advanced">
-<summary>Advanced</summary>
-<div class="panelBox" id="chatAppearanceAdvanced">
-<div class="field" data-customize-item="" data-search="bubble radius">
-<label>Bubble radius</label>
-<div class="chatFxSliderRow">
-<input id="chatFxRadius" max="28" min="6" step="1" type="range"/>
-<span class="chatFxSliderValue" id="chatFxRadiusValue">14</span>
-</div>
-</div>
-<div class="field" data-customize-item="" data-search="border thickness">
-<label>Border thickness</label>
-<div class="chatFxSliderRow">
-<input id="chatFxBorder" max="3" min="0" step="1" type="range"/>
-<span class="chatFxSliderValue" id="chatFxBorderValue">0</span>
-</div>
-</div>
-<div class="field" data-customize-item="" data-search="shadow glow">
-<label>Bubble glow intensity</label>
-<div class="chatFxSliderRow">
-<input id="chatFxGlass" max="1" min="0" step="0.05" type="range"/>
-<span class="chatFxSliderValue" id="chatFxGlassValue">0</span>
-</div>
-</div>
-<div class="field" data-customize-item="" data-search="blur">
-<label>Bubble blur</label>
-<div class="chatFxSliderRow">
-<input id="chatFxBlur" max="16" min="0" step="1" type="range"/>
-<span class="chatFxSliderValue" id="chatFxBlurValue">0</span>
-</div>
-</div>
-<div class="field" data-customize-item="" data-search="density spacing">
-<label>Message spacing</label>
-<div class="chatFxDensityRow" id="chatFxDensity">
-<button class="pillBtn" data-value="compact" type="button">Compact</button>
-<button class="pillBtn" data-value="cozy" type="button">Cozy</button>
-<button class="pillBtn" data-value="spacious" type="button">Spacious</button>
-</div>
-</div>
-<div class="field" data-customize-item="" data-search="enable bubbles">
-<div class="toggleRow">
-<label class="switch">
-<input id="chatFxEnabled" type="checkbox"/>
-<span class="slider"></span>
-</label>
-<div class="toggleLabel">Enable custom bubbles</div>
+<div class="field" data-customize-item="" data-search="message background contrast">
+<label for="msgContrastSelect">Message background contrast</label>
+<select id="msgContrastSelect">
+<option value="low">Low</option>
+<option value="medium">Medium</option>
+<option value="high">High</option>
+</select>
+<div class="small muted">Control the block tint behind messages.</div>
 </div>
 </div>
 </div>
-</details>
 <div class="customizeResetRow">
-<button class="btn secondary" id="resetChatAppearanceBtn" type="button">Reset this section</button>
+<button class="btn secondary" id="resetMessageLayoutBtn" type="button">Reset message layout</button>
 </div>
 </div>
 </div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -2557,7 +2557,7 @@ body.keyboard-open .menuContent{ padding-bottom: calc(200px + var(--kb, 0px) + e
   padding:14px 14px 12px;
   display:flex;
   flex-direction:column;
-  gap:8px;
+  gap:var(--msg-stack-gap, 8px);
   min-height:0;
   justify-content:flex-start;
 }
@@ -3028,9 +3028,117 @@ body.survival-room .survivalArena{
 /* ---- Main chat message grouping (consecutive messages) ---- */
 .msgGroup{ display:flex; gap:8px; align-items:flex-start; max-width:900px; }
 .msgGroup.self{ align-self:flex-end; flex-direction:row-reverse; }
-.msgGroupBody{ display:flex; flex-direction:column; gap:var(--fx-group-gap, 4px); min-width:0; }
-.msgItem{ position:relative; display:flex; flex-direction:row; align-items:flex-start; gap:8px; min-width:0; }
+.msgGroupBody{ display:flex; flex-direction:column; gap:var(--msg-group-gap, var(--fx-group-gap, 4px)); min-width:0; }
+.msgItem{ position:relative; display:flex; flex-direction:row; align-items:flex-start; gap:var(--msg-item-gap, 8px); min-width:0; }
 .msgItem.self{ flex-direction:row-reverse; }
+
+/* --- Message layout preferences (main chat) --- */
+body.msg-density-compact{
+  --msg-pad-y:6px;
+  --msg-pad-x:10px;
+  --msg-accent-offset:2px;
+  --msg-group-gap:2px;
+  --msg-stack-gap:6px;
+  --msg-item-gap:6px;
+  --msg-meta-gap:6px;
+  --msg-line-height:1.3;
+}
+body.msg-density-medium{
+  --msg-pad-y:8px;
+  --msg-pad-x:12px;
+  --msg-accent-offset:2px;
+  --msg-group-gap:4px;
+  --msg-stack-gap:8px;
+  --msg-item-gap:8px;
+  --msg-meta-gap:8px;
+  --msg-line-height:1.4;
+}
+body.msg-density-comfortable{
+  --msg-pad-y:11px;
+  --msg-pad-x:14px;
+  --msg-accent-offset:3px;
+  --msg-group-gap:6px;
+  --msg-stack-gap:12px;
+  --msg-item-gap:10px;
+  --msg-meta-gap:10px;
+  --msg-line-height:1.5;
+}
+
+body.msg-contrast-low{ --msg-bg-strength:12%; }
+body.msg-contrast-medium{ --msg-bg-strength:18%; }
+body.msg-contrast-high{ --msg-bg-strength:28%; }
+
+body.msg-accent-solid .msgGroup .bubble::before{
+  background:color-mix(in srgb, var(--fx-accent, var(--accent)) 45%, transparent);
+  opacity:0.55;
+}
+body.msg-accent-dotted .msgGroup .bubble::before{
+  background:repeating-linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--fx-accent, var(--accent)) 55%, transparent) 0 2px,
+    transparent 2px 5px
+  );
+  opacity:0.7;
+}
+body.msg-accent-gradient .msgGroup .bubble::before{
+  background:linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--fx-accent, var(--accent)) 55%, transparent) 0%,
+    transparent 100%
+  );
+  opacity:0.65;
+}
+body.msg-accent-hoverglow .msgGroup .bubble::before{
+  background:color-mix(in srgb, var(--fx-accent, var(--accent)) 40%, transparent);
+  opacity:0.35;
+  transition: opacity 160ms ease, box-shadow 160ms ease;
+}
+body.msg-accent-hoverglow .msgItem:hover .bubble::before,
+body.msg-accent-hoverglow .msgItem.showActions .bubble::before{
+  opacity:0.65;
+  box-shadow:0 0 6px color-mix(in srgb, var(--fx-accent, var(--accent)) 35%, transparent);
+}
+
+body.msg-name-bold .msgItem .name{ font-weight:800; }
+body.msg-name-underlinehover .msgItem .name .unameText{
+  text-decoration:none;
+  text-underline-offset:3px;
+}
+body.msg-name-underlinehover .msgItem:hover .name .unameText,
+body.msg-name-underlinehover .msgItem.showActions .name .unameText{
+  text-decoration:underline;
+}
+body.msg-name-rolechip .msgItem .name .unameText{
+  padding:2px 6px;
+  border-radius:999px;
+  background:color-mix(in srgb, var(--panel) 80%, transparent);
+  border:1px solid color-mix(in srgb, var(--fx-accent, var(--accent)) 18%, transparent);
+}
+
+body.sys-density-full{
+  --sys-msg-font-size:11px;
+  --sys-msg-pad-y:6px;
+  --sys-msg-pad-x:10px;
+  --sys-msg-opacity:1;
+}
+body.sys-density-compact{
+  --sys-msg-font-size:10px;
+  --sys-msg-pad-y:4px;
+  --sys-msg-pad-x:8px;
+  --sys-msg-opacity:0.9;
+}
+body.sys-density-minimized{
+  --sys-msg-font-size:9px;
+  --sys-msg-pad-y:3px;
+  --sys-msg-pad-x:6px;
+  --sys-msg-opacity:0.7;
+}
+
+body:not(.dice-room) .sys{
+  font-size:var(--sys-msg-font-size, 11px);
+  padding:var(--sys-msg-pad-y, 6px) var(--sys-msg-pad-x, 10px);
+  opacity:var(--sys-msg-opacity, 1);
+}
 .msgItem.message--deleting,
 .dmRow.message--deleting{
   opacity:0;
@@ -3115,7 +3223,7 @@ body.survival-room .survivalArena{
   transform: translateY(0);
 }
 /* Make grouped bubbles visually merge into one (main chat) */
-.msgGroupBody{ gap:var(--fx-group-gap, 4px); }
+.msgGroupBody{ gap:var(--msg-group-gap, var(--fx-group-gap, 4px)); }
 .msgItem.gCont .bubble{ margin-top:2px; }
 .msgItem.gMid .bubble{ margin-top:2px; }
 
@@ -3180,8 +3288,10 @@ body.survival-room .survivalArena{
   --fx-glow: 0;
   --fx-blur: 0;
   --fx-glass: 0;
-  padding:8px 12px 8px 14px;
-  background:color-mix(in srgb, var(--fx-base) 18%, transparent);
+  padding:var(--msg-pad-y, 8px) var(--msg-pad-x, 12px);
+  padding-left:calc(var(--msg-pad-x, 12px) + var(--msg-accent-offset, 2px));
+  line-height:var(--msg-line-height, 1.45);
+  background:color-mix(in srgb, var(--fx-base) var(--msg-bg-strength, 18%), transparent);
   border-color:color-mix(in srgb, var(--fx-accent, var(--accent)) 12%, var(--border));
   box-shadow:none;
 }
@@ -3343,7 +3453,7 @@ body.survival-room .survivalArena{
 /* Message meta (name/time) */
 .msgItem .meta{
   display:flex;
-  gap:8px;
+  gap:var(--msg-meta-gap, 8px);
   align-items:baseline;
   flex-wrap:wrap;
 }


### PR DESCRIPTION
### Motivation
- Replace deprecated bubble-specific customization with global, hybrid “Message Layout” controls (density, accent, username emphasis, system density, contrast) and remove bubble options from the Public Customisation UI. 
- Ensure existing code paths and persisted prefs do not break: ignore or safely migrate old bubble settings, keep DM bubbles working, and apply settings immediately via body classes/CSS variables.

### Description
- Replaced bubble controls in `public/index.html` (bubble color/style/radius/glow/blur/density/enable toggle) with a compact `Message Layout` section containing selects: `msgDensitySelect`, `msgAccentStyleSelect`, `msgUsernameEmphasisSelect`, `sysMsgDensitySelect`, and `msgContrastSelect`, each with a one-line helper hint and a `resetMessageLayoutBtn` (see `public/index.html`).
- Added message layout persistence and wiring in `public/app.js`: normalization (`normalizeMessageLayout`), storage key `messageLayout:v1`, `applyMessageLayout` which applies body classes (`msg-density-*`, `msg-accent-*`, `msg-name-*`, `sys-density-*`, `msg-contrast-*`), syncing of controls, loading/migration from server and local storage, and `wireMessageLayoutPrefs()` to handle changes and reset.
- Preserved DM behavior and prevented reintroducing bubble controls on main chat by adding `stripBubbleSettings` and sanitizing chat FX for main chat bubbles while preserving DM bubble styling (only DM bubbles still honor user bubble FX). This avoids reintroducing the old bubble UI while keeping backward compatibility.
- Added CSS rules in `public/styles.css` to implement the new layout mapping: variables for padding/gap/line-height (`--msg-pad-y`, `--msg-pad-x`, `--msg-group-gap`, etc.), classes for density, accent line styles, username emphasis, system message density and background contrast, and small changes to message block styles so changes take immediate effect when classes are toggled.
- Minor defensive JS updates to avoid null-element operations when old bubble controls are not present and to keep the `Chat & Identity` preview working with the new controls.

### Testing
- Confirmed UI change via automated render snapshot: launched a local static server and used Playwright to open `public/index.html` and capture `artifacts/message-layout-controls.png`, showing the new `Message Layout` controls (succeeded).
- Verified removal/addition by code search (`rg`) to ensure bubble inputs were removed from the Customisation section and new element IDs are present in `public/index.html` and `public/app.js` (succeeded).
- Performed a local commit and packaged the three modified files into `message-layout-patch.zip` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975587643188333b62b5539da0b556b)