### PR TITLE
Temporarily disable donation button UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -334,9 +334,12 @@
 <button class="iconBtn withBadge" id="dmToggleBtn" title="Direct messages" type="button">💬<span class="notifDot" id="dmBadgeDot" title="New DMs"></span></button>
 <button class="iconBtn withBadge" id="groupDmToggleBtn" title="Group DMs" type="button">👥<span class="notifDot" id="groupDmBadgeDot" title="New group DMs"></span></button>
 <button aria-label="Notifications" class="iconBtn withBadge" id="notificationsBtn" title="Notifications" type="button">🔔<span class="notifDot" id="notificationsDot" title="New notifications"></span></button>
+	<!-- Donation button temporarily disabled -->
+	<!--
 	<form action="https://www.paypal.com/ncp/payment/44EJ6AKA6YW42" class="paypalDonateForm" method="post" target="_blank" title="Support Banter &amp; Brats">
 	<button aria-label="Support Banter &amp; Brats" class="iconBtn donateBtn" type="submit">$</button>
 	</form>
+	-->
 <button class="iconBtn" id="roomChessBtn" title="Chess Table" type="button">♟</button>
 <button aria-label="Open Simulator" class="btn secondary small survivalOpenBtn" hidden id="survivalOpenBtn" title="Open Simulator" type="button">🧭</button>
 <button class="iconBtn mobOnly" id="openMembersBtn" title="Members" type="button">👥</button>

--- a/public/index.html
+++ b/public/index.html
@@ -591,7 +591,8 @@
 </div>
 <div id="memberList"></div>
 
-<!-- PayPal Donate (Members pane footer) -->
+<!-- Donation button temporarily disabled -->
+<!--
 <form action="https://www.paypal.com/ncp/payment/44EJ6AKA6YW42"
       method="post"
       target="_blank"
@@ -599,6 +600,7 @@
       title="Support Banter & Brats">
   <button type="submit" aria-label="Donate">💛 donate 💛</button>
 </form>
+-->
 
 <div class="memberMenu" id="memberMenu">
 <div class="memberMenuHeader">


### PR DESCRIPTION
### Motivation
- Temporarily remove the visible PayPal donation controls from the UI while preserving backend and PayPal integration for future re-enable. 
- Avoid any layout, runtime, or feature regressions by making a minimal, reversible change to the frontend markup only.

### Description
- Commented out the top-bar PayPal form in `index.html` so the `$` donate icon is hidden but the markup is preserved for re-enabling. 
- Commented out the members-pane PayPal footer form in `public/index.html` so the `💛 donate 💛` button is no longer rendered. 
- No JavaScript, backend routes, configuration, VIP/role logic, or PayPal processing code was removed or modified; only the UI form elements were gated with HTML comments.

### Testing
- Located all occurrences via `rg` for `donate|PayPal|paypal|💛` to ensure coverage and confirm the only UI instances were the two forms. 
- Launched a local static server with `python -m http.server` and captured a page render screenshot using Playwright which completed successfully and shows the donation buttons absent. 
- Page loaded without obvious runtime failures during the automated run and no backend or PayPal logic was altered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758fe9e3f48333bd5b4884aae9f067)