### PR TITLE
Main chat: show only top/bottom half of message accent lines

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -3520,7 +3520,7 @@ body.sys-density-minimized .chat-main{
   --fx-glow: 0;
   --fx-blur: 0;
   --fx-glass: 0;
-  --msg-accent-top-size: var(--msg-accent-height, 4px);
+  --msg-accent-top-size: calc(var(--msg-accent-height, 4px) * 0.5);
   --msg-accent-bottom-size: 0px;
   --fx-contrast-shadow: 0 1px 2px rgba(0,0,0,0.18);
   padding:var(--msg-pad-y, 8px) var(--msg-pad-x, 12px);
@@ -3532,7 +3532,7 @@ body.sys-density-minimized .chat-main{
   box-shadow:none;
 }
 .chat-main .msgItem.msg--main.msg--group-end .bubble{
-  --msg-accent-bottom-size: var(--msg-accent-height, 4px);
+  --msg-accent-bottom-size: calc(var(--msg-accent-height, 4px) * 0.5);
   padding-bottom:calc(var(--msg-pad-y, 8px) + var(--msg-accent-height, 4px) + var(--msg-accent-gap, 4px));
 }
 .chat-main .msg--main .bubble::before{


### PR DESCRIPTION
### Motivation
- Main-chat message accents currently render as full horizontal bands on both top and bottom, creating a strong double-border look and too much vertical separation.
- The goal is to visually clip those accents so only the top edge of the top accent and the bottom edge of the bottom accent are visible, while preserving grouping, colors, gradients, and glow behavior.

### Description
- Reduced the visible size of the main-chat accent by halving the accent size variables: set `--msg-accent-top-size` and `--msg-accent-bottom-size` to `calc(var(--msg-accent-height, 4px) * 0.5)` in `public/styles.css` within the `.chat-main .msg--main .bubble` and group-end selector respectively.
- Kept the existing `background-image`, `--msg-accent-fill`, `--msg-accent-opacity`, transitions, and all theme/accent variables unchanged so colors and glow remain identical.
- Scoped the change specifically to main chat selectors (`.chat-main .msg--main`) so DM styles are unaffected and no grouping or layout logic was modified.

### Testing
- Started the local dev server with `npm run dev` and the server came up on `http://localhost:3000`, which succeeded. 
- Ran a headless Playwright script that opened the main chat and captured a full-page screenshot, which succeeded and produced the artifact `artifacts/main-chat-accent.png` for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976226417d88333b7d509eb3685a9a6)